### PR TITLE
Add AuthorizationFailure support to auth strategies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides essential guidance to Claude Code when working with Otto.
+This file provides essential guidance to AI agents when working with Otto.
 
 ## Error Handler Registration
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,18 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.1.0/>`
 
    <!--scriv-insert-here-->
 
+.. _changelog-2.2.0:
+
+2.2.0 — 2026-06-09
+==================
+
+Added
+-----
+
+- Added ``AuthorizationFailure`` result type for auth strategies to signal 403 Forbidden distinct from 401 Unauthorized. Strategies that perform combined authentication and authorization in one pass can now return ``authorization_failure(reason)`` when a valid credential is denied a permission, allowing ``RouteAuthWrapper`` to map the result to a proper 403 response rather than collapsing it to 401.
+- Added ``#authorization_failure`` helper to ``AuthStrategy`` base class for consistent error signaling across strategy implementations.
+- Extracted ``#strategy_auth_method`` private helper to handle anonymous strategy classes (common in tests) that have a nil ``#name``.
+
 .. _changelog-2.1.0:
 
 2.1.0 — 2026-05-27

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    otto (2.1.1)
+    otto (2.2.0)
       concurrent-ruby (~> 1.3, < 2.0)
       ipaddr (~> 1, < 2.0)
       logger (~> 1, < 2.0)

--- a/changelog.d/20260609_005312_delano_failure-403.rst
+++ b/changelog.d/20260609_005312_delano_failure-403.rst
@@ -1,0 +1,6 @@
+Added
+-----
+
+- Added ``AuthorizationFailure`` result type for auth strategies to signal 403 Forbidden distinct from 401 Unauthorized. Strategies that perform combined authentication and authorization in one pass can now return ``authorization_failure(reason)`` when a valid credential is denied a permission, allowing ``RouteAuthWrapper`` to map the result to a proper 403 response rather than collapsing it to 401.
+- Added ``#authorization_failure`` helper to ``AuthStrategy`` base class for consistent error signaling across strategy implementations.
+- Extracted ``#strategy_auth_method`` private helper to handle anonymous strategy classes (common in tests) that have a nil ``#name``.

--- a/changelog.d/20260609_005312_delano_failure-403.rst
+++ b/changelog.d/20260609_005312_delano_failure-403.rst
@@ -1,6 +1,0 @@
-Added
------
-
-- Added ``AuthorizationFailure`` result type for auth strategies to signal 403 Forbidden distinct from 401 Unauthorized. Strategies that perform combined authentication and authorization in one pass can now return ``authorization_failure(reason)`` when a valid credential is denied a permission, allowing ``RouteAuthWrapper`` to map the result to a proper 403 response rather than collapsing it to 401.
-- Added ``#authorization_failure`` helper to ``AuthStrategy`` base class for consistent error signaling across strategy implementations.
-- Extracted ``#strategy_auth_method`` private helper to handle anonymous strategy classes (common in tests) that have a nil ``#name``.

--- a/lib/otto/security/authentication.rb
+++ b/lib/otto/security/authentication.rb
@@ -8,6 +8,7 @@
 require_relative 'authentication/auth_strategy'
 require_relative 'authentication/strategy_result'
 require_relative 'authentication/auth_failure'
+require_relative 'authentication/authorization_failure'
 require_relative 'authentication/route_auth_wrapper'
 
 # Load all strategies
@@ -31,4 +32,5 @@ class Otto
   # Top-level backward compatibility aliases
   StrategyResult = Security::Authentication::StrategyResult
   AuthFailure = Security::Authentication::AuthFailure
+  AuthorizationFailure = Security::Authentication::AuthorizationFailure
 end

--- a/lib/otto/security/authentication/auth_strategy.rb
+++ b/lib/otto/security/authentication/auth_strategy.rb
@@ -38,12 +38,39 @@ class Otto
         end
 
         # Helper for authentication failure - return AuthFailure
+        #
+        # Use for a missing, invalid, or expired credential. RouteAuthWrapper maps
+        # this to 401 Unauthorized. For a VALID credential that is not permitted,
+        # use #authorization_failure instead (403 Forbidden).
         def failure(reason = nil)
           Otto.logger.debug "[#{self.class}] Authentication failed: #{reason}" if reason
           Otto::Security::Authentication::AuthFailure.new(
             failure_reason: reason || 'Authentication failed',
-            auth_method: self.class.name.split('::').last
+            auth_method: strategy_auth_method
           )
+        end
+
+        # Helper for authorization failure - return AuthorizationFailure
+        #
+        # Use when the credential is valid but the authenticated subject is not
+        # permitted (wrong role, missing permission). RouteAuthWrapper maps this to
+        # 403 Forbidden, letting clients distinguish "authenticate again" (401) from
+        # "you lack this permission" (403). See AuthorizationFailure.
+        def authorization_failure(reason = nil)
+          Otto.logger.debug "[#{self.class}] Authorization denied: #{reason}" if reason
+          Otto::Security::Authentication::AuthorizationFailure.new(
+            failure_reason: reason || 'Authorization denied',
+            auth_method: strategy_auth_method
+          )
+        end
+
+        private
+
+        # Short auth_method label from the strategy class name. Anonymous strategy
+        # classes (Class.new(...), common in tests) have a nil #name, so fall back
+        # to a generic label rather than raising on nil#split.
+        def strategy_auth_method
+          (self.class.name || 'AuthStrategy').split('::').last
         end
       end
     end

--- a/lib/otto/security/authentication/auth_strategy.rb
+++ b/lib/otto/security/authentication/auth_strategy.rb
@@ -31,7 +31,7 @@ class Otto
           Otto::Security::Authentication::StrategyResult.new(
             session: session,
             user: user,
-            auth_method: auth_method || self.class.name.split('::').last,
+            auth_method: auth_method || strategy_auth_method,
             metadata: metadata,
             strategy_name: nil # Will be set by RouteAuthWrapper
           )

--- a/lib/otto/security/authentication/authorization_failure.rb
+++ b/lib/otto/security/authentication/authorization_failure.rb
@@ -1,0 +1,56 @@
+# lib/otto/security/authentication/authorization_failure.rb
+#
+# frozen_string_literal: true
+
+class Otto
+  module Security
+    module Authentication
+      # Result for AUTHORIZATION failures (authenticated, but not permitted).
+      #
+      # This is distinct from AuthFailure, which represents an AUTHENTICATION
+      # failure (no/invalid/expired credential). A strategy that performs both
+      # authentication and authorization in one pass (e.g. a token strategy that
+      # also enforces a role/permission encoded in the route requirement) returns:
+      #
+      #   * AuthFailure          -> credential missing/invalid  -> 401 Unauthorized
+      #   * AuthorizationFailure -> credential valid, but denied -> 403 Forbidden
+      #
+      # Without this type a combined strategy could only return AuthFailure, and
+      # RouteAuthWrapper would collapse an authorization denial to 401 — leaving a
+      # client unable to distinguish "authenticate again" from "you lack this
+      # permission." The wrapper maps this type to ResponseBuilder#forbidden (403);
+      # see RouteAuthWrapper#handle_all_strategies_failed.
+      #
+      # NOTE: Otto's built-in Layer-1 role check (RoleAuthorization, driven by the
+      # `role=` route token) already yields 403 for role mismatches on a successful
+      # StrategyResult. This type covers the complementary case: a strategy that
+      # owns authorization itself (including permission tiers, which Layer-1 does
+      # not model) and needs to signal a 403 directly.
+      AuthorizationFailure = Data.define(:failure_reason, :auth_method) do
+        # Authorization failures are not an authenticated request state. The
+        # request never reaches the handler, so handler-facing predicates report
+        # the same "no user context" shape AuthFailure does.
+        #
+        # @return [Boolean] False
+        def authenticated?
+          false
+        end
+
+        # @return [Boolean] True (no user context attached to a denial)
+        def anonymous?
+          true
+        end
+
+        # @return [Hash] Empty hash
+        def user_context
+          {}
+        end
+
+        # @return [String] Debug representation
+        def inspect
+          "#<AuthorizationFailure reason=#{failure_reason.inspect} method=#{auth_method}>"
+        end
+      end
+    end
+  end
+end

--- a/lib/otto/security/authentication/route_auth_wrapper.rb
+++ b/lib/otto/security/authentication/route_auth_wrapper.rb
@@ -106,11 +106,18 @@ class Otto
                                         duration, total_start_time, failed_strategies)
             end
 
-            # Handle authentication failure - continue to next strategy
-            next unless result.is_a?(AuthFailure)
+            # Handle a failure (authentication OR authorization) - record it and
+            # continue to the next strategy (OR logic; a later success still wins).
+            # AuthorizationFailure (valid credential, denied) is tagged so the
+            # final response is 403 instead of 401. See handle_all_strategies_failed.
+            next unless result.is_a?(AuthFailure) || result.is_a?(AuthorizationFailure)
 
             log_strategy_failure(env, strategy_name, result, duration, auth_requirements, requirement)
-            failed_strategies << { strategy: strategy_name, reason: result.failure_reason }
+            failed_strategies << {
+              strategy: strategy_name,
+              reason: result.failure_reason,
+              authorization: result.is_a?(AuthorizationFailure),
+            }
           end
 
           # All strategies failed
@@ -155,6 +162,14 @@ class Otto
             metadata: metadata,
             strategy_name: failure_strategy_name
           )
+
+          # Authorization denial wins over authentication failure: if any strategy
+          # authenticated the subject but denied authorization (wrong role/missing
+          # permission), respond 403 Forbidden rather than 401 — the subject IS
+          # authenticated, they simply lack access. A bare 401 would (incorrectly)
+          # tell a logged-in client to re-authenticate.
+          authz_denial = failed_strategies.find { |f| f[:authorization] }
+          return @response_builder.forbidden(env, authz_denial[:reason]) if authz_denial
 
           last_failure = if failed_strategies.any?
                            AuthFailure.new(

--- a/lib/otto/version.rb
+++ b/lib/otto/version.rb
@@ -3,5 +3,5 @@
 # frozen_string_literal: true
 
 class Otto
-  VERSION = '2.1.1'
+  VERSION = '2.2.0'
 end

--- a/spec/otto/security/route_auth_wrapper_spec.rb
+++ b/spec/otto/security/route_auth_wrapper_spec.rb
@@ -1231,4 +1231,141 @@ RSpec.describe Otto::Security::Authentication::RouteAuthWrapper do
       end
     end
   end
+
+  describe 'strategy-level authorization failure (AuthorizationFailure -> 403)' do
+    # A strategy that performs BOTH authentication and authorization in one pass
+    # (e.g. a token strategy enforcing a permission encoded in the requirement)
+    # cannot use Otto's Layer-1 role check (which only models the `role=` token).
+    # Returning AuthorizationFailure lets it signal 403 directly, distinct from the
+    # 401 it returns for a missing/invalid credential.
+    let(:combined_strategy) do
+      Class.new(Otto::Security::Authentication::AuthStrategy) do
+        # Credential is the header value; "valid:<role>" authenticates as <role>.
+        def authenticate(env, requirement)
+          cred = env['HTTP_X_TOKEN'].to_s
+          return failure('Missing token') if cred.empty?
+
+          md = /\Avalid:(.+)\z/.match(cred)
+          return failure('Invalid token') unless md
+
+          role = md[1]
+          _kind, required = requirement.to_s.split(':', 2)
+          return authorization_failure("Requires role: #{required}") unless role == required
+
+          success(user: { id: 'u1', roles: [role] }, auth_method: 'token')
+        end
+      end.new
+    end
+
+    let(:combined_config) do
+      { auth_strategies: { 'role' => combined_strategy }, login_path: '/signin' }
+    end
+
+    let(:json_route) do
+      Otto::RouteDefinition.new('GET', '/api/admin', 'AdminApi#index auth=role:admin response=json')
+    end
+
+    let(:json_wrapper) do
+      described_class.new(mock_handler, json_route, combined_config)
+    end
+
+    it 'returns 200 when the credential authorizes' do
+      env = mock_rack_env(headers: { 'X-Token' => 'valid:admin', 'Accept' => 'application/json' })
+      status, _headers, body = json_wrapper.call(env)
+
+      expect(status).to eq(200)
+      expect(body).to eq(['handler called'])
+    end
+
+    it 'returns 401 (AuthFailure) for a missing credential, not 403' do
+      env = mock_rack_env(headers: { 'Accept' => 'application/json' })
+      status, headers, body = json_wrapper.call(env)
+
+      expect(status).to eq(401)
+      expect(headers['content-type']).to eq('application/json')
+      expect(JSON.parse(body.first)['error']).to eq('Authentication Required')
+    end
+
+    it 'returns 401 (AuthFailure) for an invalid credential, not 403' do
+      env = mock_rack_env(headers: { 'X-Token' => 'garbage', 'Accept' => 'application/json' })
+      status, _headers, _body = json_wrapper.call(env)
+
+      expect(status).to eq(401)
+    end
+
+    it 'returns 403 (AuthorizationFailure) for a valid credential lacking the role' do
+      env = mock_rack_env(headers: { 'X-Token' => 'valid:user', 'Accept' => 'application/json' })
+      status, headers, body = json_wrapper.call(env)
+
+      expect(status).to eq(403)
+      expect(headers['content-type']).to eq('application/json')
+      data = JSON.parse(body.first)
+      expect(data['error']).to eq('Forbidden')
+      expect(data['message']).to include('admin')
+    end
+
+    it 'returns text/plain 403 for a non-JSON route on authorization denial' do
+      plain_route = Otto::RouteDefinition.new('GET', '/admin', 'AdminApi#index auth=role:admin')
+      plain_wrapper = described_class.new(mock_handler, plain_route, combined_config)
+
+      env = mock_rack_env(headers: { 'X-Token' => 'valid:user', 'Accept' => 'text/html' })
+      status, headers, body = plain_wrapper.call(env)
+
+      # Authorization denial is 403 regardless of content type (NOT a 302 to login —
+      # the subject is authenticated). Authentication failure still 302s (below).
+      expect(status).to eq(403)
+      expect(headers['content-type']).to eq('text/plain')
+      expect(body.first).to include('admin')
+    end
+
+    it 'still 302-redirects a non-JSON route on AUTHENTICATION failure' do
+      plain_route = Otto::RouteDefinition.new('GET', '/admin', 'AdminApi#index auth=role:admin')
+      plain_wrapper = described_class.new(mock_handler, plain_route, combined_config)
+
+      env = mock_rack_env(headers: { 'Accept' => 'text/html' })
+      status, headers, _body = plain_wrapper.call(env)
+
+      expect(status).to eq(302)
+      expect(headers['location']).to eq('/signin')
+    end
+
+    context 'multi-strategy OR semantics' do
+      let(:authn_only) do
+        Class.new(Otto::Security::Authentication::AuthStrategy) do
+          def authenticate(env, _requirement)
+            env['HTTP_X_BACKUP'] == 'ok' ? success(user: { id: 'b', roles: ['admin'] }, auth_method: 'backup') : failure('no backup')
+          end
+        end.new
+      end
+
+      let(:multi_config) do
+        { auth_strategies: { 'role' => combined_strategy, 'backup' => authn_only }, login_path: '/signin' }
+      end
+
+      let(:multi_route) do
+        Otto::RouteDefinition.new('GET', '/api/admin', 'AdminApi#index auth=role:admin,backup response=json')
+      end
+
+      let(:multi_wrapper) { described_class.new(mock_handler, multi_route, multi_config) }
+
+      it 'a later strategy success still wins over an earlier authorization denial' do
+        env = mock_rack_env(headers: { 'X-Token' => 'valid:user', 'X-Backup' => 'ok', 'Accept' => 'application/json' })
+        status, = multi_wrapper.call(env)
+        expect(status).to eq(200)
+      end
+
+      it 'authorization denial wins over a plain authentication failure when all fail' do
+        env = mock_rack_env(headers: { 'X-Token' => 'valid:user', 'Accept' => 'application/json' })
+        status, _headers, body = multi_wrapper.call(env)
+        expect(status).to eq(403)
+        expect(JSON.parse(body.first)['error']).to eq('Forbidden')
+      end
+
+      it 'returns 401 when every strategy is a pure authentication failure' do
+        env = mock_rack_env(headers: { 'Accept' => 'application/json' })
+        status, = multi_wrapper.call(env)
+        expect(status).to eq(401)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds `AuthorizationFailure` as a distinct result type for auth strategies, enabling strategies to signal 403 Forbidden separately from 401 Unauthorized. Previously, a strategy performing combined authentication and authorization could only return `AuthFailure`, causing `RouteAuthWrapper` to collapse authorization denials to 401.

Strategies now call `authorization_failure(reason)` when a valid credential lacks a required permission. `RouteAuthWrapper` maps this to a 403 response, letting clients distinguish "authenticate again" from "you lack this permission."

Also extracts `#strategy_auth_method` to handle anonymous strategy classes (nil `#name`) common in tests, and adds spec coverage for the new 403 path.

Resolves #FAILURE-403