### PR TITLE
Use rexml 3.4.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       loofah (~> 2.20)
       rack (~> 3.1, < 4.0)
       rack-parser (~> 0.7)
-      rexml (~> 3.3.6)
+      rexml (~> 3.4)
 
 GEM
   remote: https://rubygems.org/
@@ -131,7 +131,7 @@ GEM
     regexp_parser (2.11.3)
     reline (0.6.2)
       io-console (~> 0.5)
-    rexml (3.3.9)
+    rexml (3.4.4)
     rspec (3.13.1)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)

--- a/otto.gemspec
+++ b/otto.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rack', '~> 3.1', '< 4.0'
   spec.add_dependency 'rack-parser', '~> 0.7'
-  spec.add_dependency 'rexml', '~> 3.3.6'
+  spec.add_dependency 'rexml', '~> 3.4'
 
   # Security dependencies
   spec.add_dependency 'facets', '~> 3.1'


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Update rexml dependency from 3.3.6 to 3.4.x

- Allows use of latest rexml minor versions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["rexml 3.3.6"] -- "upgrade" --> B["rexml 3.4.x"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>otto.gemspec</strong><dd><code>Update rexml dependency version constraint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

otto.gemspec

<ul><li>Updated rexml dependency constraint from <code>~> 3.3.6</code> to <code>~> 3.4</code><br> <li> Enables compatibility with rexml 3.4.x releases</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/otto/pull/67/files#diff-fbd7e07dce0027e23b57cc28708ee05640cab2b6426fbd8aa74f6f6d81c038d6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

