### PR TITLE
Add on_route_matched lifecycle hook

### DIFF
--- a/lib/otto.rb
+++ b/lib/otto.rb
@@ -170,6 +170,7 @@ class Otto
     @security          = Otto::Security::Configurator.new(@security_config, @middleware, @auth_config)
     @app               = nil # Pre-built middleware app (built after initialization)
     @request_complete_callbacks = [] # Instance-level request completion callbacks
+    @route_matched_callbacks    = [] # Instance-level route matched callbacks
     @error_handlers    = {} # Registered error handlers for expected errors
 
     # Initialize helper module registries

--- a/lib/otto/core/lifecycle_hooks.rb
+++ b/lib/otto/core/lifecycle_hooks.rb
@@ -58,6 +58,42 @@ class Otto
       def request_complete_callbacks
         @request_complete_callbacks
       end
+
+      # Register a callback fired after a route matches but before the handler dispatches.
+      #
+      # The callback receives two arguments:
+      # - env: the Rack environment hash
+      # - route_definition: the matched Otto::RouteDefinition
+      #
+      # Unlike on_request_complete, exceptions raised inside on_route_matched callbacks
+      # are NOT swallowed: they propagate to Otto#handle_error so consumers can route
+      # custom error classes through register_error_handler.
+      #
+      # Does not fire for static-file routes or for the 404 fallback route.
+      #
+      # @example
+      #   otto.on_route_matched do |env, route_definition|
+      #     raise MyApp::Maintenance if maintenance? && route_definition.auth_requirement
+      #   end
+      #
+      # @yield [env, route_definition] Block to execute after route match
+      # @yieldparam env [Hash] The Rack environment
+      # @yieldparam route_definition [Otto::RouteDefinition] The matched route definition
+      # @return [self] Returns self for method chaining
+      # @raise [FrozenError] if called after configuration is frozen
+      def on_route_matched(&block)
+        ensure_not_frozen!
+        @route_matched_callbacks << block if block_given?
+        self
+      end
+
+      # Get registered route matched callbacks (for internal use)
+      #
+      # @api private
+      # @return [Array<Proc>] Array of registered callback blocks
+      def route_matched_callbacks
+        @route_matched_callbacks
+      end
     end
   end
 end

--- a/lib/otto/core/router.rb
+++ b/lib/otto/core/router.rb
@@ -110,6 +110,10 @@ class Otto
               handler: route.route_definition.definition,
               auth_strategy: route.route_definition.auth_requirement || 'none'
             ))
+          # Fire route matched hooks before dispatch; raises propagate to handle_error
+          unless @route_matched_callbacks.empty?
+            @route_matched_callbacks.each { |cb| cb.call(env, route.route_definition) }
+          end
           route.call(env)
         elsif static_route && http_verb == :GET && safe_file?(path_info)
           Otto.structured_log(:debug, 'Route matched',
@@ -180,6 +184,12 @@ class Otto
               Otto::LoggingHelpers.request_context(env).merge(
                 fallback_to: '404_route'
               ))
+          else
+            # Fire route matched hooks before dispatch; suppressed for 404 fallback.
+            # Raises propagate to handle_error so custom error classes can be registered.
+            unless @route_matched_callbacks.empty?
+              @route_matched_callbacks.each { |cb| cb.call(env, found_route.route_definition) }
+            end
           end
           found_route.call env, extra_params
         else

--- a/spec/otto/logging_integration_spec.rb
+++ b/spec/otto/logging_integration_spec.rb
@@ -176,6 +176,162 @@ RSpec.describe 'Otto Logging Integration' do
     end
   end
 
+  describe 'route matched hooks' do
+    # Use stub_const for the error class so the constant doesn't leak across files.
+    let(:route_blocked_error_class) { stub_const('RouteBlockedError', Class.new(StandardError)) }
+
+    let(:route_lines) do
+      [
+        'GET / TestApp.index',
+        'GET /show/:id TestApp.show',
+        'GET /404 TestApp.index',
+      ]
+    end
+    let(:otto) { create_minimal_otto(route_lines) }
+
+    it 'returns self and supports chaining' do
+      noop = ->(_env, _rd) { :noop }
+
+      result = otto.on_route_matched(&noop)
+      expect(result).to equal(otto)
+
+      chained = otto.on_route_matched(&noop).on_route_matched(&noop)
+      expect(chained).to equal(otto)
+      # Three callbacks registered total (one above plus two on the chained line).
+      expect(otto.route_matched_callbacks.length).to eq(3)
+    end
+
+    it 'fires after match and before handler on literal routes, with the correct RouteDefinition' do
+      order = []
+      captured_definition = nil
+
+      otto.on_route_matched do |_env, route_definition|
+        order << :hook
+        captured_definition = route_definition
+      end
+
+      # Wrap the index handler to record its execution after the hook.
+      allow(TestApp).to receive(:index).and_wrap_original do |original, *args|
+        order << :handler
+        original.call(*args)
+      end
+
+      otto.call(mock_rack_env(method: 'GET', path: '/'))
+
+      expect(order).to eq(%i[hook handler])
+      expect(captured_definition).to be_a(Otto::RouteDefinition)
+      expect(captured_definition.path).to eq('/')
+      expect(captured_definition.definition).to eq('TestApp.index')
+    end
+
+    it 'fires on dynamic routes with the correct RouteDefinition' do
+      captured = []
+      otto.on_route_matched do |env, route_definition|
+        captured << { path: route_definition.path, env_path: env['PATH_INFO'] }
+      end
+
+      otto.call(mock_rack_env(method: 'GET', path: '/show/42'))
+
+      expect(captured.length).to eq(1)
+      expect(captured.first[:path]).to eq('/show/:id')
+      expect(captured.first[:env_path]).to eq('/show/42')
+    end
+
+    it 'routes a raise from the callback through the registered error handler and skips the handler' do
+      otto.register_error_handler(route_blocked_error_class, status: 404, log_level: :info)
+
+      handler_called = false
+      allow(TestApp).to receive(:index).and_wrap_original do |original, *args|
+        handler_called = true
+        original.call(*args)
+      end
+
+      otto.on_route_matched do |_env, _rd|
+        raise route_blocked_error_class, 'blocked'
+      end
+
+      response = otto.call(mock_rack_env(method: 'GET', path: '/'))
+
+      expect(response[0]).to eq(404)
+      expect(handler_called).to be false
+    end
+
+    it 'does not fire on the 404 fallback when an unmatched path is requested' do
+      called = []
+      otto.on_route_matched do |_env, route_definition|
+        called << route_definition.path
+      end
+
+      # /does-not-exist matches no literal and no dynamic pattern; with a /404
+      # literal route present, router falls back to it WITHOUT firing the hook.
+      otto.call(mock_rack_env(method: 'GET', path: '/does-not-exist'))
+
+      expect(called).to be_empty
+    end
+
+    it 'does not fire on static file routes' do
+      static_dir = Dir.mktmpdir('otto_static_spec')
+      static_file = File.join(static_dir, 'safe.txt')
+      File.write(static_file, 'static content')
+
+      # safe_file? requires the file to be owned by the current user or group;
+      # skip if the test environment can't satisfy that constraint.
+      unless File.owned?(static_file) || File.grpowned?(static_file)
+        FileUtils.rm_rf(static_dir)
+        skip 'static file ownership requirement not satisfied in this environment'
+      end
+
+      routes_file = create_test_routes_file('test_routes_static.txt', ['GET / TestApp.index'])
+      static_otto = Otto.new(routes_file, public: static_dir)
+      Otto.unfreeze_for_testing(static_otto)
+
+      called = []
+      static_otto.on_route_matched do |_env, route_definition|
+        called << route_definition.path
+      end
+
+      static_otto.call(mock_rack_env(method: 'GET', path: '/safe.txt'))
+
+      expect(called).to be_empty
+    ensure
+      FileUtils.rm_rf(static_dir) if static_dir && Dir.exist?(static_dir)
+    end
+
+    it 'raises FrozenError when registered after configuration freeze' do
+      frozen_otto = create_minimal_otto(route_lines)
+      frozen_otto.freeze_configuration!
+
+      expect { frozen_otto.on_route_matched { |_env, _rd| :noop } }
+        .to raise_error(FrozenError)
+    end
+
+    it 'isolates callbacks between Otto instances (per-instance state)' do
+      otto_a = create_minimal_otto(route_lines)
+      otto_b = create_minimal_otto(route_lines)
+
+      a_calls = []
+      otto_a.on_route_matched do |_env, route_definition|
+        a_calls << route_definition.path
+      end
+
+      otto_b.call(mock_rack_env(method: 'GET', path: '/'))
+
+      expect(a_calls).to be_empty
+      expect(otto_b.route_matched_callbacks).to be_empty
+    end
+
+    it 'fires multiple registered callbacks in registration order' do
+      order = []
+      otto.on_route_matched { |_env, _rd| order << :first }
+      otto.on_route_matched { |_env, _rd| order << :second }
+      otto.on_route_matched { |_env, _rd| order << :third }
+
+      otto.call(mock_rack_env(method: 'GET', path: '/'))
+
+      expect(order).to eq(%i[first second third])
+    end
+  end
+
   describe 'Otto.structured_log in action' do
     it 'logs route resolution events using structured logging' do
       # Test that we can log route matching events

--- a/spec/otto/logging_integration_spec.rb
+++ b/spec/otto/logging_integration_spec.rb
@@ -2,6 +2,9 @@
 #
 # frozen_string_literal: true
 
+require 'fileutils'
+require 'tmpdir'
+
 require_relative '../spec_helper'
 
 RSpec.describe 'Otto Logging Integration' do


### PR DESCRIPTION
## Summary

Adds an `on_route_matched` lifecycle hook that fires after a route is matched but before the handler dispatches. Callbacks receive the Rack environment and the matched route definition, enabling early inspection or conditional blocking (e.g. rate limiting, feature flags, audit logging) without wrapping handlers.

Unlike `on_request_complete`, exceptions raised inside callbacks propagate to `Otto#handle_error`, so callbacks can raise registered application errors (e.g. `NotFound`, `RateLimited`) and route them through the normal error-handler path. The hook does not fire for static files or the 404 fallback route.

## Changes

- New `Otto#on_route_matched(&block)` API with method chaining
- Router fires callbacks for both literal/dynamic and custom route matches (skipping the 404 fallback)
- Exceptions in callbacks short-circuit handler dispatch and flow through `handle_error`
- 9 integration tests covering ordering, timing, exception propagation, route exclusions, frozen-config protection, and per-instance isolation

No breaking changes; the feature is purely additive.

Closes #129

## Test plan

- [ ] `bundle exec rspec spec/otto/logging_integration_spec.rb`
- [ ] `bundle exec rspec`
- [ ] `bundle exec rubocop`