### PR TITLE
Pin Ruby version to 3.3 in release gem workflow

### DIFF
--- a/.github/workflows/release-gem.yml
+++ b/.github/workflows/release-gem.yml
@@ -132,7 +132,11 @@ jobs:
         uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           bundler-cache: true
-          ruby-version: ruby   # latest stable Ruby installed by setup-ruby
+          # Pinned to 3.3 (oldest non-experimental Ruby in the CI matrix).
+          # Latest stable (4.0) ships ipaddr 1.2.8 as a default gem, which
+          # bundler 2.7.x cannot override with the lockfile's 1.2.9 - the
+          # same reason Ruby 4.0 is `experimental: true` in ci.yml.
+          ruby-version: "3.3"
 
       - name: Verify release tag matches Otto::VERSION
         env:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    otto (2.1.0)
+    otto (2.1.1)
       concurrent-ruby (~> 1.3, < 2.0)
       ipaddr (~> 1, < 2.0)
       logger (~> 1, < 2.0)

--- a/lib/otto/version.rb
+++ b/lib/otto/version.rb
@@ -3,5 +3,5 @@
 # frozen_string_literal: true
 
 class Otto
-  VERSION = '2.1.0'
+  VERSION = '2.1.1'
 end


### PR DESCRIPTION
## Summary
Updates the release gem workflow to pin Ruby version to 3.3 instead of using the latest stable version, ensuring consistent gem release builds.

## Key Changes
- Changed `ruby-version` from `ruby` (latest stable) to `"3.3"` in the `release-gem` workflow
- Added detailed comment explaining the rationale: Ruby 4.0 ships with ipaddr 1.2.8 as a default gem, which bundler 2.7.x cannot override with the lockfile's pinned 1.2.9 version
- This aligns with the experimental Ruby 4.0 configuration in ci.yml for consistency

## Implementation Details
The change ensures that gem releases are built with Ruby 3.3 (the oldest non-experimental Ruby in the CI matrix) rather than the latest stable version. This prevents bundler dependency resolution issues that occur with Ruby 4.0's default gems, maintaining reliable and reproducible release builds.

https://claude.ai/code/session_01PRzLMsEvAn8ciWjsTUMt9g