### PR TITLE
ci: add Ruby 4.0 to test matrix as experimental

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,13 @@ jobs:
 
       - name: Install dependencies
         continue-on-error: ${{ matrix.experimental }}
+        env:
+          EXPERIMENTAL: ${{ matrix.experimental }}
         run: |
           bundle config path vendor/bundle
+          if [ "$EXPERIMENTAL" = "true" ]; then
+            bundle config set --local force_ruby_platform true
+          fi
           bundle install --jobs 4 --retry 3 --with test
 
       - name: Verify setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
             experimental: false
           - ruby: "3.5"
             experimental: true
+          - ruby: "4.0"
+            experimental: true
 
     steps:
       - uses: actions/checkout@v6

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.1.0/>`
 
    <!--scriv-insert-here-->
 
+.. _changelog-2.0.1:
+
+2.0.1 — 2026-04-15
+==================
+
+- Allow running with Ruby 4
+- Update gems rack, ruby-lsp, rspec, rubocop, loofah, rack-test
+
 .. _changelog-2.0.0:
 
 2.0.0 — 2026-03-14

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    otto (2.0.0)
+    otto (2.0.1)
       concurrent-ruby (~> 1.3, < 2.0)
       facets (~> 3.1)
       ipaddr (~> 1, < 2.0)

--- a/changelog.d/20260415_113448_delano_next.rst
+++ b/changelog.d/20260415_113448_delano_next.rst
@@ -1,4 +1,0 @@
-.. Changed
-.. -------
-
-- Allow running with Ruby 4

--- a/changelog.d/20260415_113448_delano_next.rst
+++ b/changelog.d/20260415_113448_delano_next.rst
@@ -1,0 +1,4 @@
+.. Changed
+.. -------
+
+- Allow running with Ruby 4

--- a/lib/otto/version.rb
+++ b/lib/otto/version.rb
@@ -3,5 +3,5 @@
 # frozen_string_literal: true
 
 class Otto
-  VERSION = '2.0.0'
+  VERSION = '2.0.1'
 end

--- a/otto.gemspec
+++ b/otto.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/delano/otto'
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = ['>= 3.2', '< 5.0']
+  spec.required_ruby_version = ['>= 3.2', '< 4.1']
 
   spec.add_dependency 'concurrent-ruby', '~> 1.3', '< 2.0'
   spec.add_dependency 'ipaddr', '~> 1', '< 2.0'

--- a/otto.gemspec
+++ b/otto.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/delano/otto'
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = ['>= 3.2', '< 4.0']
+  spec.required_ruby_version = ['>= 3.2', '< 5.0']
 
   spec.add_dependency 'concurrent-ruby', '~> 1.3', '< 2.0'
   spec.add_dependency 'ipaddr', '~> 1', '< 2.0'


### PR DESCRIPTION
## Summary
- Add Ruby 4.0 to the CI test matrix as an experimental entry, mirroring the pattern used for 3.5 (`continue-on-error`, no bundler cache)
- Follows up on fcaed2a ("Allow running with Ruby 4") by exercising the codebase against Ruby 4.0 in CI without blocking on failures

## Test plan
- [x] CI runs the new `ruby: "4.0"` job and surfaces any incompatibilities without failing the overall workflow