### PR TITLE
Harmonize IP/trusted_proxy resolution (otto side of onetimesecret#3436)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    otto (2.2.0)
+    otto (2.3.0)
       concurrent-ruby (~> 1.3, < 2.0)
       logger (~> 1, < 2.0)
       loofah (~> 2.20)

--- a/changelog.d/20260615_065919_claude_issue-58.rst
+++ b/changelog.d/20260615_065919_claude_issue-58.rst
@@ -30,6 +30,9 @@ Changed
 - IP validation and port-stripping were consolidated into
   ``Otto::Utils.normalize_ip`` / ``strip_ip_port`` (previously duplicated in
   ``IPPrivacyMiddleware`` and ``Otto::Request``).
+- Trusted-proxy string entries are now parsed to ``IPAddr`` once at
+  registration (in ``add_trusted_proxy``) and cached, so ``trusted_proxy?``
+  no longer re-parses each entry on every request.
 
 Security
 --------

--- a/changelog.d/20260615_065919_claude_issue-58.rst
+++ b/changelog.d/20260615_065919_claude_issue-58.rst
@@ -1,0 +1,31 @@
+Changed
+-------
+
+- ``Otto::Security::Config#trusted_proxy?`` now matches string entries with
+  proper ``IPAddr`` CIDR containment for both IPv4 and IPv6, replacing the
+  previous ``==`` / ``start_with?`` text matching. Bare hosts (e.g.
+  ``192.168.1.1``) match only exactly, and CIDR ranges (e.g. ``10.0.0.0/8``)
+  now actually match contained addresses. Non-IP entries (e.g. ``172.16.``)
+  still fall back to the legacy prefix match, and ``Regexp`` entries are
+  unchanged. This is a behavior change: addresses that were previously
+  matched only because they shared a textual prefix are no longer treated as
+  trusted. (otto#58, onetimesecret#3436)
+- ``IPPrivacyMiddleware`` now resolves the client IP once into a canonical
+  ``env['otto.client_ip']`` ("resolve once, read everywhere") and is
+  idempotent: a second pass (e.g. when the middleware is mounted both at the
+  app and router levels) yields instead of re-resolving and double-masking.
+- ``Otto::Request#ip`` and ``#client_ipaddress`` now prefer
+  ``env['otto.client_ip']`` when present, falling back to Rack's native
+  resolution when the middleware has not run. Downstream code no longer
+  depends on ``REMOTE_ADDR`` / ``X-Forwarded-For`` rewriting being
+  load-bearing.
+
+Fixed
+-----
+
+- IPv6 addresses are no longer truncated during proxy resolution.
+  ``validate_ip_address`` previously did ``ip.split(':').first``, collapsing
+  an IPv6 address to its first hextet; it now uses ``IPAddr`` validation with
+  IPv6-safe port stripping (bracketed ``[2001:db8::1]:443`` and IPv4
+  ``host:port``). IPv6 clients behind trusted proxies now resolve and mask
+  correctly. (onetimesecret#3436)

--- a/changelog.d/20260615_065919_claude_issue-58.rst
+++ b/changelog.d/20260615_065919_claude_issue-58.rst
@@ -19,6 +19,27 @@ Changed
   resolution when the middleware has not run. Downstream code no longer
   depends on ``REMOTE_ADDR`` / ``X-Forwarded-For`` rewriting being
   load-bearing.
+- ``Otto::Request#secure?`` now authorizes ``X-Forwarded-Proto`` /
+  ``X-Scheme`` from a canonical, leak-free ``env['otto.via_trusted_proxy']``
+  flag recorded by ``IPPrivacyMiddleware`` before masking, instead of
+  re-deriving trust from the (now masked) ``REMOTE_ADDR``. It falls back to
+  the previous behavior when the middleware has not run.
+- ``add_trusted_proxy`` now logs a warning when given a string that is not a
+  valid IP or CIDR (e.g. ``'172.16.'``), since such entries use legacy
+  string-prefix matching; prefer a CIDR range.
+- IP validation and port-stripping were consolidated into
+  ``Otto::Utils.normalize_ip`` / ``strip_ip_port`` (previously duplicated in
+  ``IPPrivacyMiddleware`` and ``Otto::Request``).
+
+Security
+--------
+
+- Trusted-proxy matching is now correct CIDR containment rather than text
+  prefix matching, removing both false positives (e.g. ``192.168.1.100``
+  matching the host ``192.168.1.1``) and false negatives (CIDR ranges that
+  never matched). ``secure?`` no longer silently fails to trust
+  ``X-Forwarded-Proto`` behind a TLS-terminating trusted proxy when IP
+  privacy is enabled. (onetimesecret#3436)
 
 Fixed
 -----
@@ -29,3 +50,8 @@ Fixed
   IPv6-safe port stripping (bracketed ``[2001:db8::1]:443`` and IPv4
   ``host:port``). IPv6 clients behind trusted proxies now resolve and mask
   correctly. (onetimesecret#3436)
+- ``Otto::Request#redacted_fingerprint``, ``#geo_country``, ``#hashed_ip``
+  and ``#masked_ip`` (plus ``NoAuthStrategy`` metadata and
+  ``LoggingHelpers`` country) read the canonical ``otto.privacy.*`` env keys
+  the middleware actually writes; they previously read un-namespaced keys
+  that were never set and so always returned ``nil``.

--- a/docs/migrating/v2.3.0.md
+++ b/docs/migrating/v2.3.0.md
@@ -1,0 +1,86 @@
+# Otto v2.3.0 Migration Guide
+
+## Overview
+
+This release harmonizes IP address and trusted-proxy resolution (the upstream
+work for [onetimesecret#3436](https://github.com/onetimesecret/onetimesecret/issues/3436)).
+The client IP is now resolved **once** into a canonical `env['otto.client_ip']`
+that downstream code reads, trusted-proxy matching uses real CIDR containment,
+and several privacy helpers that silently returned `nil` now work. Most apps
+need no changes; the one behavior change to review is trusted-proxy matching.
+
+## Breaking / behavior changes
+
+### 1. Trusted-proxy matching is now real CIDR containment
+
+`Otto::Security::Config#trusted_proxy?` previously compared entries with
+`==` / `String#start_with?`. It now parses entries with `IPAddr` and matches
+by containment for both IPv4 and IPv6.
+
+What changes in practice:
+
+```ruby
+config.add_trusted_proxy('10.0.0.0/8')
+config.trusted_proxy?('10.1.2.3')      # was false (CIDR never matched), now true
+
+config.add_trusted_proxy('192.168.1.1')
+config.trusted_proxy?('192.168.1.100') # was true (textual prefix), now false
+```
+
+- **CIDR ranges now actually work.** Previously `add_trusted_proxy('10.0.0.0/8')`
+  was effectively a no-op because no real IP literally starts with the string
+  `'10.0.0.0/8'`. If you relied on a single-IP entry acting as a prefix to
+  cover a range, replace it with an explicit CIDR.
+- **Bare hosts match only themselves.** `192.168.1.1` no longer matches
+  `192.168.1.100`, `192.168.1.10`, etc.
+- **Non-IP strings still work via the legacy path.** An entry like `'172.16.'`
+  that does not parse as an IP/CIDR falls back to the old prefix match, and
+  `add_trusted_proxy` now logs a warning suggesting a CIDR (`172.16.0.0/12`).
+- **`Regexp` entries are unchanged.**
+
+**Action:** audit your `trusted_proxies` configuration. Convert any single-IP
+or bare-prefix entries that were meant to cover a range into proper CIDR
+notation.
+
+### 2. `secure?` trusts forwarded proto via a canonical flag
+
+`Otto::Request#secure?` previously decided whether to honor `X-Forwarded-Proto`
+/ `X-Scheme` by checking `trusted_proxy?(REMOTE_ADDR)`. With IP privacy enabled,
+`IPPrivacyMiddleware` rewrites `REMOTE_ADDR` to the masked client IP, so that
+check could no longer see the connecting proxy and `secure?` could wrongly
+return `false` behind a TLS-terminating trusted proxy.
+
+The middleware now records the peer-trust decision once (before masking) in a
+leak-free boolean `env['otto.via_trusted_proxy']`, and `secure?` reads it.
+When the middleware has not run (standalone request use), `secure?` falls back
+to its previous behavior. No app changes are required.
+
+### 3. Privacy helpers now return values (previously `nil`)
+
+These helpers read the un-namespaced env keys that the middleware never set,
+so they always returned `nil`. They now read the canonical `otto.privacy.*`
+keys and return real values when IP privacy is enabled:
+
+- `Otto::Request#redacted_fingerprint`
+- `Otto::Request#geo_country`
+- `Otto::Request#hashed_ip`
+- `Otto::Request#masked_ip`
+
+If you worked around these returning `nil`, you can now use them directly.
+
+## New / canonical env keys
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `otto.client_ip` | String | Canonical client IP, resolved once. Masked when privacy is enabled; resolved real IP when disabled or exempt. Read by `Request#ip` / `#client_ipaddress`. |
+| `otto.via_trusted_proxy` | Boolean | Whether the request arrived via a trusted proxy, decided before masking. Read by `Request#secure?`. |
+
+The privacy data keys remain `otto.privacy.{fingerprint,masked_ip,hashed_ip,geo_country}`.
+
+## No action required for
+
+- Apps that pass `trusted_proxies` as CIDR ranges or `Regexp`.
+- Apps that read `req.ip` / `req.client_ipaddress` (now backed by the canonical
+  value, same masked result).
+- Apps relying on IPv6 — IPv6 client resolution behind trusted proxies is now
+  correct (it was previously truncated to the first hextet).

--- a/lib/otto/env_keys.rb
+++ b/lib/otto/env_keys.rb
@@ -103,6 +103,16 @@ class Otto
     # PRIVACY (IP MASKING)
     # =========================================================================
 
+    # Canonical client IP, resolved once early by IPPrivacyMiddleware
+    # ("resolve once, read everywhere"). Downstream code (client_ipaddress,
+    # Request#ip) reads this instead of re-deriving from REMOTE_ADDR / XFF.
+    # Type: String
+    # Set by: IPPrivacyMiddleware (every request, all modes)
+    # Value: masked IP when privacy enabled; resolved real IP when privacy
+    #        disabled or the address is exempt (private/localhost)
+    # Note: presence also acts as the idempotency guard for the middleware
+    CLIENT_IP = 'otto.client_ip'
+
     # Privacy-safe masked IP address
     # Type: String (e.g., '192.168.1.0')
     # Set by: IPPrivacyMiddleware

--- a/lib/otto/env_keys.rb
+++ b/lib/otto/env_keys.rb
@@ -61,6 +61,14 @@ class Otto
     # Used by: All security middleware (CSRF, Headers, Validation)
     SECURITY_CONFIG = 'otto.security_config'
 
+    # Whether the request arrived via a trusted proxy.
+    # Type: Boolean
+    # Set by: IPPrivacyMiddleware (every request, evaluated on the original
+    #   peer BEFORE REMOTE_ADDR is masked)
+    # Used by: Otto::Request#secure? to authorize X-Forwarded-Proto / X-Scheme
+    #   without depending on the (masked) REMOTE_ADDR
+    VIA_TRUSTED_PROXY = 'otto.via_trusted_proxy'
+
     # =========================================================================
     # LOCALIZATION (I18N)
     # =========================================================================

--- a/lib/otto/logging_helpers.rb
+++ b/lib/otto/logging_helpers.rb
@@ -77,7 +77,7 @@ class Otto
             method: env['REQUEST_METHOD'],
               path: env['PATH_INFO'],
                 ip: env['REMOTE_ADDR'], # Already masked by IPPrivacyMiddleware for public IPs
-           country: env['otto.geo_country'],
+           country: env['otto.privacy.geo_country'],
         user_agent: env['HTTP_USER_AGENT']&.slice(0, 100), # Already anonymized by IPPrivacyMiddleware
       }.compact
     end

--- a/lib/otto/request.rb
+++ b/lib/otto/request.rb
@@ -63,7 +63,7 @@ class Otto
     #   fingerprint.masked_ip    # => '192.168.1.0'
     #   fingerprint.country      # => 'US'
     def redacted_fingerprint
-      env['otto.redacted_fingerprint']
+      env['otto.privacy.fingerprint']
     end
 
     # Get the geo-location country code for the request
@@ -75,7 +75,7 @@ class Otto
     # @example
     #   req.geo_country  # => 'US'
     def geo_country
-      redacted_fingerprint&.country || env['otto.geo_country']
+      redacted_fingerprint&.country || env['otto.privacy.geo_country']
     end
 
     # Get anonymized user agent string
@@ -103,7 +103,7 @@ class Otto
     # @example
     #   req.masked_ip  # => '192.168.1.0'
     def masked_ip
-      env['otto.masked_ip'] || env['REMOTE_ADDR']
+      env['otto.privacy.masked_ip'] || env['REMOTE_ADDR']
     end
 
     # Get hashed IP for session correlation
@@ -116,7 +116,7 @@ class Otto
     # @example
     #   req.hashed_ip  # => 'a3f8b2c4d5e6f7...'
     def hashed_ip
-      redacted_fingerprint&.hashed_ip || env['otto.hashed_ip']
+      redacted_fingerprint&.hashed_ip || env['otto.privacy.hashed_ip']
     end
 
     def client_ipaddress

--- a/lib/otto/request.rb
+++ b/lib/otto/request.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require 'rack/request'
+require 'ipaddr'
 
 class Otto
   # Otto's enhanced Rack::Request class with built-in helpers
@@ -24,13 +25,25 @@ class Otto
       env['HTTP_USER_AGENT']
     end
 
-    # NOTE: We do NOT override Rack::Request#ip
+    # Canonical client IP for the request.
     #
-    # IPPrivacyMiddleware masks both REMOTE_ADDR and X-Forwarded-For headers,
-    # so Rack's native ip resolution logic works correctly with masked values.
-    # This allows Rack to handle proxy scenarios (trusted proxies, header parsing)
-    # while still returning privacy-safe masked IPs.
+    # Prefers env['otto.client_ip'] — the value resolved once, early, by
+    # IPPrivacyMiddleware ("resolve once, read everywhere"): the masked IP
+    # when privacy is enabled, or the resolved real IP when privacy is
+    # disabled or the address is exempt. This means downstream code no longer
+    # depends on REMOTE_ADDR / X-Forwarded-For rewriting being load-bearing.
     #
+    # Falls back to Rack's native resolution when the middleware has not run
+    # (e.g. standalone request use without the Otto middleware stack).
+    #
+    # @return [String, nil] Canonical (privacy-applied) client IP
+    def ip
+      canonical = env['otto.client_ip']
+      return canonical if canonical && !canonical.empty?
+
+      super
+    end
+
     # If you need the masked IP explicitly, use:
     #   req.masked_ip  # => '192.168.1.0' or nil if privacy disabled
     #
@@ -108,6 +121,12 @@ class Otto
     end
 
     def client_ipaddress
+      # Prefer the canonical client IP resolved once by IPPrivacyMiddleware
+      # ("resolve once, read everywhere"). Falls back to deriving it directly
+      # for standalone use without the middleware.
+      canonical = env['otto.client_ip']
+      return canonical if canonical && !canonical.empty?
+
       remote_addr = env['REMOTE_ADDR']
 
       # If we don't have a security config or trusted proxies, use direct connection
@@ -229,17 +248,33 @@ class Otto
     def validate_ip_address(ip)
       return nil if ip.nil? || ip.empty?
 
-      # Remove any port number
-      clean_ip = ip.split(':').first
+      candidate = strip_port(ip.strip)
+      return nil if candidate.nil? || candidate.empty?
 
-      # Basic IP format validation
-      return nil unless clean_ip.match?(/\A\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\z/)
+      # IPAddr validates both IPv4 and IPv6; raises for malformed input
+      IPAddr.new(candidate)
+      candidate
+    rescue IPAddr::InvalidAddressError
+      nil
+    end
 
-      # Validate each octet
-      octets = clean_ip.split('.')
-      return nil unless octets.all? { |octet| (0..255).cover?(octet.to_i) }
+    # Strip an optional port without corrupting IPv6 addresses.
+    #
+    # Handles bracketed IPv6 with a port (`[2001:db8::1]:443`) and IPv4
+    # host:port (`203.0.113.5:443`). A bare IPv6 address (multiple colons,
+    # no brackets) is returned unchanged.
+    #
+    # @param ip [String] candidate address, possibly including a port
+    # @return [String] address with any port removed
+    def strip_port(ip)
+      if ip.start_with?('[')
+        inner = ip[/\A\[([^\]]+)\]/, 1]
+        return inner if inner
+      end
 
-      clean_ip
+      return ip.split(':', 2).first if ip.count(':') == 1
+
+      ip
     end
 
     def private_ip?(ip)

--- a/lib/otto/request.rb
+++ b/lib/otto/request.rb
@@ -3,7 +3,6 @@
 # frozen_string_literal: true
 
 require 'rack/request'
-require 'ipaddr'
 
 class Otto
   # Otto's enhanced Rack::Request class with built-in helpers
@@ -246,35 +245,7 @@ class Otto
     end
 
     def validate_ip_address(ip)
-      return nil if ip.nil? || ip.empty?
-
-      candidate = strip_port(ip.strip)
-      return nil if candidate.nil? || candidate.empty?
-
-      # IPAddr validates both IPv4 and IPv6; raises for malformed input
-      IPAddr.new(candidate)
-      candidate
-    rescue IPAddr::InvalidAddressError
-      nil
-    end
-
-    # Strip an optional port without corrupting IPv6 addresses.
-    #
-    # Handles bracketed IPv6 with a port (`[2001:db8::1]:443`) and IPv4
-    # host:port (`203.0.113.5:443`). A bare IPv6 address (multiple colons,
-    # no brackets) is returned unchanged.
-    #
-    # @param ip [String] candidate address, possibly including a port
-    # @return [String] address with any port removed
-    def strip_port(ip)
-      if ip.start_with?('[')
-        inner = ip[/\A\[([^\]]+)\]/, 1]
-        return inner if inner
-      end
-
-      return ip.split(':', 2).first if ip.count(':') == 1
-
-      ip
+      Otto::Utils.normalize_ip(ip)
     end
 
     def private_ip?(ip)

--- a/lib/otto/request.rb
+++ b/lib/otto/request.rb
@@ -198,16 +198,27 @@ class Otto
       # Check direct HTTPS connection
       return true if env['HTTPS'] == 'on' || env['SERVER_PORT'] == '443'
 
-      remote_addr = env['REMOTE_ADDR']
+      # Only trust forwarded proto headers when the request actually arrived via
+      # a trusted proxy.
+      return false unless forwarded_by_trusted_proxy?
 
-      # Only trust forwarded proto headers from trusted proxies
-      if otto_security_config && trusted_proxy?(remote_addr)
-        # X-Scheme is set by nginx
-        # X-FORWARDED-PROTO is set by elastic load balancer
-        return env['HTTP_X_FORWARDED_PROTO'] == 'https' || env['HTTP_X_SCHEME'] == 'https'
-      end
+      # X-Scheme is set by nginx; X-Forwarded-Proto by elastic load balancer
+      env['HTTP_X_FORWARDED_PROTO'] == 'https' || env['HTTP_X_SCHEME'] == 'https'
+    end
 
-      false
+    # Whether the request arrived through a trusted proxy.
+    #
+    # Prefers the canonical decision recorded once by IPPrivacyMiddleware in
+    # env['otto.via_trusted_proxy'] — evaluated against the original peer before
+    # REMOTE_ADDR is masked, so it stays correct even after masking. Falls back
+    # to evaluating the current REMOTE_ADDR when the middleware has not run
+    # (standalone request use).
+    #
+    # @return [Boolean]
+    def forwarded_by_trusted_proxy?
+      return env['otto.via_trusted_proxy'] if env.key?('otto.via_trusted_proxy')
+
+      otto_security_config ? trusted_proxy?(env['REMOTE_ADDR']) : false
     end
 
     # See: http://stackoverflow.com/questions/10013812/how-to-prevent-jquery-ajax-from-following-a-redirect-after-a-post

--- a/lib/otto/security/authentication/strategies/noauth_strategy.rb
+++ b/lib/otto/security/authentication/strategies/noauth_strategy.rb
@@ -14,7 +14,7 @@ class Otto
           def authenticate(env, _requirement)
             # Note: env['REMOTE_ADDR'] is masked by IPPrivacyMiddleware by default
             metadata = { ip: env['REMOTE_ADDR'] }
-            metadata[:country] = env['otto.geo_country'] if env['otto.geo_country']
+            metadata[:country] = env['otto.privacy.geo_country'] if env['otto.privacy.geo_country']
 
             Otto::Security::Authentication::StrategyResult.anonymous(metadata: metadata)
           end

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -4,6 +4,7 @@
 
 require 'securerandom'
 require 'digest'
+require 'ipaddr'
 require_relative '../core/freezable'
 
 class Otto
@@ -123,17 +124,25 @@ class Otto
 
       # Check if an IP address is from a trusted proxy
       #
+      # String entries that parse as an IP or CIDR range are matched with
+      # proper IPAddr containment (IPv4 and IPv6). Entries that are not valid
+      # IPs (e.g. a bare prefix like '172.16.') fall back to the legacy
+      # exact/prefix string match for backward compatibility. Regexp entries
+      # are matched against the raw IP string.
+      #
       # @param ip [String] IP address to check
       # @return [Boolean] true if the IP is from a trusted proxy
       def trusted_proxy?(ip)
-        return false if @trusted_proxies.empty?
+        return false if @trusted_proxies.empty? || ip.nil? || ip.empty?
+
+        client = parse_ipaddr(ip)
 
         @trusted_proxies.any? do |proxy|
           case proxy
-          when String
-            ip == proxy || ip.start_with?(proxy)
           when Regexp
             proxy.match?(ip)
+          when String
+            string_proxy_match?(proxy, ip, client)
           else
             false
           end
@@ -322,6 +331,48 @@ class Otto
       end
 
       private
+
+      # Parse a value into an IPAddr, returning nil for invalid / non-IP input.
+      #
+      # @param value [String] candidate IP or CIDR string
+      # @return [IPAddr, nil]
+      def parse_ipaddr(value)
+        IPAddr.new(value)
+      rescue IPAddr::InvalidAddressError, IPAddr::AddressFamilyError
+        nil
+      end
+
+      # Match a single string proxy entry against a client IP.
+      #
+      # Valid IP/CIDR entries use proper IPAddr containment (IPv4 + IPv6).
+      # Non-IP entries (e.g. '172.16.') or an unparseable client fall back to
+      # the legacy exact/prefix string match for backward compatibility.
+      #
+      # @param proxy [String] trusted proxy entry
+      # @param ip [String] raw client IP string
+      # @param client [IPAddr, nil] parsed client IP (nil if it didn't parse)
+      # @return [Boolean]
+      def string_proxy_match?(proxy, ip, client)
+        range = parse_ipaddr(proxy)
+        if range && client
+          ip_in_range?(range, client)
+        else
+          ip == proxy || ip.start_with?(proxy)
+        end
+      end
+
+      # CIDR/host containment that is safe across address families.
+      #
+      # @param range [IPAddr] trusted proxy range or host
+      # @param client [IPAddr] client address
+      # @return [Boolean]
+      def ip_in_range?(range, client)
+        return false unless range.family == client.family
+
+        range.include?(client)
+      rescue IPAddr::InvalidAddressError
+        false
+      end
 
       def extract_existing_session_id(request)
         # Try session first

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -114,8 +114,10 @@ class Otto
 
         case proxy
         when String, Regexp
+          warn_if_legacy_proxy_entry(proxy)
           @trusted_proxies << proxy
         when Array
+          proxy.each { |entry| warn_if_legacy_proxy_entry(entry) }
           @trusted_proxies.concat(proxy)
         else
           raise ArgumentError, 'Proxy must be a String, Regexp, or Array'
@@ -340,6 +342,23 @@ class Otto
         IPAddr.new(value)
       rescue IPAddr::InvalidAddressError, IPAddr::AddressFamilyError
         nil
+      end
+
+      # Warn when a string proxy entry is not a valid IP/CIDR and will fall
+      # back to legacy string-prefix matching. Regexp entries are intentional
+      # and not flagged.
+      #
+      # @param entry [String, Regexp] trusted proxy entry being added
+      # @return [void]
+      def warn_if_legacy_proxy_entry(entry)
+        return unless entry.is_a?(String)
+        return if parse_ipaddr(entry) # valid IP/CIDR -> proper matching
+
+        Otto.logger&.warn(
+          "[Otto::Security::Config] trusted proxy #{entry.inspect} is not a " \
+          'valid IP or CIDR; using legacy string-prefix matching. Prefer a ' \
+          "CIDR range (e.g. '172.16.0.0/12')."
+        )
       end
 
       # Match a single string proxy entry against a client IP.

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -48,6 +48,7 @@ class Otto
         @max_param_depth        = 32
         @max_param_keys         = 64
         @trusted_proxies        = []
+        @trusted_proxy_matchers = []
         @require_secure_cookies = false
         @security_headers       = default_security_headers
         @input_validation       = true
@@ -114,10 +115,10 @@ class Otto
 
         case proxy
         when String, Regexp
-          warn_if_legacy_proxy_entry(proxy)
           @trusted_proxies << proxy
+          @trusted_proxy_matchers << register_proxy_matcher(proxy)
         when Array
-          proxy.each { |entry| warn_if_legacy_proxy_entry(entry) }
+          proxy.each { |entry| @trusted_proxy_matchers << register_proxy_matcher(entry) }
           @trusted_proxies.concat(proxy)
         else
           raise ArgumentError, 'Proxy must be a String, Regexp, or Array'
@@ -132,19 +133,25 @@ class Otto
       # exact/prefix string match for backward compatibility. Regexp entries
       # are matched against the raw IP string.
       #
+      # Proxy entries are parsed once at registration (see #add_trusted_proxy)
+      # into @trusted_proxy_matchers, so this never re-parses per request.
+      #
       # @param ip [String] IP address to check
       # @return [Boolean] true if the IP is from a trusted proxy
       def trusted_proxy?(ip)
-        return false if @trusted_proxies.empty? || ip.nil? || ip.empty?
+        return false if @trusted_proxy_matchers.empty? || ip.nil? || ip.empty?
 
         client = parse_ipaddr(ip)
 
-        @trusted_proxies.any? do |proxy|
-          case proxy
-          when Regexp
-            proxy.match?(ip)
-          when String
-            string_proxy_match?(proxy, ip, client)
+        @trusted_proxy_matchers.any? do |entry, range|
+          if range
+            # Pre-parsed IP/CIDR entry -> proper containment
+            client && ip_in_range?(range, client)
+          elsif entry.is_a?(Regexp)
+            entry.match?(ip)
+          elsif entry.is_a?(String)
+            # Legacy non-IP entry (e.g. '172.16.') -> exact/prefix match
+            ip == entry || ip.start_with?(entry)
           else
             false
           end
@@ -344,40 +351,34 @@ class Otto
         nil
       end
 
-      # Warn when a string proxy entry is not a valid IP/CIDR and will fall
-      # back to legacy string-prefix matching. Regexp entries are intentional
-      # and not flagged.
+      # Build a cached matcher tuple for a proxy entry at registration time.
       #
-      # @param entry [String, Regexp] trusted proxy entry being added
-      # @return [void]
-      def warn_if_legacy_proxy_entry(entry)
-        return unless entry.is_a?(String)
-        return if parse_ipaddr(entry) # valid IP/CIDR -> proper matching
+      # String entries are parsed to an IPAddr exactly once here; the result is
+      # reused for both the legacy-entry warning and per-request matching, so
+      # trusted_proxy? never re-parses. Non-IP strings and Regexp/other entries
+      # store a nil range and fall back to prefix/regexp matching.
+      #
+      # @param entry [String, Regexp, Object] trusted proxy entry being added
+      # @return [Array(Object, IPAddr)] [raw_entry, parsed_range_or_nil]
+      def register_proxy_matcher(entry)
+        return [entry, nil] unless entry.is_a?(String)
 
+        range = parse_ipaddr(entry)
+        warn_legacy_proxy_entry(entry) unless range
+        [entry, range]
+      end
+
+      # Warn that a string proxy entry is not a valid IP/CIDR and will use
+      # legacy string-prefix matching.
+      #
+      # @param entry [String] trusted proxy entry
+      # @return [void]
+      def warn_legacy_proxy_entry(entry)
         Otto.logger&.warn(
           "[Otto::Security::Config] trusted proxy #{entry.inspect} is not a " \
           'valid IP or CIDR; using legacy string-prefix matching. Prefer a ' \
           "CIDR range (e.g. '172.16.0.0/12')."
         )
-      end
-
-      # Match a single string proxy entry against a client IP.
-      #
-      # Valid IP/CIDR entries use proper IPAddr containment (IPv4 + IPv6).
-      # Non-IP entries (e.g. '172.16.') or an unparseable client fall back to
-      # the legacy exact/prefix string match for backward compatibility.
-      #
-      # @param proxy [String] trusted proxy entry
-      # @param ip [String] raw client IP string
-      # @param client [IPAddr, nil] parsed client IP (nil if it didn't parse)
-      # @return [Boolean]
-      def string_proxy_match?(proxy, ip, client)
-        range = parse_ipaddr(proxy)
-        if range && client
-          ip_in_range?(range, client)
-        else
-          ip == proxy || ip.start_with?(proxy)
-        end
       end
 
       # CIDR/host containment that is safe across address families.

--- a/lib/otto/security/middleware/ip_privacy_middleware.rb
+++ b/lib/otto/security/middleware/ip_privacy_middleware.rb
@@ -15,7 +15,7 @@ class Otto
       #
       # @example Default behavior (privacy enabled)
       #   # env['REMOTE_ADDR'] is masked to 192.168.1.0
-      #   # env['otto.redacted_fingerprint'] contains full anonymized data
+      #   # env['otto.privacy.fingerprint'] contains full anonymized data
       #   # env['otto.original_ip'] is NOT set
       #
       # @example Privacy disabled

--- a/lib/otto/security/middleware/ip_privacy_middleware.rb
+++ b/lib/otto/security/middleware/ip_privacy_middleware.rb
@@ -2,8 +2,6 @@
 #
 # frozen_string_literal: true
 
-require 'ipaddr'
-
 class Otto
   module Security
     module Middleware
@@ -202,35 +200,7 @@ class Otto
         # @param ip [String, nil] IP address to validate (optionally with a port)
         # @return [String, nil] Cleaned IP or nil if invalid
         def validate_ip_address(ip)
-          return nil if ip.nil? || ip.empty?
-
-          candidate = strip_port(ip.strip)
-          return nil if candidate.nil? || candidate.empty?
-
-          # IPAddr validates both IPv4 and IPv6; raises for malformed input
-          IPAddr.new(candidate)
-          candidate
-        rescue IPAddr::InvalidAddressError
-          nil
-        end
-
-        # Strip an optional port without corrupting IPv6 addresses.
-        #
-        # Handles bracketed IPv6 with a port (`[2001:db8::1]:443`) and IPv4
-        # host:port (`203.0.113.5:443`). A bare IPv6 address (multiple colons,
-        # no brackets) is returned unchanged.
-        #
-        # @param ip [String] candidate address, possibly including a port
-        # @return [String] address with any port removed
-        def strip_port(ip)
-          if ip.start_with?('[')
-            inner = ip[/\A\[([^\]]+)\]/, 1]
-            return inner if inner
-          end
-
-          return ip.split(':', 2).first if ip.count(':') == 1
-
-          ip
+          Otto::Utils.normalize_ip(ip)
         end
 
         # Apply no-privacy settings (privacy explicitly disabled)

--- a/lib/otto/security/middleware/ip_privacy_middleware.rb
+++ b/lib/otto/security/middleware/ip_privacy_middleware.rb
@@ -48,6 +48,11 @@ class Otto
           # Otto's built-in router mount) order-safe instead of double-masking.
           return @app.call(env) if env.key?('otto.client_ip')
 
+          # Record the connecting peer's trust decision BEFORE any masking, so
+          # secure? can authorize X-Forwarded-Proto canonically even after
+          # REMOTE_ADDR is rewritten to the masked client IP. Leak-free boolean.
+          env['otto.via_trusted_proxy'] = trusted_proxy?(env['REMOTE_ADDR'])
+
           if @privacy_enabled
             apply_privacy(env)
           else

--- a/lib/otto/security/middleware/ip_privacy_middleware.rb
+++ b/lib/otto/security/middleware/ip_privacy_middleware.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require 'ipaddr'
+
 class Otto
   module Security
     module Middleware
@@ -42,6 +44,12 @@ class Otto
         # @param env [Hash] Rack environment
         # @return [Array] Rack response tuple [status, headers, body]
         def call(env)
+          # Idempotency: if a prior IPPrivacyMiddleware pass already resolved the
+          # canonical client IP for this request, do not re-resolve or re-mask.
+          # This makes stacking two instances (e.g. an app-level mount plus
+          # Otto's built-in router mount) order-safe instead of double-masking.
+          return @app.call(env) if env.key?('otto.client_ip')
+
           if @privacy_enabled
             apply_privacy(env)
           else
@@ -63,7 +71,8 @@ class Otto
         #
         # @param env [Hash] Rack environment
         def apply_privacy(env)
-          # Resolve the actual client IP (handling proxies)
+          # Resolve the actual client IP once (handling proxies). This is the
+          # canonical resolution step; masking below operates on this value.
           client_ip = resolve_client_ip(env)
 
           Otto.logger.debug "[IPPrivacyMiddleware] Resolved client IP: #{client_ip}" if Otto.debug
@@ -75,6 +84,8 @@ class Otto
               # Update REMOTE_ADDR to the resolved client IP (even though it's not masked)
               env['REMOTE_ADDR'] = client_ip
               env['otto.original_ip'] = client_ip
+              # Canonical client IP downstream reads (exempt: not masked)
+              env['otto.client_ip'] = client_ip
               # Don't mask forwarded headers for private IPs
               Otto.logger.debug "[IPPrivacyMiddleware] Private/localhost IP exempted: #{client_ip}" if Otto.debug
               return
@@ -98,6 +109,10 @@ class Otto
           # This ensures downstream code (rate limiting, auth, logging, Rack's request.ip)
           # automatically uses the masked values without modification
           env['REMOTE_ADDR'] = fingerprint.masked_ip
+
+          # Canonical client IP downstream reads ("resolve once, read everywhere").
+          # Privacy-safe: holds the masked value, never the original public IP.
+          env['otto.client_ip'] = fingerprint.masked_ip
 
           # Replace User-Agent with anonymized version (consistent with IP masking)
           # CRITICAL: Always replace, even if nil, to clear original sensitive data
@@ -182,24 +197,40 @@ class Otto
           @security_config.trusted_proxy?(ip)
         end
 
-        # Validate and clean IP address
+        # Validate and clean IP address (IPv4 and IPv6)
         #
-        # @param ip [String, nil] IP address to validate
+        # @param ip [String, nil] IP address to validate (optionally with a port)
         # @return [String, nil] Cleaned IP or nil if invalid
         def validate_ip_address(ip)
           return nil if ip.nil? || ip.empty?
 
-          # Remove any port number
-          clean_ip = ip.split(':').first
+          candidate = strip_port(ip.strip)
+          return nil if candidate.nil? || candidate.empty?
 
-          # Basic IPv4 format validation
-          return nil unless clean_ip.match?(/\A\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\z/)
+          # IPAddr validates both IPv4 and IPv6; raises for malformed input
+          IPAddr.new(candidate)
+          candidate
+        rescue IPAddr::InvalidAddressError
+          nil
+        end
 
-          # Validate each octet
-          octets = clean_ip.split('.')
-          return nil unless octets.all? { |octet| (0..255).cover?(octet.to_i) }
+        # Strip an optional port without corrupting IPv6 addresses.
+        #
+        # Handles bracketed IPv6 with a port (`[2001:db8::1]:443`) and IPv4
+        # host:port (`203.0.113.5:443`). A bare IPv6 address (multiple colons,
+        # no brackets) is returned unchanged.
+        #
+        # @param ip [String] candidate address, possibly including a port
+        # @return [String] address with any port removed
+        def strip_port(ip)
+          if ip.start_with?('[')
+            inner = ip[/\A\[([^\]]+)\]/, 1]
+            return inner if inner
+          end
 
-          clean_ip
+          return ip.split(':', 2).first if ip.count(':') == 1
+
+          ip
         end
 
         # Apply no-privacy settings (privacy explicitly disabled)
@@ -209,6 +240,11 @@ class Otto
         #
         # @param env [Hash] Rack environment
         def apply_no_privacy(env)
+          # Resolve the canonical client IP once, even with privacy disabled, so
+          # downstream code can read env['otto.client_ip'] instead of re-deriving
+          # it from REMOTE_ADDR / forwarded headers.
+          env['otto.client_ip'] = resolve_client_ip(env)
+
           # Store original values for explicit access when privacy is disabled
           if env['REMOTE_ADDR']
             env['otto.original_ip'] = env['REMOTE_ADDR'].dup.force_encoding('UTF-8')

--- a/lib/otto/utils.rb
+++ b/lib/otto/utils.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require 'ipaddr'
+
 class Otto
   # Utility methods for common operations and helpers
   module Utils
@@ -34,6 +36,45 @@ class Otto
     # yes?('1')     # => true
     def yes?(value)
       !value.to_s.empty? && %w[true yes 1].include?(value.to_s.downcase)
+    end
+
+    # Validate and normalize an IP address (IPv4 and IPv6).
+    #
+    # Strips an optional port (IPv6-safe), validates with IPAddr, and returns
+    # the cleaned address string, or nil if the input is blank or malformed.
+    #
+    # @param ip [String, nil] candidate address, optionally with a port
+    # @return [String, nil] cleaned IP string, or nil if invalid
+    def normalize_ip(ip)
+      return nil if ip.nil? || ip.empty?
+
+      candidate = strip_ip_port(ip.strip)
+      return nil if candidate.nil? || candidate.empty?
+
+      # IPAddr validates both IPv4 and IPv6; raises for malformed input
+      IPAddr.new(candidate)
+      candidate
+    rescue IPAddr::InvalidAddressError
+      nil
+    end
+
+    # Strip an optional port without corrupting IPv6 addresses.
+    #
+    # Handles bracketed IPv6 with a port (`[2001:db8::1]:443`) and IPv4
+    # host:port (`203.0.113.5:443`). A bare IPv6 address (multiple colons,
+    # no brackets) is returned unchanged.
+    #
+    # @param ip [String] candidate address, possibly including a port
+    # @return [String] address with any port removed
+    def strip_ip_port(ip)
+      if ip.start_with?('[')
+        inner = ip[/\A\[([^\]]+)\]/, 1]
+        return inner if inner
+      end
+
+      return ip.split(':', 2).first if ip.count(':') == 1
+
+      ip
     end
   end
 end

--- a/lib/otto/utils.rb
+++ b/lib/otto/utils.rb
@@ -54,7 +54,7 @@ class Otto
       # IPAddr validates both IPv4 and IPv6; raises for malformed input
       IPAddr.new(candidate)
       candidate
-    rescue IPAddr::InvalidAddressError
+    rescue IPAddr::InvalidAddressError, IPAddr::AddressFamilyError
       nil
     end
 

--- a/lib/otto/version.rb
+++ b/lib/otto/version.rb
@@ -3,5 +3,5 @@
 # frozen_string_literal: true
 
 class Otto
-  VERSION = '2.2.0'
+  VERSION = '2.3.0'
 end

--- a/spec/README.md
+++ b/spec/README.md
@@ -20,7 +20,8 @@ Comprehensive tests for `Otto::Security::Config` covering:
 Key findings:
 - Otto follows security-by-default principles
 - CSRF tokens use cryptographically secure generation with session binding
-- Trusted proxy matching uses simple string prefix matching, not proper CIDR
+- Trusted proxy matching uses proper IPAddr CIDR containment (IPv4 + IPv6),
+  falling back to string prefix matching only for non-IP entries (e.g. '172.16.')
 - All security features must be explicitly enabled
 
 ### 🔄 Otto Main Class (`otto_spec.rb`)

--- a/spec/otto/ip_harmonization_spec.rb
+++ b/spec/otto/ip_harmonization_spec.rb
@@ -241,6 +241,27 @@ RSpec.describe 'IP resolution harmonization (otto#58 / OTS#3436)' do
       end
     end
 
+    describe 'privacy helpers read the canonical otto.privacy.* keys' do
+      # Regression: these helpers previously read un-namespaced keys
+      # (otto.redacted_fingerprint / otto.geo_country / otto.hashed_ip) that the
+      # middleware never sets, so they always returned nil.
+      def run_privacy(remote_addr)
+        env = { 'REMOTE_ADDR' => remote_addr }
+        Otto::Security::Middleware::IPPrivacyMiddleware
+          .new(app, Otto::Security::Config.new).call(env)
+        described_class.new(env)
+      end
+
+      it 'populates redacted_fingerprint, masked_ip, hashed_ip and geo_country' do
+        req = run_privacy('8.8.8.8') # public IP; geo range -> US
+
+        expect(req.redacted_fingerprint).to be_a(Otto::Privacy::RedactedFingerprint)
+        expect(req.masked_ip).to eq('8.8.8.0')
+        expect(req.hashed_ip).to match(/\A[0-9a-f]{64}\z/)
+        expect(req.geo_country).to eq('US')
+      end
+    end
+
     describe '#validate_ip_address (IPv6-safe)' do
       let(:req) { request_for }
 

--- a/spec/otto/ip_harmonization_spec.rb
+++ b/spec/otto/ip_harmonization_spec.rb
@@ -1,0 +1,208 @@
+# spec/otto/ip_harmonization_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Coverage for the IP/trusted-proxy resolution harmonization described in
+# OTS issue onetimesecret#3436 (upstream dependency on otto#58):
+#   1. Proper IPAddr CIDR matching in Security::Config#trusted_proxy?
+#   2. Resolve-once canonical env['otto.client_ip'] (resolve/mask split)
+#   3. IPPrivacyMiddleware idempotency (order-safe when mounted twice)
+#   4. IPv6-safe validate_ip_address (no more split(':') truncation)
+RSpec.describe 'IP resolution harmonization (otto#58 / OTS#3436)' do
+  let(:app) { ->(_env) { [200, {}, ['OK']] } }
+
+  describe Otto::Security::Config, '#trusted_proxy? CIDR matching' do
+    let(:config) { described_class.new }
+
+    it 'matches IPv4 addresses inside a CIDR range' do
+      config.add_trusted_proxy('10.0.0.0/8')
+
+      expect(config.trusted_proxy?('10.1.2.3')).to be true
+      expect(config.trusted_proxy?('10.255.255.254')).to be true
+      expect(config.trusted_proxy?('11.0.0.1')).to be false
+    end
+
+    it 'matches a bare host only exactly (no textual-prefix false positives)' do
+      config.add_trusted_proxy('203.0.113.7')
+
+      expect(config.trusted_proxy?('203.0.113.7')).to be true
+      expect(config.trusted_proxy?('203.0.113.70')).to be false
+    end
+
+    it 'matches IPv6 addresses inside a CIDR range' do
+      config.add_trusted_proxy('2001:db8::/32')
+
+      expect(config.trusted_proxy?('2001:db8:abcd::1')).to be true
+      expect(config.trusted_proxy?('2001:dead::1')).to be false
+    end
+
+    it 'does not match across address families' do
+      config.add_trusted_proxy('10.0.0.0/8')
+
+      expect(config.trusted_proxy?('::1')).to be false
+    end
+
+    it 'returns false for malformed / blank query values instead of raising' do
+      config.add_trusted_proxy('10.0.0.0/8')
+
+      expect(config.trusted_proxy?('not-an-ip')).to be false
+      expect(config.trusted_proxy?('')).to be false
+      expect(config.trusted_proxy?(nil)).to be false
+    end
+
+    it 'still supports Regexp and non-IP prefix entries' do
+      config.add_trusted_proxy(/\A192\.168\./)
+      config.add_trusted_proxy('172.16.')
+
+      expect(config.trusted_proxy?('192.168.5.5')).to be true
+      expect(config.trusted_proxy?('172.16.9.9')).to be true
+      expect(config.trusted_proxy?('10.0.0.1')).to be false
+    end
+  end
+
+  describe Otto::Security::Middleware::IPPrivacyMiddleware do
+    let(:security_config) { Otto::Security::Config.new }
+    let(:middleware) { described_class.new(app, security_config) }
+
+    describe "canonical env['otto.client_ip']" do
+      it 'is the masked IP for a public direct connection' do
+        env = { 'REMOTE_ADDR' => '203.0.113.50' }
+        middleware.call(env)
+
+        expect(env['otto.client_ip']).to eq('203.0.113.0')
+        expect(env['otto.client_ip']).to eq(env['REMOTE_ADDR'])
+      end
+
+      it 'is the real (unmasked) IP for an exempt private connection' do
+        env = { 'REMOTE_ADDR' => '192.168.1.100' }
+        middleware.call(env)
+
+        expect(env['otto.client_ip']).to eq('192.168.1.100')
+      end
+
+      it 'is the resolved real IP when privacy is disabled' do
+        security_config.ip_privacy_config.disable!
+        env = { 'REMOTE_ADDR' => '203.0.113.50' }
+        described_class.new(app, security_config).call(env)
+
+        expect(env['otto.client_ip']).to eq('203.0.113.50')
+      end
+
+      it 'resolves the client (not the proxy) behind a trusted proxy' do
+        security_config.add_trusted_proxy('10.0.0.1')
+        env = {
+          'REMOTE_ADDR' => '10.0.0.1',
+          'HTTP_X_FORWARDED_FOR' => '203.0.113.50',
+        }
+        middleware.call(env)
+
+        expect(env['otto.client_ip']).to eq('203.0.113.0')
+      end
+    end
+
+    describe 'idempotency' do
+      it 'a second pass with a different config does not re-resolve or re-mask' do
+        env = { 'REMOTE_ADDR' => '203.0.113.50' }
+
+        # First pass: mask 1 octet -> 203.0.113.0
+        described_class.new(app, security_config).call(env)
+        expect(env['otto.client_ip']).to eq('203.0.113.0')
+
+        # A 2-octet config would yield 203.0.0.0 if it ran; the idempotency
+        # guard must prevent the second pass from touching anything.
+        cfg2 = Otto::Security::Config.new
+        cfg2.ip_privacy_config.octet_precision = 2
+        described_class.new(app, cfg2).call(env)
+
+        expect(env['otto.client_ip']).to eq('203.0.113.0')
+        expect(env['REMOTE_ADDR']).to eq('203.0.113.0')
+      end
+
+      it 'is order-safe when two instances are stacked' do
+        security_config.add_trusted_proxy('10.0.0.1')
+        inner = described_class.new(app, security_config)
+        outer = described_class.new(inner, security_config)
+
+        env = {
+          'REMOTE_ADDR' => '10.0.0.1',
+          'HTTP_X_FORWARDED_FOR' => '203.0.113.50',
+        }
+        outer.call(env)
+
+        expect(env['otto.client_ip']).to eq('203.0.113.0')
+        expect(env['REMOTE_ADDR']).to eq('203.0.113.0')
+        expect(env['HTTP_X_FORWARDED_FOR']).to eq('203.0.113.0')
+      end
+    end
+
+    describe 'IPv6 proxy resolution' do
+      before { security_config.add_trusted_proxy('2001:db8::/32') }
+
+      it 'resolves and masks an IPv6 client behind a trusted IPv6 proxy' do
+        env = {
+          'REMOTE_ADDR' => '2001:db8::1',                  # trusted proxy
+          'HTTP_X_FORWARDED_FOR' => '2606:4700:4700::1111', # real client
+        }
+        middleware.call(env)
+
+        # Last 80 bits zeroed (octet_precision 1); surfaced canonically.
+        expect(env['otto.client_ip']).to eq('2606:4700:4700::')
+        expect(env['REMOTE_ADDR']).to eq('2606:4700:4700::')
+      end
+    end
+  end
+
+  describe Otto::Request, 'canonical reads' do
+    def request_for(env_overrides = {})
+      env = Rack::MockRequest.env_for('/', env_overrides)
+      described_class.new(env)
+    end
+
+    it '#ip prefers env[otto.client_ip] when present' do
+      req = request_for('REMOTE_ADDR' => '198.51.100.9')
+      req.env['otto.client_ip'] = '203.0.113.0'
+
+      expect(req.ip).to eq('203.0.113.0')
+    end
+
+    it '#ip falls back to Rack resolution without the middleware' do
+      req = request_for('REMOTE_ADDR' => '198.51.100.9')
+
+      expect(req.ip).to eq('198.51.100.9')
+    end
+
+    it '#client_ipaddress prefers env[otto.client_ip] when present' do
+      req = request_for('REMOTE_ADDR' => '198.51.100.9')
+      req.env['otto.client_ip'] = '203.0.113.0'
+
+      expect(req.client_ipaddress).to eq('203.0.113.0')
+    end
+
+    describe '#validate_ip_address (IPv6-safe)' do
+      let(:req) { request_for }
+
+      it 'accepts a bare IPv6 address without truncating it' do
+        expect(req.send(:validate_ip_address, '2001:db8::1')).to eq('2001:db8::1')
+      end
+
+      it 'strips a port from a bracketed IPv6 address' do
+        expect(req.send(:validate_ip_address, '[2001:db8::1]:443')).to eq('2001:db8::1')
+      end
+
+      it 'strips a port from an IPv4 host:port' do
+        expect(req.send(:validate_ip_address, '203.0.113.5:8080')).to eq('203.0.113.5')
+      end
+
+      it 'accepts a bare IPv4 address' do
+        expect(req.send(:validate_ip_address, '203.0.113.5')).to eq('203.0.113.5')
+      end
+
+      it 'rejects malformed input' do
+        expect(req.send(:validate_ip_address, 'nope')).to be_nil
+        expect(req.send(:validate_ip_address, '')).to be_nil
+      end
+    end
+  end
+end

--- a/spec/otto/ip_harmonization_spec.rb
+++ b/spec/otto/ip_harmonization_spec.rb
@@ -152,6 +152,26 @@ RSpec.describe 'IP resolution harmonization (otto#58 / OTS#3436)' do
         expect(env['REMOTE_ADDR']).to eq('2606:4700:4700::')
       end
     end
+
+    describe "canonical env['otto.via_trusted_proxy']" do
+      before { security_config.add_trusted_proxy('10.0.0.1') }
+
+      it 'is true when the original peer is a trusted proxy (recorded pre-mask)' do
+        env = { 'REMOTE_ADDR' => '10.0.0.1', 'HTTP_X_FORWARDED_FOR' => '203.0.113.50' }
+        middleware.call(env)
+
+        expect(env['otto.via_trusted_proxy']).to be true
+        # REMOTE_ADDR was masked to the client, but the trust flag is preserved
+        expect(env['REMOTE_ADDR']).to eq('203.0.113.0')
+      end
+
+      it 'is false when the connecting peer is not a trusted proxy' do
+        env = { 'REMOTE_ADDR' => '198.51.100.1' }
+        middleware.call(env)
+
+        expect(env['otto.via_trusted_proxy']).to be false
+      end
+    end
   end
 
   describe Otto::Request, 'canonical reads' do
@@ -178,6 +198,47 @@ RSpec.describe 'IP resolution harmonization (otto#58 / OTS#3436)' do
       req.env['otto.client_ip'] = '203.0.113.0'
 
       expect(req.client_ipaddress).to eq('203.0.113.0')
+    end
+
+    describe '#secure?' do
+      it 'is true for a direct HTTPS connection' do
+        expect(request_for('SERVER_PORT' => '443').secure?).to be true
+        expect(request_for('HTTPS' => 'on').secure?).to be true
+      end
+
+      it 'trusts X-Forwarded-Proto when the canonical trust flag is set' do
+        req = request_for('REMOTE_ADDR' => '203.0.113.0', 'HTTP_X_FORWARDED_PROTO' => 'https')
+        req.env['otto.via_trusted_proxy'] = true
+
+        expect(req.secure?).to be true
+      end
+
+      it 'trusts X-Scheme when the canonical trust flag is set' do
+        req = request_for('REMOTE_ADDR' => '203.0.113.0', 'HTTP_X_SCHEME' => 'https')
+        req.env['otto.via_trusted_proxy'] = true
+
+        expect(req.secure?).to be true
+      end
+
+      it 'does not trust forwarded proto when the peer is untrusted' do
+        req = request_for('REMOTE_ADDR' => '203.0.113.0', 'HTTP_X_FORWARDED_PROTO' => 'https')
+        req.env['otto.via_trusted_proxy'] = false
+
+        expect(req.secure?).to be false
+      end
+
+      it 'is not secure when forwarded proto is absent even via a trusted proxy' do
+        req = request_for('REMOTE_ADDR' => '203.0.113.0')
+        req.env['otto.via_trusted_proxy'] = true
+
+        expect(req.secure?).to be false
+      end
+
+      it 'does not trust forwarded proto without the middleware or a security config' do
+        req = request_for('REMOTE_ADDR' => '10.0.0.1', 'HTTP_X_FORWARDED_PROTO' => 'https')
+
+        expect(req.secure?).to be false
+      end
     end
 
     describe '#validate_ip_address (IPv6-safe)' do

--- a/spec/otto/ip_harmonization_spec.rb
+++ b/spec/otto/ip_harmonization_spec.rb
@@ -60,6 +60,25 @@ RSpec.describe 'IP resolution harmonization (otto#58 / OTS#3436)' do
       expect(config.trusted_proxy?('172.16.9.9')).to be true
       expect(config.trusted_proxy?('10.0.0.1')).to be false
     end
+
+    it 'parses each string proxy entry once at registration, not per request' do
+      allow(IPAddr).to receive(:new).and_call_original
+
+      config.add_trusted_proxy('10.0.0.0/8')
+      3.times { config.trusted_proxy?('10.1.2.3') }
+
+      # The proxy entry is parsed once (at registration); only the per-request
+      # client IP is parsed on each call.
+      expect(IPAddr).to have_received(:new).with('10.0.0.0/8').once
+    end
+
+    it 'still matches correctly after the config is deep-frozen' do
+      config.add_trusted_proxy('10.0.0.0/8')
+      config.deep_freeze!
+
+      expect(config.trusted_proxy?('10.1.2.3')).to be true
+      expect(config.trusted_proxy?('11.0.0.1')).to be false
+    end
   end
 
   describe Otto::Security::Middleware::IPPrivacyMiddleware do

--- a/spec/otto/logging_integration_spec.rb
+++ b/spec/otto/logging_integration_spec.rb
@@ -416,7 +416,7 @@ RSpec.describe 'Otto Logging Integration' do
         'PATH_INFO' => '/test',
         'REMOTE_ADDR' => '192.168.1.0',  # Already masked
         'HTTP_USER_AGENT' => 'Mozilla/*.* (Macintosh; Intel Mac OS X *.*) Chrome/*.*',  # Already anonymized
-        'otto.geo_country' => 'US'
+        'otto.privacy.geo_country' => 'US'
       }
 
       context = Otto::LoggingHelpers.request_context(env)
@@ -465,7 +465,7 @@ RSpec.describe 'Otto Logging Integration' do
         'REMOTE_ADDR' => '9.9.9.0',
         'HTTP_USER_AGENT' => 'Mozilla/*.*',  # Already anonymized by middleware
         'otto.privacy.fingerprint' => fingerprint,
-        'otto.geo_country' => 'CH'
+        'otto.privacy.geo_country' => 'CH'
       }
 
       context = Otto::LoggingHelpers.request_context(env)

--- a/spec/otto/utils_spec.rb
+++ b/spec/otto/utils_spec.rb
@@ -103,4 +103,50 @@ RSpec.describe Otto::Utils do
       expect(Otto::Utils.yes?(false)).to be false
     end
   end
+
+  describe "#normalize_ip" do
+    it "accepts a bare IPv4 address" do
+      expect(Otto::Utils.normalize_ip("203.0.113.5")).to eq("203.0.113.5")
+    end
+
+    it "accepts a bare IPv6 address without truncating it" do
+      expect(Otto::Utils.normalize_ip("2001:db8::1")).to eq("2001:db8::1")
+    end
+
+    it "strips a port from an IPv4 host:port" do
+      expect(Otto::Utils.normalize_ip("203.0.113.5:8080")).to eq("203.0.113.5")
+    end
+
+    it "strips a port from a bracketed IPv6 address" do
+      expect(Otto::Utils.normalize_ip("[2001:db8::1]:443")).to eq("2001:db8::1")
+    end
+
+    it "trims surrounding whitespace" do
+      expect(Otto::Utils.normalize_ip("  203.0.113.5  ")).to eq("203.0.113.5")
+    end
+
+    it "returns nil for malformed or blank input" do
+      expect(Otto::Utils.normalize_ip("nope")).to be_nil
+      expect(Otto::Utils.normalize_ip("")).to be_nil
+      expect(Otto::Utils.normalize_ip(nil)).to be_nil
+    end
+  end
+
+  describe "#strip_ip_port" do
+    it "removes a port from an IPv4 host:port" do
+      expect(Otto::Utils.strip_ip_port("203.0.113.5:8080")).to eq("203.0.113.5")
+    end
+
+    it "unwraps a bracketed IPv6 literal with a port" do
+      expect(Otto::Utils.strip_ip_port("[2001:db8::1]:443")).to eq("2001:db8::1")
+    end
+
+    it "leaves a bare IPv6 address unchanged" do
+      expect(Otto::Utils.strip_ip_port("2001:db8::1")).to eq("2001:db8::1")
+    end
+
+    it "leaves a bare IPv4 address unchanged" do
+      expect(Otto::Utils.strip_ip_port("203.0.113.5")).to eq("203.0.113.5")
+    end
+  end
 end

--- a/spec/security_config_spec.rb
+++ b/spec/security_config_spec.rb
@@ -204,19 +204,37 @@ RSpec.describe Otto::Security::Config do
         expect(config.trusted_proxy?('192.168.1.2')).to be false
       end
 
-      it 'identifies CIDR range matches using string prefix matching' do
-        # The implementation uses simple string prefix matching, not proper CIDR
-        # '10.0.0.1'.start_with?('10.0.0.0/8') is false since it doesn't literally start with that string
-        expect(config.trusted_proxy?('10.0.0.0/8')).to be true # Exact match with CIDR
-        expect(config.trusted_proxy?('10.0.0.0/8123')).to be true # Starts with CIDR string
-        expect(config.trusted_proxy?('10.0.0.1')).to be false # Different IP that doesn't start with proxy string
+      it 'identifies CIDR range matches using proper IPAddr containment' do
+        # Real CIDR matching: any address inside 10.0.0.0/8 is trusted,
+        # addresses outside it are not.
+        expect(config.trusted_proxy?('10.0.0.1')).to be true
+        expect(config.trusted_proxy?('10.255.255.254')).to be true
         expect(config.trusted_proxy?('11.0.0.1')).to be false
       end
 
-      it 'handles string matching for network ranges' do
+      it 'does not treat unrelated IPs sharing a textual prefix as trusted' do
+        # Regression guard against the old start_with? matcher:
+        # '192.168.1.10' must NOT match the exact host '192.168.1.1'.
+        expect(config.trusted_proxy?('192.168.1.1')).to be true
+        expect(config.trusted_proxy?('192.168.1.10')).to be false
+        expect(config.trusted_proxy?('192.168.1.100')).to be false
+      end
+
+      it 'falls back to string prefix matching for non-IP entries' do
         config.add_trusted_proxy('172.16.')
         expect(config.trusted_proxy?('172.16.1.1')).to be true
         expect(config.trusted_proxy?('172.17.1.1')).to be false
+      end
+
+      it 'matches IPv6 addresses within a CIDR range' do
+        config.add_trusted_proxy('2001:db8::/32')
+        expect(config.trusted_proxy?('2001:db8::1')).to be true
+        expect(config.trusted_proxy?('2001:db9::1')).to be false
+      end
+
+      it 'does not match across address families' do
+        config.add_trusted_proxy('10.0.0.0/8')
+        expect(config.trusted_proxy?('::1')).to be false
       end
     end
   end


### PR DESCRIPTION
## Summary

Implements the four upstream changes that **onetimesecret#3436** depends on. The `IPPrivacy` class and masking levels (#58) already shipped in v2.2.0; this adds the IP/`trusted_proxy` *harmonization* layer that was still missing.

Handoff/tracking context: #144.

### The 4 blockers (all implemented + tested)

1. **Real CIDR matcher in `Security::Config#trusted_proxy?`** — replaces `ip == proxy || ip.start_with?(proxy)` with `IPAddr` containment (IPv4 + IPv6). Bare hosts match exactly; CIDR ranges (`10.0.0.0/8`) now actually match contained addresses; non-IP entries (e.g. `172.16.`) keep the legacy prefix fallback; `Regexp` entries unchanged.

2. **Resolve once, read everywhere → canonical `env['otto.client_ip']`** — `IPPrivacyMiddleware` resolves the client IP once: masked when privacy is enabled, resolved real IP when disabled/exempt. `Otto::Request#ip` and `#client_ipaddress` read it, so `REMOTE_ADDR`/`X-Forwarded-For` rewriting is no longer load-bearing downstream.

3. **Middleware idempotency** — a second pass yields when `env['otto.client_ip']` is already set, making double-mounting (app + router, the #3436 "two passes in series" case) order-safe instead of double-masking.

4. **IPv6 fix in `validate_ip_address`** — was `ip.split(':').first` (collapsed IPv6 to its first hextet); now `IPAddr` validation with IPv6-safe port stripping (bracketed `[2001:db8::1]:443` and IPv4 `host:port`), in both the middleware and `Otto::Request`.

## ⚠️ Behavior change (intentional)

Addresses previously "trusted" only because they shared a **textual prefix** with a single-IP entry are no longer trusted (e.g. `192.168.1.123` no longer matches proxy `192.168.1.1`). Use real CIDR ranges, which now work correctly. The one existing test asserting the old prefix behavior was updated; `spec/README.md`'s "string prefix matching, not proper CIDR" note was corrected.

## Files

```
lib/otto/security/config.rb                           # CIDR matcher + parse_ipaddr/string_proxy_match?/ip_in_range?
lib/otto/security/middleware/ip_privacy_middleware.rb # idempotency, canonical client_ip, IPv6 validate
lib/otto/request.rb                                   # #ip override, client_ipaddress canonical, IPv6 validate
lib/otto/env_keys.rb                                  # document otto.client_ip
spec/otto/ip_harmonization_spec.rb                    # NEW — 21 examples
spec/security_config_spec.rb                          # update old prefix-behavior test
spec/README.md                                        # correct the CIDR note
changelog.d/20260615_065919_claude_issue-58.rst       # scriv fragment
```

## Testing

Full suite green: **1142 examples, 0 failures** (1121 baseline + 21 new in `spec/otto/ip_harmonization_spec.rb`, covering CIDR/IPv6 matching, idempotency, canonical reads, and IPv6-safe validation).

## Not in this PR (tracked in #144)

- `Otto::Request#secure?` still reads `REMOTE_ADDR` for proxy trust (lost after masking); making it canonical needs a peer-trust signal and was left out to keep scope to the 4 blockers.
- Pre-existing `otto.privacy.*` vs `otto.*` env-key mismatch causing `req.redacted_fingerprint`/`geo_country`/`hashed_ip` to return nil.
- IPv6-aware `private_ip?`.

Relates to #58. Downstream consumer: onetimesecret#3436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017oayfuFAeEqvbGJ1FZnSrL

---
_Generated by [Claude Code](https://claude.ai/code/session_017oayfuFAeEqvbGJ1FZnSrL)_