### PR TITLE
Release v2.1.0: Route matching hooks and handler wrappers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,31 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.1.0/>`
 
    <!--scriv-insert-here-->
 
+.. _changelog-2.1.0:
+
+2.1.0 — 2026-05-27
+==================
+
+- Add ``Otto#on_route_matched`` lifecycle hook. Callbacks fire after a
+  route matches but before the handler dispatches, with signature
+  ``(env, route_definition)``. Mirrors ``on_request_complete`` for
+  registration and freezing, but exceptions raised from a callback
+  propagate through ``handle_error`` rather than being swallowed, so
+  consumers can route custom error classes through
+  ``register_error_handler`` for short-circuit gating. Skipped for
+  static file routes and the 404 fallback; fires on both literal and
+  dynamic matches. Per-instance state, zero overhead when no callbacks
+  are registered. (#129)
+
+- Add ``Otto#register_handler_wrapper`` API for per-request handler
+  composition. Registers factory blocks composed around each route
+  handler at request time; wrappers nest outermost-first in
+  registration order, with ``RouteAuthWrapper`` preserved as the
+  innermost wrapper so consumers see ``env['otto.strategy_result']``.
+  ``freeze_configuration!`` now exercises every registered wrapper
+  against every loaded route, surfacing ``TypeError`` and factory bugs
+  at boot rather than on the first matching request. (#130)
+
 .. _changelog-2.0.2:
 
 2.0.2 — 2026-04-15

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    otto (2.0.2)
+    otto (2.1.0)
       concurrent-ruby (~> 1.3, < 2.0)
       ipaddr (~> 1, < 2.0)
       logger (~> 1, < 2.0)

--- a/lib/otto/version.rb
+++ b/lib/otto/version.rb
@@ -3,5 +3,5 @@
 # frozen_string_literal: true
 
 class Otto
-  VERSION = '2.0.2'
+  VERSION = '2.1.0'
 end


### PR DESCRIPTION
## Summary

This release introduces two new lifecycle features for Otto: a `on_route_matched` hook that fires after route matching but before handler dispatch, and a `register_handler_wrapper` API for per-request handler composition. These features enable custom middleware-like behavior at the handler level while maintaining Otto's security-first architecture.

## Key Changes

- **Add `Otto#on_route_matched` lifecycle hook** (#129)
  - Fires after route matches but before handler dispatch
  - Signature: `(env, route_definition)`
  - Mirrors `on_request_complete` for registration and freezing
  - Exceptions propagate through `handle_error` for custom error routing
  - Skipped for static file routes and 404 fallback
  - Per-instance state with zero overhead when no callbacks registered

- **Add `Otto#register_handler_wrapper` API** (#130)
  - Factory blocks composed around each route handler at request time
  - Wrappers nest outermost-first in registration order
  - `RouteAuthWrapper` preserved as innermost wrapper to maintain `env['otto.strategy_result']` visibility
  - `freeze_configuration!` now exercises every registered wrapper against every loaded route
  - Surfaces `TypeError` and factory bugs at boot rather than on first matching request

- **Version bump to 2.1.0**
  - Updated `lib/otto/version.rb`
  - Added changelog entry with implementation details

## Implementation Details

Both features follow Otto's established patterns:
- Configuration must complete before first request (enforced by freezing)
- Per-instance state allows multi-app deployments
- Handler wrappers integrate seamlessly with existing authentication architecture
- Error handling consistency with existing lifecycle hooks

https://claude.ai/code/session_01PRzLMsEvAn8ciWjsTUMt9g