### PR TITLE
Fix #84: Convert on_request_complete to instance-level callbacks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,28 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.1.0/>`
 
    <!--scriv-insert-here-->
 
+.. _changelog-2.0.0.pre6:
+
+2.0.0.pre6 — TBD
+================
+
+Changed
+-------
+
+- **BREAKING**: ``Otto.on_request_complete`` is now an instance method instead of a class method. This fixes duplicate callback invocations in multi-app architectures (e.g., Rack::URLMap with multiple Otto instances). Each Otto instance now maintains its own isolated set of callbacks that only fire for requests processed by that specific instance.
+
+  **Migration**: Change ``Otto.on_request_complete { |req, res, dur| ... }`` to ``otto.on_request_complete { |req, res, dur| ... }``
+
+Fixed
+-----
+
+- Fixed issue #84 where ``on_request_complete`` callbacks would fire N times per request in multi-app architectures, causing duplicate logging and metrics
+
+AI Assistance
+-------------
+
+- This enhancement was developed with assistance from Claude Code (Opus 4.1)
+
 .. _changelog-2.0.0.pre5:
 
 2.0.0.pre5 — 2025-10-21


### PR DESCRIPTION
### **User description**
## Problem

In multi-app architectures (e.g., Rack::URLMap with multiple Otto instances), `Otto.on_request_complete` was a class-level hook. This caused all registered callbacks to fire for **every request** processed by **any** Otto instance, resulting in duplicate logging and metrics.

For example, with 3 Otto instances in production, a single request would trigger all 3 callbacks, producing 3 identical log entries.

## Solution

Converted `on_request_complete` from a class method to an instance method. Each Otto instance now maintains its own isolated set of callbacks that only fire for requests processed by that specific instance.

## Breaking Change

⚠️ **API Change Required**

**Before:**
```ruby
Otto.on_request_complete do |req, res, duration|
  logger.info "Request completed", path: req.path
end
```

**After:**
```ruby
otto = Otto.new(routes_file)
otto.on_request_complete do |req, res, duration|
  logger.info "Request completed", path: req.path
end
```

**Migration**: Change `Otto.on_request_complete` to `otto.on_request_complete`

## Implementation Details

- Moved callback storage from class variable to instance variable (`@request_complete_callbacks`)
- Initialized callbacks array in `initialize_core_state`
- Added `ensure_not_frozen!` check for configuration safety (consistent with other Otto config methods)
- Updated `call` method to use instance-level callbacks
- Added comprehensive documentation with multi-app examples

## Testing

- Updated all existing callback tests to use instance method
- Added new test that validates isolation between multiple Otto instances
- Test directly simulates the multi-app scenario from issue #84
- All 791 tests pass (1 unrelated flaky timing test)

## Impact

This fixes a real production issue affecting multi-app architectures where Otto instances are mounted via Rack::URLMap or similar patterns. Users will no longer see duplicate logs/metrics for each request.

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Convert `on_request_complete` from class-level to instance-level callbacks

- Fix duplicate callback invocations in multi-app architectures

- Each Otto instance now maintains isolated callback registry

- Add comprehensive multi-instance isolation test and documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Class-level callbacks<br/>Otto.on_request_complete"] -->|BREAKING CHANGE| B["Instance-level callbacks<br/>otto.on_request_complete"]
  B -->|Isolation| C["Each Otto instance<br/>has own callbacks"]
  C -->|Result| D["No duplicate invocations<br/>in multi-app setups"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>otto.rb</strong><dd><code>Migrate callbacks from class to instance level</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/otto.rb

<ul><li>Move callback storage from class variable <code>@request_complete_callbacks</code> <br>to instance variable<br> <li> Update <code>call</code> method to use instance-level callbacks instead of <br>class-level<br> <li> Add <code>on_request_complete</code> instance method with comprehensive <br>documentation<br> <li> Add <code>request_complete_callbacks</code> getter method for internal use<br> <li> Initialize <code>@request_complete_callbacks</code> array in <code>initialize_core_state</code><br> <li> Remove class-level callback methods from <code>class << self</code> block</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/otto/pull/85/files#diff-2aa053d47b0c5aee3f3828d24055cde396b275c01cb77db245120387a185b9e8">+55/-13</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>logging_integration_spec.rb</strong><dd><code>Update tests for instance-level callbacks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spec/otto/logging_integration_spec.rb

<ul><li>Update all callback registrations to use instance method <br><code>otto.on_request_complete</code><br> <li> Remove class-level callback cleanup in <code>after</code> hook<br> <li> Add conditional <code>skip_before</code> metadata to avoid setup conflicts<br> <li> Add comprehensive multi-instance isolation test with three Otto <br>instances<br> <li> Verify callbacks only fire for their respective instances with no <br>cross-contamination</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/otto/pull/85/files#diff-864d50f7ba135a7733562fb5687e8c82c1233d1831f7485c4cb37d4d505a05a2">+59/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.rst</strong><dd><code>Document breaking change and fix in changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.rst

<ul><li>Add new section for version 2.0.0.pre6 with breaking change notice<br> <li> Document migration path from class method to instance method<br> <li> Reference issue #84 fix for multi-app architecture duplicate callbacks<br> <li> Add AI assistance attribution to Claude Code</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/otto/pull/85/files#diff-2c623f3c6a917be56c59d43279244996836262cb1e12d9d0786c9c49eef6b43c">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

