### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,21 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.1.0/>`
 
    <!--scriv-insert-here-->
 
+.. _changelog-2.0.0:
+
+2.0.0 — 2026-03-14
+==================
+
+Added
+-----
+
+- Optional ``fallback_locale`` configuration for ``Otto::Locale::Middleware`` and ``Locale::Config``, enabling custom locale fallback chains between exact region match and primary code resolution
+
+Fixed
+-----
+
+- Locale middleware now tries exact region match (``fr-FR`` → ``fr_FR``) before falling back to primary language code, fixing locale resolution for region-qualified ``available_locales`` entries (#117)
+
 .. _changelog-2.0.0.pre10:
 
 2.0.0.pre10 — 2025-12-09

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    otto (2.0.0.pre10)
+    otto (2.0.0)
       concurrent-ruby (~> 1.3, < 2.0)
       facets (~> 3.1)
       ipaddr (~> 1, < 2.0)

--- a/changelog.d/20260314_192657_locale_region_match.rst
+++ b/changelog.d/20260314_192657_locale_region_match.rst
@@ -1,9 +1,0 @@
-Fixed
------
-
-- Locale middleware now tries exact region match (``fr-FR`` → ``fr_FR``) before falling back to primary language code, fixing locale resolution for region-qualified ``available_locales`` entries (#117)
-
-Added
------
-
-- Optional ``fallback_locale`` configuration for ``Otto::Locale::Middleware`` and ``Locale::Config``, enabling custom locale fallback chains between exact region match and primary code resolution

--- a/lib/otto/version.rb
+++ b/lib/otto/version.rb
@@ -3,5 +3,5 @@
 # frozen_string_literal: true
 
 class Otto
-  VERSION = '2.0.0.pre10'
+  VERSION = '2.0.0'
 end

--- a/otto.gemspec
+++ b/otto.gemspec
@@ -5,7 +5,7 @@ require_relative 'lib/otto/version'
 Gem::Specification.new do |spec|
   spec.name          = 'otto'
   spec.version       = Otto::VERSION.to_s
-  spec.summary       = 'Auto-define your rack-apps in plaintext.'
+  spec.summary       = 'Define your rack-apps in plaintext.'
   spec.description   = "Otto: #{spec.summary}"
   spec.email         = 'gems@solutious.com'
   spec.authors       = ['Delano Mandelbaum']


### PR DESCRIPTION
## Summary

Promotes Otto from 2.0.0.pre10 to stable 2.0.0, collecting the changelog fragment and finalizing the release.

## What's in this release

The headline feature is enhanced locale middleware from #117/#118: region-specific locale resolution now tries an exact match (e.g., `fr-FR` → `fr_FR`) before falling back to the primary language code. A new optional `fallback_locale` config enables custom fallback chains. BCP 47 canonical case handling and stable sort are included.

Also updates the gemspec summary wording ("Auto-define" → "Define").

## Changes

- Version bump: 2.0.0.pre10 → 2.0.0
- Collected changelog fragment into CHANGELOG.rst
- Updated gemspec summary

## Breaking changes

None. All changes are backward compatible.

## Test plan

- [ ] `bundle exec rspec` passes
- [ ] `bundle exec rubocop` passes
- [ ] Gem builds cleanly with `gem build otto.gemspec`