### PR TITLE
Remove ipaddr gemspec dependency to fix bundler 2.7.x compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     otto (2.1.1)
       concurrent-ruby (~> 1.3, < 2.0)
-      ipaddr (~> 1, < 2.0)
       logger (~> 1, < 2.0)
       loofah (~> 2.20)
       rack (~> 3.1, < 4.0)
@@ -55,7 +54,6 @@ GEM
     erb (6.0.4)
     hana (1.3.7)
     io-console (0.8.2)
-    ipaddr (1.2.9)
     irb (1.18.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)

--- a/otto.gemspec
+++ b/otto.gemspec
@@ -21,7 +21,14 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ['>= 3.2', '< 4.1']
 
   spec.add_dependency 'concurrent-ruby', '~> 1.3', '< 2.0'
-  spec.add_dependency 'ipaddr', '~> 1', '< 2.0'
+
+  # ipaddr is a default gem on every supported Ruby (3.2+), so `require
+  # 'ipaddr'` works without a gemspec dependency. Declaring one collides
+  # with bundler 2.7.x's default-gem handling: the lockfile pins a version
+  # newer than the activated default and bundler refuses to swap, breaking
+  # `bundle exec` (including `rake release`). Drop the declaration and
+  # rely on the runtime default gem until bundler ships default-gem
+  # override support for ipaddr.
 
   # Logger is not part of the default gems as of Ruby 3.5.0
   spec.add_dependency 'logger', '~> 1', '< 2.0'


### PR DESCRIPTION
## Summary

Removes the explicit `ipaddr` gemspec dependency to resolve a conflict with bundler 2.7.x's default-gem handling that breaks `bundle exec` commands.

## Changes

- Removed `spec.add_dependency 'ipaddr', '~> 1', '< 2.0'` from otto.gemspec
- Added detailed comment explaining the rationale: `ipaddr` is a default gem in all supported Ruby versions (3.2+), so an explicit gemspec dependency is unnecessary and causes bundler to pin a newer version than the activated default, which bundler 2.7.x refuses to swap

## Implementation Details

The change relies on the runtime default gem `ipaddr` that ships with Ruby 3.2+ rather than declaring an external dependency. This eliminates the version conflict where bundler's lockfile pins a version newer than the activated default gem, which previously caused bundler 2.7.x to refuse the swap and break `bundle exec` (including `rake release`).

The solution is temporary until bundler ships default-gem override support for `ipaddr`.

https://claude.ai/code/session_01PRzLMsEvAn8ciWjsTUMt9g