### PR TITLE
Version bump to v2.0.0-pre10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    otto (2.0.0.pre9)
+    otto (2.0.0.pre10)
       concurrent-ruby (~> 1.3, < 2.0)
       facets (~> 3.1)
       ipaddr (~> 1, < 2.0)

--- a/lib/otto/version.rb
+++ b/lib/otto/version.rb
@@ -3,5 +3,5 @@
 # frozen_string_literal: true
 
 class Otto
-  VERSION = '2.0.0.pre9'
+  VERSION = '2.0.0.pre10'
 end


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Bump version from 2.0.0.pre9 to 2.0.0.pre10


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["VERSION 2.0.0.pre9"] -- "increment pre-release" --> B["VERSION 2.0.0.pre10"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>version.rb</strong><dd><code>Update version constant to pre10</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/otto/version.rb

- Updated VERSION constant from '2.0.0.pre9' to '2.0.0.pre10'


</details>


  </td>
  <td><a href="https://github.com/delano/otto/pull/106/files#diff-9ed4ba786934270486816b80ddff8bc83f597afd5c11531fa66b74eb73b61c59">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

