### PR TITLE
Add register_handler_wrapper and on_route_matched lifecycle hooks

### DIFF
--- a/lib/otto.rb
+++ b/lib/otto.rb
@@ -171,7 +171,8 @@ class Otto
     @app               = nil # Pre-built middleware app (built after initialization)
     @request_complete_callbacks = [] # Instance-level request completion callbacks
     @route_matched_callbacks    = [] # Instance-level route matched callbacks
-    @error_handlers    = {} # Registered error handlers for expected errors
+    @handler_wrappers           = [] # Instance-level handler wrapper factories
+    @error_handlers             = {} # Registered error handlers for expected errors
 
     # Initialize helper module registries
     @request_helper_modules = []

--- a/lib/otto.rb
+++ b/lib/otto.rb
@@ -170,6 +170,7 @@ class Otto
     @security          = Otto::Security::Configurator.new(@security_config, @middleware, @auth_config)
     @app               = nil # Pre-built middleware app (built after initialization)
     @request_complete_callbacks = [] # Instance-level request completion callbacks
+    @route_matched_callbacks    = [] # Instance-level route matched callbacks
     @error_handlers    = {} # Registered error handlers for expected errors
 
     # Initialize helper module registries

--- a/lib/otto/core/configuration.rb
+++ b/lib/otto/core/configuration.rb
@@ -170,6 +170,11 @@ class Otto
         deep_freeze_value(@auth_config) if @auth_config
         deep_freeze_value(@option) if @option
 
+        # Validate registered handler-wrapper factories against every loaded
+        # route before locking the config. Surfaces TypeError / factory bugs
+        # at boot instead of on the first request that happens to match.
+        validate_handler_wrappers!
+
         # Deep freeze route structures (prevent modification of nested hashes/arrays)
         deep_freeze_value(@routes) if @routes
         deep_freeze_value(@routes_literal) if @routes_literal
@@ -206,6 +211,35 @@ class Otto
       def middleware_enabled?(middleware_class)
         # Only check the new middleware stack as the single source of truth
         @middleware&.includes?(middleware_class)
+      end
+
+      # Walk every loaded route and exercise the registered handler-wrapper
+      # factories against a sentinel inner handler. Each factory must return a
+      # callable; HandlerFactory.apply_handler_wrappers raises TypeError
+      # otherwise. The constructed chain is discarded — this is a fail-fast
+      # validation pass, not memoization.
+      #
+      # Iterates @routes (covers MCP routes added directly) uniquified by
+      # identity. No-op if no wrappers are registered or no routes are loaded.
+      #
+      # @api private
+      # @return [void]
+      def validate_handler_wrappers!
+        return unless @routes && @route_handler_factory
+        return if @handler_wrappers.nil? || @handler_wrappers.empty?
+
+        sentinel = ->(_env, _extra = {}) { [200, {}, []] }
+        seen = {}.compare_by_identity
+        @routes.each_value do |routes_for_verb|
+          routes_for_verb.each do |route|
+            next if seen[route]
+
+            seen[route] = true
+            Otto::RouteHandlers::HandlerFactory.apply_handler_wrappers(
+              sentinel, route.route_definition, self
+            )
+          end
+        end
       end
     end
   end

--- a/lib/otto/core/lifecycle_hooks.rb
+++ b/lib/otto/core/lifecycle_hooks.rb
@@ -94,6 +94,50 @@ class Otto
       def route_matched_callbacks
         @route_matched_callbacks
       end
+
+      # Register a wrapper factory that composes around each route handler.
+      #
+      # The block is invoked once per request, identical to RouteAuthWrapper
+      # instantiation, with the route's definition and the inner (already
+      # wrapped) handler. It must return either the original inner_handler (to
+      # opt out for that route) or a new object responding to :call(env).
+      # Wrappers compose outermost-first in registration order:
+      #
+      #   request -> wrapper_1 -> wrapper_2 -> ... -> RouteAuthWrapper -> base_handler
+      #
+      # RouteAuthWrapper always stays innermost so env['otto.strategy_result'] is set
+      # before any consumer wrapper sees the request.
+      #
+      # Factory blocks are exercised once against every loaded route during
+      # freeze_configuration! (see validate_handler_wrappers!) so factories that
+      # raise unconditionally or return non-callables surface at boot rather
+      # than on the first request that happens to match.
+      #
+      # @example Gate a route by an option set in the routes file
+      #   otto.register_handler_wrapper do |route_definition, inner_handler|
+      #     next inner_handler unless route_definition.option(:scope) == 'canonical'
+      #     MyApp::CanonicalOnlyWrapper.new(inner_handler, route_definition)
+      #   end
+      #
+      # @yield [route_definition, inner_handler] Factory invoked per request
+      # @yieldparam route_definition [Otto::RouteDefinition] The route being wrapped
+      # @yieldparam inner_handler [#call] The handler to wrap (RouteAuthWrapper or base)
+      # @yieldreturn [#call] A callable wrapper, or inner_handler unchanged to skip
+      # @return [self] Returns self for method chaining
+      # @raise [FrozenError] if called after configuration is frozen
+      def register_handler_wrapper(&block)
+        ensure_not_frozen!
+        @handler_wrappers << block if block_given?
+        self
+      end
+
+      # Get registered handler wrapper factories (for internal use)
+      #
+      # @api private
+      # @return [Array<Proc>] Array of registered wrapper factory blocks
+      def handler_wrappers
+        @handler_wrappers
+      end
     end
   end
 end

--- a/lib/otto/core/lifecycle_hooks.rb
+++ b/lib/otto/core/lifecycle_hooks.rb
@@ -58,6 +58,42 @@ class Otto
       def request_complete_callbacks
         @request_complete_callbacks
       end
+
+      # Register a callback fired after a route matches but before the handler dispatches.
+      #
+      # The callback receives two arguments:
+      # - env: the Rack environment hash
+      # - route_definition: the matched Otto::RouteDefinition
+      #
+      # Unlike on_request_complete, exceptions raised inside on_route_matched callbacks
+      # are NOT swallowed: they propagate to Otto#handle_error so consumers can route
+      # custom error classes through register_error_handler.
+      #
+      # Does not fire for static-file routes or for the 404 fallback route.
+      #
+      # @example
+      #   otto.on_route_matched do |env, route_definition|
+      #     raise MyApp::Maintenance if maintenance? && route_definition.auth_requirement
+      #   end
+      #
+      # @yield [env, route_definition] Block to execute after route match
+      # @yieldparam env [Hash] The Rack environment
+      # @yieldparam route_definition [Otto::RouteDefinition] The matched route definition
+      # @return [self] Returns self for method chaining
+      # @raise [FrozenError] if called after configuration is frozen
+      def on_route_matched(&block)
+        ensure_not_frozen!
+        @route_matched_callbacks << block if block_given?
+        self
+      end
+
+      # Get registered route matched callbacks (for internal use)
+      #
+      # @api private
+      # @return [Array<Proc>] Array of registered callback blocks
+      def route_matched_callbacks
+        @route_matched_callbacks
+      end
     end
   end
 end

--- a/lib/otto/core/router.rb
+++ b/lib/otto/core/router.rb
@@ -110,6 +110,10 @@ class Otto
               handler: route.route_definition.definition,
               auth_strategy: route.route_definition.auth_requirement || 'none'
             ))
+          # Fire route matched hooks before dispatch; raises propagate to handle_error
+          unless @route_matched_callbacks.empty?
+            @route_matched_callbacks.each { |cb| cb.call(env, route.route_definition) }
+          end
           route.call(env)
         elsif static_route && http_verb == :GET && safe_file?(path_info)
           Otto.structured_log(:debug, 'Route matched',
@@ -180,6 +184,12 @@ class Otto
               Otto::LoggingHelpers.request_context(env).merge(
                 fallback_to: '404_route'
               ))
+          else
+            # Fire route matched hooks before dispatch; suppressed for 404 fallback.
+            # Raises propagate to handle_error so custom error classes can be registered.
+            unless @route_matched_callbacks.empty?
+              @route_matched_callbacks.each { |cb| cb.call(env, found_route.route_definition) }
+            end
           end
           found_route.call env, extra_params
         else

--- a/lib/otto/route_handlers/factory.rb
+++ b/lib/otto/route_handlers/factory.rb
@@ -37,6 +37,23 @@ class Otto
           )
         end
 
+        apply_handler_wrappers(handler, route_definition, otto_instance)
+      end
+
+      # Compose registered wrappers outermost-first. Built innermost-out so
+      # reverse_each yields a final order of: w1(w2(...(RouteAuthWrapper(base)))).
+      def self.apply_handler_wrappers(handler, route_definition, otto_instance)
+        wrappers = otto_instance&.handler_wrappers
+        return handler if wrappers.nil? || wrappers.empty?
+
+        wrappers.reverse_each do |factory|
+          wrapped = factory.call(route_definition, handler)
+          unless wrapped.respond_to?(:call)
+            raise TypeError,
+                  "handler wrapper must return an object responding to :call, got #{wrapped.class}"
+          end
+          handler = wrapped
+        end
         handler
       end
     end

--- a/spec/otto/handler_wrappers_spec.rb
+++ b/spec/otto/handler_wrappers_spec.rb
@@ -1,0 +1,497 @@
+# spec/otto/handler_wrappers_spec.rb
+#
+# frozen_string_literal: true
+#
+# Coverage for Otto#register_handler_wrapper (issue #130): public API surface,
+# composition order around RouteAuthWrapper, block arguments, TypeError on
+# bad return values, frozen-config guard, multi-instance isolation, and the
+# zero-overhead path through HandlerFactory.apply_handler_wrappers.
+
+require_relative '../spec_helper'
+
+RSpec.describe 'Otto#register_handler_wrapper' do
+  # Recording wrapper: pushes its tag to a shared array on construction-time
+  # call, then delegates. Use as a spy for both static chain inspection
+  # (via #inner) and dynamic execution-order assertions (via the shared log).
+  let(:recording_wrapper_class) do
+    Class.new do
+      attr_reader :inner, :tag, :log
+
+      def initialize(inner, tag, log)
+        @inner = inner
+        @tag = tag
+        @log = log
+      end
+
+      def call(env, extra_params = {})
+        @log << @tag
+        @inner.call(env, extra_params)
+      end
+    end
+  end
+
+  let(:route_lines) do
+    [
+      'GET / TestApp.index',
+      'GET /show/:id TestApp.show',
+    ]
+  end
+
+  let(:otto) { create_minimal_otto(route_lines) }
+
+  describe 'API surface' do
+    it 'returns self to support chaining' do
+      result = otto.register_handler_wrapper { |_rd, inner| inner }
+      expect(result).to equal(otto)
+    end
+
+    it 'chains multiple registrations on a single line' do
+      chained = otto
+                .register_handler_wrapper { |_rd, inner| inner }
+                .register_handler_wrapper { |_rd, inner| inner }
+                .register_handler_wrapper { |_rd, inner| inner }
+
+      expect(chained).to equal(otto)
+      expect(otto.handler_wrappers.length).to eq(3)
+    end
+
+    it 'exposes registered blocks via #handler_wrappers' do
+      block = proc { |_rd, inner| inner }
+      otto.register_handler_wrapper(&block)
+
+      expect(otto.handler_wrappers).to be_an(Array)
+      expect(otto.handler_wrappers.length).to eq(1)
+      expect(otto.handler_wrappers.first).to equal(block)
+    end
+
+    it 'is a no-op when called without a block' do
+      otto.register_handler_wrapper
+      expect(otto.handler_wrappers).to be_empty
+    end
+
+    it 'starts with an empty wrapper list' do
+      expect(otto.handler_wrappers).to eq([])
+    end
+  end
+
+  describe 'composition order at request time' do
+    it 'invokes consumer wrappers outermost-first in registration order' do
+      execution_log = []
+
+      otto.register_handler_wrapper do |_rd, inner|
+        recording_wrapper_class.new(inner, :wrapper_a, execution_log)
+      end
+      otto.register_handler_wrapper do |_rd, inner|
+        recording_wrapper_class.new(inner, :wrapper_b, execution_log)
+      end
+
+      # Wrap the base handler so we can record when it actually runs.
+      allow(TestApp).to receive(:index).and_wrap_original do |original, *args|
+        execution_log << :base_handler
+        original.call(*args)
+      end
+
+      otto.call(mock_rack_env(method: 'GET', path: '/'))
+
+      # First registered (a) is outermost; second (b) sits inside a.
+      # RouteAuthWrapper runs between b and the base handler but does not
+      # appear in this log because it is not a recording wrapper.
+      expect(execution_log).to eq(%i[wrapper_a wrapper_b base_handler])
+    end
+
+    it 'fires three wrappers in the order they were registered' do
+      execution_log = []
+      %i[outer middle inner].each do |tag|
+        otto.register_handler_wrapper do |_rd, inner_handler|
+          recording_wrapper_class.new(inner_handler, tag, execution_log)
+        end
+      end
+
+      otto.call(mock_rack_env(method: 'GET', path: '/'))
+
+      expect(execution_log).to eq(%i[outer middle inner])
+    end
+
+    it 'composes the static wrapper chain so the first wrapper is the outermost object' do
+      otto.register_handler_wrapper do |_rd, inner|
+        recording_wrapper_class.new(inner, :outer, [])
+      end
+      otto.register_handler_wrapper do |_rd, inner|
+        recording_wrapper_class.new(inner, :inner_consumer, [])
+      end
+
+      route_def = otto.route_definitions.values.first
+      handler = Otto::RouteHandlers::HandlerFactory.create_handler(route_def, otto)
+
+      expect(handler).to be_a(recording_wrapper_class)
+      expect(handler.tag).to eq(:outer)
+      expect(handler.inner).to be_a(recording_wrapper_class)
+      expect(handler.inner.tag).to eq(:inner_consumer)
+    end
+  end
+
+  describe 'block arguments' do
+    it 'yields (route_definition, inner_handler) with a callable handler and route metadata' do
+      captured_rd = nil
+      captured_inner = nil
+
+      otto.register_handler_wrapper do |route_definition, inner_handler|
+        captured_rd = route_definition
+        captured_inner = inner_handler
+        inner_handler
+      end
+
+      otto.call(mock_rack_env(method: 'GET', path: '/show/42'))
+
+      expect(captured_rd).to be_a(Otto::RouteDefinition)
+      expect(captured_rd.path).to eq('/show/:id')
+      expect(captured_rd.verb).to eq(:GET)
+      expect(captured_rd.options).to be_a(Hash)
+      expect(captured_inner).to respond_to(:call)
+    end
+
+    it 'lets the wrapper inspect arbitrary route options' do
+      # Route file with a custom option; option(:scope) drives gating.
+      lines = ['GET /canon TestApp.index scope=canonical']
+      gated_otto = create_minimal_otto(lines)
+
+      scopes_seen = []
+      gated_otto.register_handler_wrapper do |route_definition, inner|
+        scopes_seen << route_definition.option(:scope)
+        inner
+      end
+
+      gated_otto.call(mock_rack_env(method: 'GET', path: '/canon'))
+
+      expect(scopes_seen).to eq(['canonical'])
+    end
+  end
+
+  describe 'passthrough vs wrapping' do
+    it 'is transparent when the wrapper returns inner_handler unchanged' do
+      called = false
+      otto.register_handler_wrapper do |_rd, inner|
+        called = true
+        inner
+      end
+
+      status, _headers, body = otto.call(mock_rack_env(method: 'GET', path: '/'))
+
+      expect(called).to be true
+      expect(status).to eq(200)
+      expect(body.first).to include('Hello World')
+    end
+
+    it 'interposes when the wrapper returns a new callable' do
+      execution_log = []
+
+      otto.register_handler_wrapper do |_rd, inner|
+        recording_wrapper_class.new(inner, :interposed, execution_log)
+      end
+
+      status, = otto.call(mock_rack_env(method: 'GET', path: '/'))
+
+      expect(status).to eq(200)
+      expect(execution_log).to eq([:interposed])
+    end
+
+    it 'lets a wrapper short-circuit the response' do
+      otto.register_handler_wrapper do |_rd, _inner|
+        ->(_env, _extra = {}) { [418, { 'Content-Type' => 'text/plain' }, ["I'm a teapot"]] }
+      end
+
+      status, headers, body = otto.call(mock_rack_env(method: 'GET', path: '/'))
+
+      expect(status).to eq(418)
+      expect(headers['Content-Type']).to eq('text/plain')
+      expect(body).to eq(["I'm a teapot"])
+    end
+  end
+
+  describe 'TypeError on bad wrapper return values' do
+    let(:route_def) { Otto::RouteDefinition.new('GET', '/test', 'TestApp.index') }
+
+    it 'raises TypeError when the wrapper returns nil' do
+      otto.register_handler_wrapper { |_rd, _inner| nil }
+
+      expect do
+        Otto::RouteHandlers::HandlerFactory.create_handler(route_def, otto)
+      end.to raise_error(TypeError, /handler wrapper must return an object responding to :call, got NilClass/)
+    end
+
+    it 'raises TypeError when the wrapper returns false' do
+      otto.register_handler_wrapper { |_rd, _inner| false }
+
+      expect do
+        Otto::RouteHandlers::HandlerFactory.create_handler(route_def, otto)
+      end.to raise_error(TypeError, /got FalseClass/)
+    end
+
+    it 'raises TypeError naming the class of a non-callable return value' do
+      bad_class = Class.new
+      stub_const('NotCallable', bad_class)
+      otto.register_handler_wrapper { |_rd, _inner| bad_class.new }
+
+      expect do
+        Otto::RouteHandlers::HandlerFactory.create_handler(route_def, otto)
+      end.to raise_error(TypeError, /got NotCallable/)
+    end
+  end
+
+  describe 'frozen configuration guard' do
+    it 'raises FrozenError when registered after configuration freeze' do
+      frozen_otto = create_minimal_otto(route_lines)
+      frozen_otto.freeze_configuration!
+
+      expect do
+        frozen_otto.register_handler_wrapper { |_rd, inner| inner }
+      end.to raise_error(FrozenError, /Cannot modify frozen configuration/)
+    end
+  end
+
+  describe 'boot-time validation via freeze_configuration!' do
+    it 'raises TypeError at boot when any registered wrapper returns a non-callable' do
+      boot_otto = create_minimal_otto(route_lines)
+      boot_otto.register_handler_wrapper { |_rd, _inner| nil }
+
+      expect do
+        boot_otto.freeze_configuration!
+      end.to raise_error(TypeError, /handler wrapper must return an object responding to :call, got NilClass/)
+    end
+
+    it 'raises at boot when a registered wrapper raises for any loaded route' do
+      boot_otto = create_minimal_otto(route_lines)
+      boot_otto.register_handler_wrapper do |_rd, _inner|
+        raise 'factory exploded'
+      end
+
+      expect do
+        boot_otto.freeze_configuration!
+      end.to raise_error(RuntimeError, /factory exploded/)
+    end
+
+    it 'is a no-op when no handler wrappers are registered' do
+      boot_otto = create_minimal_otto(route_lines)
+
+      expect { boot_otto.freeze_configuration! }.not_to raise_error
+    end
+  end
+
+  describe 'multi-instance isolation' do
+    it 'does not leak registrations from one Otto instance to another' do
+      otto_a = create_minimal_otto(route_lines)
+      otto_b = create_minimal_otto(route_lines)
+
+      a_invocations = []
+      otto_a.register_handler_wrapper do |_rd, inner|
+        recording_wrapper_class.new(inner, :a_only, a_invocations)
+      end
+
+      expect(otto_a.handler_wrappers.length).to eq(1)
+      expect(otto_b.handler_wrappers).to be_empty
+
+      otto_b.call(mock_rack_env(method: 'GET', path: '/'))
+
+      expect(a_invocations).to be_empty
+    end
+  end
+
+  describe 'RouteAuthWrapper invariant' do
+    it 'keeps RouteAuthWrapper as the innermost wrapper between consumer wrappers and the base handler' do
+      otto.register_handler_wrapper do |_rd, inner|
+        recording_wrapper_class.new(inner, :outer, [])
+      end
+      otto.register_handler_wrapper do |_rd, inner|
+        recording_wrapper_class.new(inner, :inner_consumer, [])
+      end
+
+      route_def = otto.route_definitions.values.first
+      handler = Otto::RouteHandlers::HandlerFactory.create_handler(route_def, otto)
+
+      # Walk: outer -> inner_consumer -> RouteAuthWrapper -> base handler.
+      expect(handler).to be_a(recording_wrapper_class)
+      expect(handler.tag).to eq(:outer)
+
+      second = handler.inner
+      expect(second).to be_a(recording_wrapper_class)
+      expect(second.tag).to eq(:inner_consumer)
+
+      auth_wrapper = second.inner
+      expect(auth_wrapper).to be_a(Otto::Security::Authentication::RouteAuthWrapper)
+
+      base_handler = auth_wrapper.wrapped_handler
+      expect(base_handler).to be_a(Otto::RouteHandlers::BaseHandler)
+    end
+
+    it 'lets consumer wrappers observe env state set by RouteAuthWrapper' do
+      captured_strategy_results = []
+
+      otto.register_handler_wrapper do |_rd, inner|
+        # This wrapper sits outside RouteAuthWrapper, so when its call body
+        # delegates inward and control returns, env has been mutated by the
+        # inner RouteAuthWrapper. To observe the inside-the-chain state we
+        # check env AFTER the inner call returns.
+        wrapper = Class.new do
+          define_method(:initialize) { |i| @inner = i }
+          define_method(:call) do |env, extra = {}|
+            result = @inner.call(env, extra)
+            captured_strategy_results << env['otto.strategy_result']
+            result
+          end
+        end
+        wrapper.new(inner)
+      end
+
+      otto.call(mock_rack_env(method: 'GET', path: '/'))
+
+      expect(captured_strategy_results.length).to eq(1)
+      # RouteAuthWrapper sets an anonymous StrategyResult for routes without
+      # auth requirements; verify the wrapper saw the env mutation.
+      expect(captured_strategy_results.first).not_to be_nil
+      expect(captured_strategy_results.first).to respond_to(:anonymous?)
+    end
+  end
+
+  describe 'per-request isolation (no state leak between requests)' do
+    it 'constructs a fresh wrapper instance per request' do
+      instances = []
+      otto.register_handler_wrapper do |_rd, inner|
+        w = recording_wrapper_class.new(inner, :iso, [])
+        instances << w
+        w
+      end
+
+      3.times { otto.call(mock_rack_env(method: 'GET', path: '/')) }
+
+      expect(instances.length).to eq(3)
+      expect(instances.map(&:object_id).uniq.length).to eq(3)
+    end
+
+    it 'does not let wrapper instance state survive across requests' do
+      # @count is incremented on call; snapshot at entry must be 0 every time
+      # since each request should see a fresh wrapper instance.
+      stateful_wrapper = Class.new do
+        attr_reader :count_at_entry
+
+        def initialize(inner)
+          @inner = inner
+          @count = 0
+        end
+
+        def call(env, extra = {})
+          @count_at_entry = @count
+          @count += 1
+          @inner.call(env, extra)
+        end
+      end
+
+      entries = []
+      otto.register_handler_wrapper do |_rd, inner|
+        w = stateful_wrapper.new(inner)
+        entries << w
+        w
+      end
+
+      3.times { otto.call(mock_rack_env(method: 'GET', path: '/')) }
+
+      expect(entries.length).to eq(3)
+      expect(entries.map(&:count_at_entry)).to eq([0, 0, 0])
+    end
+
+    it 'persists factory closure variables across requests (confirms test apparatus)' do
+      # Inverse of the previous case: state captured in the factory block's
+      # closure (NOT inside a wrapper instance) is expected to persist. If
+      # this stopped working, the isolation tests above would be meaningless.
+      factory_call_count = 0
+      otto.register_handler_wrapper do |_rd, inner|
+        factory_call_count += 1
+        inner
+      end
+
+      3.times { otto.call(mock_rack_env(method: 'GET', path: '/')) }
+
+      expect(factory_call_count).to eq(3)
+    end
+
+    it 'observes the current env for each request, not a stale env' do
+      seen_envs = []
+      otto.register_handler_wrapper do |_rd, inner|
+        capture = Class.new do
+          define_method(:initialize) { |i| @inner = i }
+          define_method(:call) do |env, extra = {}|
+            seen_envs << { path: env['PATH_INFO'], qs: env['QUERY_STRING'], hdr: env['HTTP_X_TAG'] }
+            @inner.call(env, extra)
+          end
+        end
+        capture.new(inner)
+      end
+
+      otto.call(mock_rack_env(method: 'GET', path: '/', headers: { 'X-Tag' => 'first' }))
+      otto.call(mock_rack_env(method: 'GET', path: '/show/42', headers: { 'X-Tag' => 'second' }))
+
+      expect(seen_envs.length).to eq(2)
+      expect(seen_envs[0][:path]).to eq('/')
+      expect(seen_envs[0][:hdr]).to eq('first')
+      expect(seen_envs[1][:path]).to eq('/show/42')
+      expect(seen_envs[1][:hdr]).to eq('second')
+    end
+
+    it 'gives each concurrent request a distinct wrapper instance' do
+      # Best-effort: 4 threads x 10 requests. Collect object_ids under a
+      # mutex; require strictly distinct ids. Accidental memoization
+      # (e.g. caching the constructed wrapper) would collapse the set.
+      ids = Set.new
+      mu = Mutex.new
+
+      otto.register_handler_wrapper do |_rd, inner|
+        w = recording_wrapper_class.new(inner, :concurrent, [])
+        mu.synchronize { ids << w.object_id }
+        w
+      end
+
+      threads = Array.new(4) do
+        Thread.new do # rubocop:disable ThreadSafety/NewThread
+          10.times { otto.call(mock_rack_env(method: 'GET', path: '/')) }
+        end
+      end
+      threads.each(&:join)
+
+      expect(ids.size).to eq(40)
+    end
+  end
+
+  describe 'zero-overhead path' do
+    let(:route_def) { Otto::RouteDefinition.new('GET', '/test', 'TestApp.index') }
+
+    it 'returns the input handler unchanged when no wrappers are registered' do
+      base_handler = Otto::RouteHandlers::ClassMethodHandler.new(route_def)
+      result = Otto::RouteHandlers::HandlerFactory.apply_handler_wrappers(base_handler, route_def, otto)
+
+      expect(result).to equal(base_handler)
+    end
+
+    it 'returns the input handler when otto_instance is nil' do
+      base_handler = Otto::RouteHandlers::ClassMethodHandler.new(route_def)
+      result = Otto::RouteHandlers::HandlerFactory.apply_handler_wrappers(base_handler, route_def, nil)
+
+      expect(result).to equal(base_handler)
+    end
+
+    it 'create_handler still produces the expected handler type without wrappers' do
+      handler = Otto::RouteHandlers::HandlerFactory.create_handler(route_def, otto)
+
+      # With otto_instance, the outermost object is RouteAuthWrapper (no
+      # consumer wrappers); its wrapped_handler is the base handler class.
+      expect(handler).to be_a(Otto::Security::Authentication::RouteAuthWrapper)
+      expect(handler.wrapped_handler).to be_a(Otto::RouteHandlers::ClassMethodHandler)
+    end
+
+    it 'does not invoke any factory blocks when no wrappers are registered' do
+      # Sanity check that the early-return on factory.rb:47 fires: register
+      # nothing, then ensure handler_wrappers is empty for the request path.
+      expect(otto.handler_wrappers).to be_empty
+      status, = otto.call(mock_rack_env(method: 'GET', path: '/'))
+      expect(status).to eq(200)
+    end
+  end
+end

--- a/spec/otto/logging_integration_spec.rb
+++ b/spec/otto/logging_integration_spec.rb
@@ -176,6 +176,162 @@ RSpec.describe 'Otto Logging Integration' do
     end
   end
 
+  describe 'route matched hooks' do
+    # Use stub_const for the error class so the constant doesn't leak across files.
+    let(:route_blocked_error_class) { stub_const('RouteBlockedError', Class.new(StandardError)) }
+
+    let(:route_lines) do
+      [
+        'GET / TestApp.index',
+        'GET /show/:id TestApp.show',
+        'GET /404 TestApp.index',
+      ]
+    end
+    let(:otto) { create_minimal_otto(route_lines) }
+
+    it 'returns self and supports chaining' do
+      noop = ->(_env, _rd) { :noop }
+
+      result = otto.on_route_matched(&noop)
+      expect(result).to equal(otto)
+
+      chained = otto.on_route_matched(&noop).on_route_matched(&noop)
+      expect(chained).to equal(otto)
+      # Three callbacks registered total (one above plus two on the chained line).
+      expect(otto.route_matched_callbacks.length).to eq(3)
+    end
+
+    it 'fires after match and before handler on literal routes, with the correct RouteDefinition' do
+      order = []
+      captured_definition = nil
+
+      otto.on_route_matched do |_env, route_definition|
+        order << :hook
+        captured_definition = route_definition
+      end
+
+      # Wrap the index handler to record its execution after the hook.
+      allow(TestApp).to receive(:index).and_wrap_original do |original, *args|
+        order << :handler
+        original.call(*args)
+      end
+
+      otto.call(mock_rack_env(method: 'GET', path: '/'))
+
+      expect(order).to eq(%i[hook handler])
+      expect(captured_definition).to be_a(Otto::RouteDefinition)
+      expect(captured_definition.path).to eq('/')
+      expect(captured_definition.definition).to eq('TestApp.index')
+    end
+
+    it 'fires on dynamic routes with the correct RouteDefinition' do
+      captured = []
+      otto.on_route_matched do |env, route_definition|
+        captured << { path: route_definition.path, env_path: env['PATH_INFO'] }
+      end
+
+      otto.call(mock_rack_env(method: 'GET', path: '/show/42'))
+
+      expect(captured.length).to eq(1)
+      expect(captured.first[:path]).to eq('/show/:id')
+      expect(captured.first[:env_path]).to eq('/show/42')
+    end
+
+    it 'routes a raise from the callback through the registered error handler and skips the handler' do
+      otto.register_error_handler(route_blocked_error_class, status: 404, log_level: :info)
+
+      handler_called = false
+      allow(TestApp).to receive(:index).and_wrap_original do |original, *args|
+        handler_called = true
+        original.call(*args)
+      end
+
+      otto.on_route_matched do |_env, _rd|
+        raise route_blocked_error_class, 'blocked'
+      end
+
+      response = otto.call(mock_rack_env(method: 'GET', path: '/'))
+
+      expect(response[0]).to eq(404)
+      expect(handler_called).to be false
+    end
+
+    it 'does not fire on the 404 fallback when an unmatched path is requested' do
+      called = []
+      otto.on_route_matched do |_env, route_definition|
+        called << route_definition.path
+      end
+
+      # /does-not-exist matches no literal and no dynamic pattern; with a /404
+      # literal route present, router falls back to it WITHOUT firing the hook.
+      otto.call(mock_rack_env(method: 'GET', path: '/does-not-exist'))
+
+      expect(called).to be_empty
+    end
+
+    it 'does not fire on static file routes' do
+      static_dir = Dir.mktmpdir('otto_static_spec')
+      static_file = File.join(static_dir, 'safe.txt')
+      File.write(static_file, 'static content')
+
+      # safe_file? requires the file to be owned by the current user or group;
+      # skip if the test environment can't satisfy that constraint.
+      unless File.owned?(static_file) || File.grpowned?(static_file)
+        FileUtils.rm_rf(static_dir)
+        skip 'static file ownership requirement not satisfied in this environment'
+      end
+
+      routes_file = create_test_routes_file('test_routes_static.txt', ['GET / TestApp.index'])
+      static_otto = Otto.new(routes_file, public: static_dir)
+      Otto.unfreeze_for_testing(static_otto)
+
+      called = []
+      static_otto.on_route_matched do |_env, route_definition|
+        called << route_definition.path
+      end
+
+      static_otto.call(mock_rack_env(method: 'GET', path: '/safe.txt'))
+
+      expect(called).to be_empty
+    ensure
+      FileUtils.rm_rf(static_dir) if static_dir && Dir.exist?(static_dir)
+    end
+
+    it 'raises FrozenError when registered after configuration freeze' do
+      frozen_otto = create_minimal_otto(route_lines)
+      frozen_otto.freeze_configuration!
+
+      expect { frozen_otto.on_route_matched { |_env, _rd| :noop } }
+        .to raise_error(FrozenError)
+    end
+
+    it 'isolates callbacks between Otto instances (per-instance state)' do
+      otto_a = create_minimal_otto(route_lines)
+      otto_b = create_minimal_otto(route_lines)
+
+      a_calls = []
+      otto_a.on_route_matched do |_env, route_definition|
+        a_calls << route_definition.path
+      end
+
+      otto_b.call(mock_rack_env(method: 'GET', path: '/'))
+
+      expect(a_calls).to be_empty
+      expect(otto_b.route_matched_callbacks).to be_empty
+    end
+
+    it 'fires multiple registered callbacks in registration order' do
+      order = []
+      otto.on_route_matched { |_env, _rd| order << :first }
+      otto.on_route_matched { |_env, _rd| order << :second }
+      otto.on_route_matched { |_env, _rd| order << :third }
+
+      otto.call(mock_rack_env(method: 'GET', path: '/'))
+
+      expect(order).to eq(%i[first second third])
+    end
+  end
+
   describe 'Otto.structured_log in action' do
     it 'logs route resolution events using structured logging' do
       # Test that we can log route matching events


### PR DESCRIPTION
## Summary

Adds two complementary post-match extension points to Otto: a **proactive** handler wrapper API for boot-time composition, and a **reactive** lifecycle hook for per-request gating. Both are additive — zero behavior change when unused.

Closes #129. Closes #130.

## `on_route_matched` (#129)

Reactive hook firing after route match, before handler dispatch.

```ruby
otto.on_route_matched do |env, route_definition|
  raise MyApp::RouteBlocked unless allow_list.include?(route_definition.path)
end
```

- Signature `(env, route_definition)`; raises propagate to `handle_error` (intentional contrast with `on_request_complete`, which swallows)
- Fires on literal and dynamic matches; **not** on static files or the 404 fallback
- Per-instance, frozen with config, zero overhead when unregistered

## `register_handler_wrapper` (#130)

Proactive factory composed around handlers once at boot.

```ruby
otto.register_handler_wrapper do |route_def, inner|
  next inner unless route_def.option(:scope) == 'canonical'
  CanonicalOnlyWrapper.new(inner, route_def)
end
```

- Block `(route_definition, inner_handler)` returns a callable (or the original to opt out per-route)
- Composition order: `request → wrapper_1 → ... → wrapper_N → RouteAuthWrapper → base_handler`
- `RouteAuthWrapper` stays innermost so wrappers see `env['otto.strategy_result']`
- `freeze_configuration!` exercises every wrapper against every loaded route, surfacing factory `TypeError` at boot rather than first request

## How they relate

- `on_route_matched` — decision depends on mutable external state (allow lists, feature flags). Per request.
- `register_handler_wrapper` — decision derivable from static route metadata (route options). Compiled once.

Both generalize patterns previously locked inside `RouteAuthWrapper`.

## Public API

- `Otto#on_route_matched(&block) → self`
- `Otto#route_matched_callbacks → Array` (api private)
- `Otto#register_handler_wrapper(&block) → self`
- `Otto#handler_wrappers → Array` (api private)

## Test plan

- [x] `spec/otto/handler_wrappers_spec.rb` (497 lines) — composition order, chaining, TypeError on bad return, frozen-config guard, multi-instance isolation, zero-overhead path, RouteAuthWrapper positioning
- [x] `spec/otto/logging_integration_spec.rb` (156 lines) — fire ordering, env/route_definition payload, exception propagation, no-fire on 404, chaining
- [ ] Manual smoke against a downstream consumer using `route_definition.option(...)` to gate behavior