### PR TITLE
Improve path cleaning and remove debug log

### DIFF
--- a/lib/otto/route.rb
+++ b/lib/otto/route.rb
@@ -47,7 +47,7 @@ class Otto
       req.params.replace Otto::Static.indifferent_params(req.params)
       klass.extend Otto::Route::ClassMethods
       klass.otto = self.otto
-      Otto.logger.debug "Route class: #{klass}"
+
       case kind
       when :instance
         inst = klass.new req, res


### PR DESCRIPTION
The first commit removes a debug log line that was unnecessary for the routing process. The second commit enhances the path cleaning process by adding UTF-8 encoding and error handling. This improves the robustness of path_info processing, handles invalid byte sequences in URLs, adds error logging for debugging purposes, and maintains the original path as a fallback for invalid inputs.

Resolves #613.
