### PR TITLE
Security hardening: CSRF token signing, constant resolver, constant-time auth

### DIFF
--- a/changelog.d/20260621_073201_claude_security-review-147.rst
+++ b/changelog.d/20260621_073201_claude_security-review-147.rst
@@ -58,14 +58,19 @@ Changed
   ``StandardError`` and are unaffected; downstream code that specifically
   rescued ``NameError`` from handler resolution should rescue ``ArgumentError``
   (or ``StandardError``) instead. (otto#147)
-- Removed the bare SQL-keyword substring blocklist
-  (``union|select|insert|update|delete|...``) from
-  ``ValidationMiddleware``'s ``SQL_INJECTION_PATTERNS``. It produced false
-  positives on legitimate input (e.g. ``"updated_at"``, ``"selection"``) while
-  remaining trivially bypassable, giving a false sense of protection. The
-  remaining best-effort signatures stay as defense-in-depth; the real protection
-  for SQL injection is parameterized queries / prepared statements at the
-  data-access layer. (otto#147)
+- Removed SQL-injection pattern matching from input validation entirely. The
+  ``ValidationMiddleware::SQL_INJECTION_PATTERNS`` constant and the matching
+  checks in ``ValidationMiddleware`` and ``ValidationHelpers#validate_input``
+  are gone. Input-validation blocklists for SQL are bypassable theater and
+  produce false positives on legitimate input (e.g. ``"updated_at"``,
+  ``"selection"``, ``"SELECT * FROM users"``); the correct defense is
+  parameterized queries / prepared statements at the data-access layer.
+  XSS/script-injection, null-byte, control-character, size, and structural
+  validations are unchanged. (otto#147)
+- ``Otto.logger`` never returns ``nil``: it lazily falls back to a default
+  ``$stdout`` logger, so call sites no longer need defensive ``&.`` guards.
+  Assign your own logger (or a null logger to silence output) via
+  ``Otto.logger=``. (otto#147)
 
 AI Assistance
 -------------

--- a/changelog.d/20260621_073201_claude_security-review-147.rst
+++ b/changelog.d/20260621_073201_claude_security-review-147.rst
@@ -1,0 +1,72 @@
+Security
+--------
+
+- CSRF tokens are now signed with **HMAC-SHA256 keyed by a server-side secret**
+  and are **bound to a per-session id**, closing a forgery hole where tokens
+  were signed with a bare ``SHA256`` digest against a static ``'no-session'``
+  base. Previously any client could self-mint an accepted token
+  (``token:SHA256("no-session:#{token}")``) and all sessionless tokens were
+  mutually valid, defeating CSRF protection for any token issued before a
+  session existed. ``Otto::Security::Config#generate_csrf_token`` now requires a
+  non-empty session binding (raises ``ArgumentError`` otherwise) and
+  ``#verify_csrf_token`` rejects blank bindings; both go through the keyed HMAC.
+  The secret is read from ``ENV['OTTO_CSRF_SECRET']`` (or the new
+  ``config.csrf_secret=`` accessor) and falls back to a random per-process
+  secret with a one-time warning — set ``OTTO_CSRF_SECRET`` so tokens stay valid
+  across workers and restarts. (otto#147)
+- Class-name resolution for every dynamic-dispatch path now flows through a
+  single validated ``Otto::Security::ConstantResolver.safe_const_get`` that
+  enforces the class-name format and a forbidden-class blocklist (``Kernel``,
+  ``Process``, ``IO``, ``File``, ``Object``, ...). Previously
+  ``RouteHandlers::BaseHandler#safe_const_get`` (used by ``ClassMethodHandler`` /
+  ``InstanceMethodHandler``) and the MCP dispatch in ``Otto::MCP::Registry`` and
+  ``Otto::MCP::Server`` resolved handler class names with bare
+  ``Object.const_get`` / ``const_get`` and no guards, bypassing the protections
+  already present in ``Otto::Route``. The shared resolver also closes a blocklist
+  gap present in the original ``Otto::Route`` check: a forbidden class reached
+  through a namespace prefix (``"Object::Kernel"``) or via Ruby's trailing-segment
+  constant inheritance (``"App::File"`` resolving to top-level ``::File``) is now
+  rejected by an identity check on the *resolved* constant, while an app's own
+  distinct class that merely shares a name is unaffected. (otto#147)
+- MCP bearer-token authentication (``Otto::MCP::Auth::TokenAuth``) and API-key
+  authentication (``Security::Authentication::Strategies::APIKeyStrategy``) now
+  compare credentials in constant time with ``Rack::Utils.secure_compare``
+  against every configured value, instead of ``Set#include?`` / ``Array#include?``
+  which short-circuit and leak timing. The "no API keys configured accepts any
+  key" semantics is preserved. (otto#147)
+
+Fixed
+-----
+
+- The CSRF meta-tag injector now matches an opening ``<head>`` tag **with
+  attributes** (e.g. ``<head class="x">``) using ``/<head(?:\s[^>]*)?>/i`` and
+  preserves the original tag when injecting, instead of only matching a bare
+  ``<head>``. The CSRF ``<meta>`` tag is no longer silently dropped on such
+  documents (``<header>`` is still not matched). (otto#147)
+
+Changed
+-------
+
+- ``RouteHandlers::BaseHandler`` now raises ``ArgumentError`` (not ``NameError``)
+  when a handler's class name is malformed, forbidden, or not found, since it
+  shares the validated resolver with ``Otto::Route``. Internal callers rescue
+  ``StandardError`` and are unaffected; downstream code that specifically
+  rescued ``NameError`` from handler resolution should rescue ``ArgumentError``
+  (or ``StandardError``) instead. (otto#147)
+- Removed the bare SQL-keyword substring blocklist
+  (``union|select|insert|update|delete|...``) from
+  ``ValidationMiddleware``'s ``SQL_INJECTION_PATTERNS``. It produced false
+  positives on legitimate input (e.g. ``"updated_at"``, ``"selection"``) while
+  remaining trivially bypassable, giving a false sense of protection. The
+  remaining best-effort signatures stay as defense-in-depth; the real protection
+  for SQL injection is parameterized queries / prepared statements at the
+  data-access layer. (otto#147)
+
+AI Assistance
+-------------
+
+- Static-analysis security findings (issue #147) triaged, fixed, and verified
+  with AI assistance: parallel implementation across the CSRF, constant
+  resolution, and constant-time-comparison work streams, followed by an
+  adversarial finding-by-finding verification pass and a codebase sweep for the
+  same anti-pattern classes.

--- a/changelog.d/20260621_073201_claude_security-review-147.rst
+++ b/changelog.d/20260621_073201_claude_security-review-147.rst
@@ -1,82 +1,43 @@
 Security
 --------
 
-- CSRF tokens are now signed with **HMAC-SHA256 keyed by a server-side secret**
-  and are **bound to a per-session id**, closing a forgery hole where tokens
-  were signed with a bare ``SHA256`` digest against a static ``'no-session'``
-  base. Previously any client could self-mint an accepted token
-  (``token:SHA256("no-session:#{token}")``) and all sessionless tokens were
-  mutually valid, defeating CSRF protection for any token issued before a
-  session existed. ``Otto::Security::Config#generate_csrf_token`` now requires a
-  non-empty session binding (raises ``ArgumentError`` otherwise) and
-  ``#verify_csrf_token`` rejects blank bindings; both go through the keyed HMAC.
-  The secret is read from ``ENV['OTTO_CSRF_SECRET']`` (or the new
-  ``config.csrf_secret=`` accessor) and falls back to a random per-process
-  secret with a one-time warning — set ``OTTO_CSRF_SECRET`` so tokens stay valid
-  across workers and restarts. In **production** (``RACK_ENV=production``)
-  enabling CSRF without a configured secret is a hard error rather than a silent
-  fallback: it raises at config finalization (``deep_freeze!``) and at token
-  generation, so a horizontally-scaled deployment fails loudly instead of
-  serving non-persistent, cross-worker-invalid tokens. Non-production
-  environments keep the zero-config generated-secret fallback. (otto#147)
-- Class-name resolution for every dynamic-dispatch path now flows through a
-  single validated ``Otto::Security::ConstantResolver.safe_const_get`` that
-  enforces the class-name format and a forbidden-class blocklist (``Kernel``,
-  ``Process``, ``IO``, ``File``, ``Object``, ...). Previously
-  ``RouteHandlers::BaseHandler#safe_const_get`` (used by ``ClassMethodHandler`` /
-  ``InstanceMethodHandler``) and the MCP dispatch in ``Otto::MCP::Registry`` and
-  ``Otto::MCP::Server`` resolved handler class names with bare
-  ``Object.const_get`` / ``const_get`` and no guards, bypassing the protections
-  already present in ``Otto::Route``. The shared resolver also closes a blocklist
-  gap present in the original ``Otto::Route`` check: a forbidden class reached
-  through a namespace prefix (``"Object::Kernel"``) or via Ruby's trailing-segment
-  constant inheritance (``"App::File"`` resolving to top-level ``::File``) is now
-  rejected by an identity check on the *resolved* constant, while an app's own
-  distinct class that merely shares a name is unaffected. (otto#147)
-- MCP bearer-token authentication (``Otto::MCP::Auth::TokenAuth``) and API-key
-  authentication (``Security::Authentication::Strategies::APIKeyStrategy``) now
-  compare credentials in constant time with ``Rack::Utils.secure_compare``
-  against every configured value, instead of ``Set#include?`` / ``Array#include?``
-  which short-circuit and leak timing. The "no API keys configured accepts any
-  key" semantics is preserved. (otto#147)
+- CSRF tokens are now signed with HMAC-SHA256 keyed by a server-side secret and
+  bound to the session id, so they can no longer be self-minted or replayed
+  across sessions. Set the secret via ``OTTO_CSRF_SECRET`` or
+  ``Otto::Security::Config#csrf_secret=``; enabling CSRF in production without
+  one now raises instead of silently using a per-process secret. (otto#147)
+- All route/handler class-name resolution goes through
+  ``Otto::Security::ConstantResolver``, extending the existing format check and
+  forbidden-class blocklist to ``RouteHandlers::BaseHandler`` and the MCP
+  registry/server (previously unguarded). Forbidden classes reached via a
+  namespace prefix or constant inheritance (e.g. ``Object::Kernel``) are now
+  rejected as well. (otto#147)
+- MCP bearer tokens and API keys are compared in constant time. (otto#147)
 
 Fixed
 -----
 
-- The CSRF meta-tag injector now matches an opening ``<head>`` tag **with
-  attributes** (e.g. ``<head class="x">``) using ``/<head(?:\s[^>]*)?>/i`` and
-  preserves the original tag when injecting, instead of only matching a bare
-  ``<head>``. The CSRF ``<meta>`` tag is no longer silently dropped on such
-  documents (``<header>`` is still not matched). (otto#147)
+- The CSRF ``<meta>`` tag is now injected into ``<head>`` tags that carry
+  attributes, not only a bare ``<head>``. (otto#147)
 
 Changed
 -------
 
-- ``RouteHandlers::BaseHandler`` now raises ``ArgumentError`` (not ``NameError``)
-  when a handler's class name is malformed, forbidden, or not found, since it
-  shares the validated resolver with ``Otto::Route``. Internal callers rescue
-  ``StandardError`` and are unaffected; downstream code that specifically
-  rescued ``NameError`` from handler resolution should rescue ``ArgumentError``
-  (or ``StandardError``) instead. (otto#147)
-- Removed SQL-injection pattern matching from input validation entirely. The
-  ``ValidationMiddleware::SQL_INJECTION_PATTERNS`` constant and the matching
-  checks in ``ValidationMiddleware`` and ``ValidationHelpers#validate_input``
-  are gone. Input-validation blocklists for SQL are bypassable theater and
-  produce false positives on legitimate input (e.g. ``"updated_at"``,
-  ``"selection"``, ``"SELECT * FROM users"``); the correct defense is
-  parameterized queries / prepared statements at the data-access layer.
-  XSS/script-injection, null-byte, control-character, size, and structural
-  validations are unchanged. (otto#147)
-- ``Otto.logger`` never returns ``nil``: it lazily falls back to a default
-  ``$stdout`` logger, so call sites no longer need defensive ``&.`` guards.
-  Assign your own logger (or a null logger to silence output) via
-  ``Otto.logger=``. (otto#147)
+- ``RouteHandlers::BaseHandler`` raises ``ArgumentError`` (was ``NameError``)
+  for an unresolvable handler class name. (otto#147)
+- ``Otto.logger`` never returns ``nil`` (lazy ``$stdout`` default); assign
+  ``Otto.logger=`` to override or silence. (otto#147)
+
+Removed
+-------
+
+- SQL-injection pattern matching from input validation
+  (``ValidationMiddleware::SQL_INJECTION_PATTERNS`` and related checks). It
+  produced false positives and was trivially bypassable; defend against SQL
+  injection with parameterized queries at the data-access layer. (otto#147)
 
 AI Assistance
 -------------
 
-- Static-analysis security findings (issue #147) triaged, fixed, and verified
-  with AI assistance: parallel implementation across the CSRF, constant
-  resolution, and constant-time-comparison work streams, followed by an
-  adversarial finding-by-finding verification pass and a codebase sweep for the
-  same anti-pattern classes.
+- Issue #147 findings triaged, fixed, and verified with AI assistance, including
+  an adversarial review that surfaced the namespace-prefix blocklist bypass.

--- a/changelog.d/20260621_073201_claude_security-review-147.rst
+++ b/changelog.d/20260621_073201_claude_security-review-147.rst
@@ -13,7 +13,12 @@ Security
   The secret is read from ``ENV['OTTO_CSRF_SECRET']`` (or the new
   ``config.csrf_secret=`` accessor) and falls back to a random per-process
   secret with a one-time warning — set ``OTTO_CSRF_SECRET`` so tokens stay valid
-  across workers and restarts. (otto#147)
+  across workers and restarts. In **production** (``RACK_ENV=production``)
+  enabling CSRF without a configured secret is a hard error rather than a silent
+  fallback: it raises at config finalization (``deep_freeze!``) and at token
+  generation, so a horizontally-scaled deployment fails loudly instead of
+  serving non-persistent, cross-worker-invalid tokens. Non-production
+  environments keep the zero-config generated-secret fallback. (otto#147)
 - Class-name resolution for every dynamic-dispatch path now flows through a
   single validated ``Otto::Security::ConstantResolver.safe_const_get`` that
   enforces the class-name format and a forbidden-class blocklist (``Kernel``,

--- a/lib/otto.rb
+++ b/lib/otto.rb
@@ -214,7 +214,15 @@ class Otto
   end
 
   class << self
-    attr_accessor :debug, :logger # rubocop:disable ThreadSafety/ClassAndModuleAttributes
+    attr_accessor :debug # rubocop:disable ThreadSafety/ClassAndModuleAttributes
+    attr_writer :logger # rubocop:disable ThreadSafety/ClassAndModuleAttributes
+
+    # Otto's logger. Never nil: falls back to a default $stdout logger so call
+    # sites can log unconditionally without defensive `&.` guards. Assign your
+    # own logger (or a null logger to silence) via `Otto.logger = ...`.
+    def logger
+      @logger ||= Logger.new($stdout, Logger::INFO)
+    end
 
     # Helper method for structured logging that works with both standard Logger and structured loggers
     def structured_log(level, message, data = {})

--- a/lib/otto/helpers/validation.rb
+++ b/lib/otto/helpers/validation.rb
@@ -38,11 +38,9 @@ class Otto
           input_str       = sanitized_input
         end
 
-        # Always check for SQL injection
-        ValidationMiddleware::SQL_INJECTION_PATTERNS.each do |pattern|
-          raise Otto::Security::ValidationError, 'Potential SQL injection detected' if input_str.match?(pattern)
-        end
-
+        # NOTE: no SQL-injection inspection here on purpose — see
+        # ValidationMiddleware. Defend against SQL injection with parameterized
+        # queries at the data-access layer, not input blocklists.
         input_str
       end
 

--- a/lib/otto/mcp/auth/token.rb
+++ b/lib/otto/mcp/auth/token.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require 'json'
+require 'rack/utils'
 
 class Otto
   module MCP
@@ -17,10 +18,20 @@ class Otto
           token = extract_token(env)
           return false unless token
 
-          @tokens.include?(token)
+          valid_token?(token)
         end
 
         private
+
+        def valid_token?(candidate)
+          # Constant-time membership: compare against every configured token without
+          # short-circuiting on the first match, so neither match position nor
+          # membership leaks via timing. Rack::Utils.secure_compare itself is
+          # constant-time for equal-length strings.
+          @tokens.reduce(false) do |matched, token|
+            Rack::Utils.secure_compare(token, candidate) || matched
+          end
+        end
 
         def extract_token(env)
           # Try Authorization header first (Bearer token)

--- a/lib/otto/mcp/registry.rb
+++ b/lib/otto/mcp/registry.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require_relative '../security/constant_resolver'
+
 class Otto
   module MCP
     # Registry for managing MCP resources and tools
@@ -82,7 +84,7 @@ class Otto
           klass_name   = klass_method[0..-2].join('::')
           method_name  = klass_method.last
 
-          klass  = Object.const_get(klass_name)
+          klass  = Otto::Security::ConstantResolver.safe_const_get(klass_name)
           result = klass.public_send(method_name, arguments, env)
         else
           raise "Invalid tool handler: #{handler}"

--- a/lib/otto/mcp/server.rb
+++ b/lib/otto/mcp/server.rb
@@ -8,6 +8,7 @@ require_relative 'route_parser'
 require_relative 'auth/token'
 require_relative 'schema_validation'
 require_relative 'rate_limiting'
+require_relative '../security/constant_resolver'
 
 class Otto
   module MCP
@@ -124,7 +125,7 @@ class Otto
 
         # Create resource handler
         handler = lambda do
-          klass = Object.const_get(klass_name)
+          klass = Otto::Security::ConstantResolver.safe_const_get(klass_name)
           method = klass.method(method_name)
           if method.arity != 0
             raise ArgumentError, "Handler #{klass_name}.#{method_name} must be a zero-arity method for resource #{uri}"

--- a/lib/otto/route.rb
+++ b/lib/otto/route.rb
@@ -53,7 +53,7 @@ class Otto
       @route_definition = Otto::RouteDefinition.new(verb, path, definition, pattern: pattern, keys: keys)
 
       # Resolve the class
-      @klass = safe_const_get(@route_definition.klass_name)
+      @klass = Otto::Security::ConstantResolver.safe_const_get(@route_definition.klass_name)
     end
 
     # Delegate common methods to route_definition for backward compatibility
@@ -171,22 +171,6 @@ class Otto
     end
 
     private
-
-    # Safely resolve a class name using Object.const_get with security validations
-    # This replaces the previous eval() usage to prevent code injection attacks.
-    #
-    # Security features:
-    # - Validates class name format (must start with capital letter)
-    # - Prevents access to dangerous system classes
-    # - Blocks relative class references (starting with ::)
-    # - Provides clear error messages for debugging
-    #
-    # @param class_name [String] The class name to resolve
-    # @return [Class] The resolved class
-    # @raise [ArgumentError] if class name is invalid, forbidden, or not found
-    def safe_const_get(class_name)
-      Otto::Security::ConstantResolver.safe_const_get(class_name)
-    end
 
     def compile(path)
       keys = []

--- a/lib/otto/route.rb
+++ b/lib/otto/route.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require_relative 'security/constant_resolver'
+
 class Otto
   # Otto::Route
   #
@@ -183,33 +185,7 @@ class Otto
     # @return [Class] The resolved class
     # @raise [ArgumentError] if class name is invalid, forbidden, or not found
     def safe_const_get(class_name)
-      # Validate class name format
-      unless class_name.match?(/\A[A-Z][a-zA-Z0-9_]*(?:::[A-Z][a-zA-Z0-9_]*)*\z/)
-        raise ArgumentError, "Invalid class name format: #{class_name}"
-      end
-
-      # Remove any leading :: then add exactly one
-      fq_class_name = "::#{class_name.sub(/^::+/, '')}"
-
-      # Prevent dangerous class names
-      forbidden_classes = %w[
-        Kernel Module Class Object BasicObject
-        File Dir IO Process System
-        Binding Proc Method UnboundMethod
-        Thread ThreadGroup Fiber
-        ObjectSpace GC
-      ]
-
-      if forbidden_classes.include?(class_name) || class_name.start_with?('::')
-        raise ArgumentError, "Forbidden class name: #{class_name}"
-      end
-
-      begin
-        # Always guarantee exactly two leading colons
-        Object.const_get(fq_class_name)
-      rescue NameError => e
-        raise ArgumentError, "Class not found: #{fq_class_name} - #{e.message}"
-      end
+      Otto::Security::ConstantResolver.safe_const_get(class_name)
     end
 
     def compile(path)

--- a/lib/otto/route_handlers/base.rb
+++ b/lib/otto/route_handlers/base.rb
@@ -5,6 +5,8 @@
 require 'json'
 require 'securerandom'
 
+require_relative '../security/constant_resolver'
+
 class Otto
   module RouteHandlers
     # Base class for all route handlers
@@ -194,11 +196,7 @@ class Otto
       # @param name [String] Class name
       # @return [Class] The class
       def safe_const_get(name)
-        name.split('::').inject(Object) do |scope, const_name|
-          scope.const_get(const_name)
-        end
-      rescue NameError => e
-        raise NameError, "Unknown class: #{name} (#{e})"
+        Otto::Security::ConstantResolver.safe_const_get(name)
       end
     end
   end

--- a/lib/otto/route_handlers/base.rb
+++ b/lib/otto/route_handlers/base.rb
@@ -45,7 +45,7 @@ class Otto
       # Get the target class, loading it safely
       # @return [Class] The target class
       def target_class
-        @target_class ||= safe_const_get(route_definition.klass_name)
+        @target_class ||= Otto::Security::ConstantResolver.safe_const_get(route_definition.klass_name)
       end
 
       # Template method for subclasses to implement their invocation logic
@@ -188,15 +188,6 @@ class Otto
                         end
 
         handler_class.handle(result, response, context)
-      end
-
-      private
-
-      # Safely get a constant from a string name
-      # @param name [String] Class name
-      # @return [Class] The class
-      def safe_const_get(name)
-        Otto::Security::ConstantResolver.safe_const_get(name)
       end
     end
   end

--- a/lib/otto/security.rb
+++ b/lib/otto/security.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require_relative 'security/core'
+require_relative 'security/constant_resolver'
 require_relative 'security/authentication/strategy_result'
 require_relative 'security/authorization_error'
 require_relative 'security/config'

--- a/lib/otto/security/authentication/strategies/api_key_strategy.rb
+++ b/lib/otto/security/authentication/strategies/api_key_strategy.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require_relative '../auth_strategy'
+require 'rack/utils'
 
 class Otto
   module Security
@@ -27,12 +28,23 @@ class Otto
 
             return failure('No API key provided') unless api_key
 
-            if @api_keys.empty? || @api_keys.include?(api_key)
+            if @api_keys.empty? || valid_api_key?(api_key)
               # Create a simple user hash for API key authentication
               user_data = { api_key: api_key }
               success(user: user_data, api_key: api_key)
             else
               failure('Invalid API key')
+            end
+          end
+
+          private
+
+          # Constant-time membership check over the configured API keys. Compares
+          # against every key without short-circuiting so match position/membership is
+          # not leaked via timing.
+          def valid_api_key?(api_key)
+            @api_keys.reduce(false) do |matched, key|
+              Rack::Utils.secure_compare(key, api_key) || matched
             end
           end
         end

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -31,21 +31,26 @@ class Otto
       # Error raised when the two mutually-exclusive trusted-proxy resolution
       # modes are configured together: CIDR-walk (enumerated #trusted_proxies)
       # and count-based depth (#trusted_proxy_depth >= 1).
-      PROXY_MODE_CONFLICT_MESSAGE = 'Cannot configure both trusted_proxies ' \
-        '(CIDR filter mode) and trusted_proxy_depth >= 1 (count mode). ' \
-        'Enumerate proxy CIDRs OR set a hop count, not both.'
+      PROXY_MODE_CONFLICT_MESSAGE = <<~MSG.gsub(/\s+/, ' ').strip.freeze
+        Cannot configure both trusted_proxies (CIDR filter mode) and
+        trusted_proxy_depth >= 1 (count mode). Enumerate proxy CIDRs OR set a
+        hop count, not both.
+      MSG
 
       # Error raised when CSRF protection is enabled in production without an
       # explicitly configured secret. A randomly-generated per-process secret
       # silently breaks token verification across workers and restarts, so we
       # refuse it in production rather than serve intermittently-failing tokens.
-      CSRF_SECRET_REQUIRED_MESSAGE = 'CSRF protection is enabled in production ' \
-        'without a configured secret. Set OTTO_CSRF_SECRET (or ' \
-        'config.csrf_secret=) to a stable random value (e.g. ' \
-        'SecureRandom.hex(32)); a per-process random secret is not valid ' \
-        'across workers or restarts.'
+      CSRF_SECRET_REQUIRED_MESSAGE = <<~MSG.gsub(/\s+/, ' ').strip.freeze
+        CSRF protection is enabled in production without a configured secret.
+        Set OTTO_CSRF_SECRET (or config.csrf_secret=) to a stable random value
+        (e.g. SecureRandom.hex(32)); a per-process random secret is not valid
+        across workers or restarts.
+      MSG
 
-      attr_accessor :input_validation, :max_param_depth, :csrf_token_key, :rate_limiting_config, :csrf_session_key, :max_request_size, :max_param_keys
+      attr_accessor :input_validation, :max_param_depth, :csrf_token_key,
+                    :rate_limiting_config, :csrf_session_key, :max_request_size,
+                    :max_param_keys
 
       attr_reader :csrf_protection,  :csrf_header_key,
                   :trusted_proxies, :require_secure_cookies,
@@ -77,13 +82,9 @@ class Otto
         @rate_limiting_config   = { custom_rules: {} }
         @ip_privacy_config      = Otto::Privacy::Config.new
 
-        @csrf_secret = ENV.fetch('OTTO_CSRF_SECRET', nil)
-        if @csrf_secret.nil? || @csrf_secret.empty?
-          @csrf_secret           = SecureRandom.hex(32)
-          @csrf_secret_generated = true
-        else
-          @csrf_secret_generated = false
-        end
+        configured_secret      = ENV.fetch('OTTO_CSRF_SECRET', nil)
+        @csrf_secret_generated = configured_secret.nil? || configured_secret.empty?
+        @csrf_secret           = @csrf_secret_generated ? SecureRandom.hex(32) : configured_secret
       end
 
       # Enable CSRF (Cross-Site Request Forgery) protection
@@ -97,7 +98,7 @@ class Otto
       # @return [void]
       # @raise [FrozenError] if configuration is frozen
       def enable_csrf_protection!
-        raise FrozenError, 'Cannot modify frozen configuration' if frozen?
+        ensure_not_frozen!
 
         @csrf_protection = true
       end
@@ -107,7 +108,7 @@ class Otto
       # @return [void]
       # @raise [FrozenError] if configuration is frozen
       def disable_csrf_protection!
-        raise FrozenError, 'Cannot modify frozen configuration' if frozen?
+        ensure_not_frozen!
 
         @csrf_protection = false
       end
@@ -139,7 +140,7 @@ class Otto
       # @example Add multiple proxies
       #   config.add_trusted_proxy(['10.0.0.1', '172.16.0.0/12'])
       def add_trusted_proxy(proxy)
-        raise FrozenError, 'Cannot modify frozen configuration' if frozen?
+        ensure_not_frozen!
         # CIDR-walk and count-based depth are mutually exclusive. Catch the
         # conflict eagerly here (and in #trusted_proxy_depth=) so it surfaces at
         # configuration time, not only at freeze (which the test harness skips).
@@ -217,7 +218,7 @@ class Otto
       # @raise [ArgumentError] if depth is non-integer/negative, or if
       #   trusted_proxies are already configured and depth >= 1
       def trusted_proxy_depth=(depth)
-        raise FrozenError, 'Cannot modify frozen configuration' if frozen?
+        ensure_not_frozen!
 
         validate_trusted_proxy_depth!(depth)
         raise ArgumentError, PROXY_MODE_CONFLICT_MESSAGE if depth.to_i >= 1 && @trusted_proxies.any?
@@ -245,7 +246,7 @@ class Otto
       # a stable value (e.g. ENV['OTTO_CSRF_SECRET']) in multi-process or
       # multi-host deployments so tokens stay valid across workers and restarts.
       def csrf_secret=(secret)
-        raise FrozenError, 'Cannot modify frozen configuration' if frozen?
+        ensure_not_frozen!
 
         @csrf_secret           = secret
         @csrf_secret_generated = false
@@ -290,7 +291,7 @@ class Otto
       # @return [void]
       # @raise [FrozenError] if configuration is frozen
       def enable_hsts!(max_age: 31_536_000, include_subdomains: true)
-        raise FrozenError, 'Cannot modify frozen configuration' if frozen?
+        ensure_not_frozen!
 
         hsts_value                                     = "max-age=#{max_age}"
         hsts_value                                    += '; includeSubDomains' if include_subdomains
@@ -309,7 +310,7 @@ class Otto
       # @example Custom policy
       #   config.enable_csp!("default-src 'self'; script-src 'self' 'unsafe-inline'")
       def enable_csp!(policy = "default-src 'self'")
-        raise FrozenError, 'Cannot modify frozen configuration' if frozen?
+        ensure_not_frozen!
 
         @security_headers['content-security-policy'] = policy
       end
@@ -327,7 +328,7 @@ class Otto
       # @example
       #   config.enable_csp_with_nonce!(debug: true)
       def enable_csp_with_nonce!(debug: false)
-        raise FrozenError, 'Cannot modify frozen configuration' if frozen?
+        ensure_not_frozen!
 
         @csp_nonce_enabled = true
         @debug_csp         = debug
@@ -338,7 +339,7 @@ class Otto
       # @return [void]
       # @raise [FrozenError] if configuration is frozen
       def disable_csp_nonce!
-        raise FrozenError, 'Cannot modify frozen configuration' if frozen?
+        ensure_not_frozen!
 
         @csp_nonce_enabled = false
       end
@@ -373,7 +374,7 @@ class Otto
       # @return [void]
       # @raise [FrozenError] if configuration is frozen
       def enable_frame_protection!(option = 'SAMEORIGIN')
-        raise FrozenError, 'Cannot modify frozen configuration' if frozen?
+        ensure_not_frozen!
 
         @security_headers['x-frame-options'] = option
       end
@@ -390,7 +391,7 @@ class Otto
       #     'cross-origin-opener-policy' => 'same-origin'
       #   })
       def set_custom_headers(headers)
-        raise FrozenError, 'Cannot modify frozen configuration' if frozen?
+        ensure_not_frozen!
 
         @security_headers.merge!(headers)
       end
@@ -423,6 +424,12 @@ class Otto
       end
 
       private
+
+      # Guard for mutators: refuse changes once the configuration is frozen.
+      # Centralizes the repeated frozen-check so every setter shares one message.
+      def ensure_not_frozen!
+        raise FrozenError, 'Cannot modify frozen configuration' if frozen?
+      end
 
       # Validate a candidate trusted_proxy_depth value (type and range).
       #
@@ -494,7 +501,7 @@ class Otto
       # @param entry [String] trusted proxy entry
       # @return [void]
       def warn_legacy_proxy_entry(entry)
-        Otto.logger&.warn(
+        Otto.logger.warn(
           "[Otto::Security::Config] trusted proxy #{entry.inspect} is not a " \
           'valid IP or CIDR; using legacy string-prefix matching. Prefer a ' \
           "CIDR range (e.g. '172.16.0.0/12')."
@@ -593,12 +600,12 @@ class Otto
         return if @csrf_secret_warning_emitted
 
         @csrf_secret_warning_emitted = true
-        Otto.logger&.warn(
-          '[Otto::Security::Config] CSRF tokens are signed with a randomly ' \
-          'generated per-process secret; they will not survive restarts or be ' \
-          'valid across workers. Set OTTO_CSRF_SECRET (or config.csrf_secret=) ' \
-          'for stable CSRF tokens in multi-process deployments.'
-        )
+        Otto.logger.warn(<<~MSG.gsub(/\s+/, ' ').strip)
+          [Otto::Security::Config] CSRF tokens are signed with a randomly
+          generated per-process secret; they will not survive restarts or be
+          valid across workers. Set OTTO_CSRF_SECRET (or config.csrf_secret=)
+          for stable CSRF tokens in multi-process deployments.
+        MSG
       end
 
       # Freeze-time backstop: refuse to finalize a production configuration that

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -56,8 +56,7 @@ class Otto
                   :trusted_proxies, :require_secure_cookies,
                   :security_headers,
                   :csp_nonce_enabled, :debug_csp, :mcp_auth,
-                  :ip_privacy_config, :trusted_proxy_depth,
-                  :csrf_secret
+                  :ip_privacy_config, :trusted_proxy_depth
 
       # Initialize security configuration with safe defaults
       #
@@ -245,6 +244,9 @@ class Otto
       # Set the server-side secret used to sign (HMAC) CSRF tokens. Set this to
       # a stable value (e.g. ENV['OTTO_CSRF_SECRET']) in multi-process or
       # multi-host deployments so tokens stay valid across workers and restarts.
+      #
+      # Write-only by design: the signing key has no public reader, so it is not
+      # exposed to inspection/logging/serialization via the config object.
       def csrf_secret=(secret)
         ensure_not_frozen!
 
@@ -273,7 +275,7 @@ class Otto
         binding_id = session_id.to_s
         return false if binding_id.empty?
 
-        token_part, signature = token.split(':')
+        token_part, signature = token.split(':', 2)
         return false if token_part.nil? || signature.nil?
 
         expected_signature = sign_csrf_token(binding_id, token_part)

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -35,6 +35,16 @@ class Otto
         '(CIDR filter mode) and trusted_proxy_depth >= 1 (count mode). ' \
         'Enumerate proxy CIDRs OR set a hop count, not both.'
 
+      # Error raised when CSRF protection is enabled in production without an
+      # explicitly configured secret. A randomly-generated per-process secret
+      # silently breaks token verification across workers and restarts, so we
+      # refuse it in production rather than serve intermittently-failing tokens.
+      CSRF_SECRET_REQUIRED_MESSAGE = 'CSRF protection is enabled in production ' \
+        'without a configured secret. Set OTTO_CSRF_SECRET (or ' \
+        'config.csrf_secret=) to a stable random value (e.g. ' \
+        'SecureRandom.hex(32)); a per-process random secret is not valid ' \
+        'across workers or restarts.'
+
       attr_accessor :input_validation, :max_param_depth, :csrf_token_key, :rate_limiting_config, :csrf_session_key, :max_request_size, :max_param_keys
 
       attr_reader :csrf_protection,  :csrf_header_key,
@@ -248,6 +258,7 @@ class Otto
         binding_id = session_id.to_s
         raise ArgumentError, 'CSRF token generation requires a session binding' if binding_id.empty?
 
+        reject_generated_secret_in_production!
         warn_generated_csrf_secret
         token = SecureRandom.hex(32)
         "#{token}:#{sign_csrf_token(binding_id, token)}"
@@ -394,6 +405,7 @@ class Otto
         # Ensure custom_rules is initialized (should already be done in constructor)
         @rate_limiting_config[:custom_rules] ||= {}
         validate_trusted_proxy_config!
+        validate_csrf_secret_config!
         super
       end
 
@@ -587,6 +599,35 @@ class Otto
           'valid across workers. Set OTTO_CSRF_SECRET (or config.csrf_secret=) ' \
           'for stable CSRF tokens in multi-process deployments.'
         )
+      end
+
+      # Freeze-time backstop: refuse to finalize a production configuration that
+      # enables CSRF with a generated (non-configured) secret. Mirrors
+      # #validate_trusted_proxy_config! so the failure surfaces at boot, before
+      # serving traffic, for apps that deep-freeze their config.
+      def validate_csrf_secret_config!
+        raise ArgumentError, CSRF_SECRET_REQUIRED_MESSAGE if csrf_secret_unsafe_for_production?
+      end
+
+      # Generation-time guard for apps that never freeze their config: never
+      # mint a CSRF token signed with a generated per-process secret in
+      # production (fail loud instead of serving tokens that won't verify).
+      def reject_generated_secret_in_production!
+        raise ArgumentError, CSRF_SECRET_REQUIRED_MESSAGE if csrf_secret_unsafe_for_production?
+      end
+
+      # True when CSRF is enabled, the secret was randomly generated (not
+      # configured via OTTO_CSRF_SECRET / #csrf_secret=), and we are running in
+      # a production environment.
+      def csrf_secret_unsafe_for_production?
+        @csrf_protection && @csrf_secret_generated && production_environment?
+      end
+
+      # Whether RACK_ENV indicates a production deployment. Gated to an explicit
+      # allowlist (not "anything but dev") so test/unknown environments keep the
+      # zero-config generated-secret fallback.
+      def production_environment?
+        defined?(Otto) && Otto.respond_to?(:env?) && Otto.env?(:production, :prod)
       end
 
       # Generate CSP directives for development environment

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -4,6 +4,7 @@
 
 require 'securerandom'
 require 'digest'
+require 'openssl'
 require 'ipaddr'
 require_relative '../core/freezable'
 
@@ -40,7 +41,8 @@ class Otto
                   :trusted_proxies, :require_secure_cookies,
                   :security_headers,
                   :csp_nonce_enabled, :debug_csp, :mcp_auth,
-                  :ip_privacy_config, :trusted_proxy_depth
+                  :ip_privacy_config, :trusted_proxy_depth,
+                  :csrf_secret
 
       # Initialize security configuration with safe defaults
       #
@@ -64,6 +66,14 @@ class Otto
         @debug_csp              = false
         @rate_limiting_config   = { custom_rules: {} }
         @ip_privacy_config      = Otto::Privacy::Config.new
+
+        @csrf_secret = ENV.fetch('OTTO_CSRF_SECRET', nil)
+        if @csrf_secret.nil? || @csrf_secret.empty?
+          @csrf_secret           = SecureRandom.hex(32)
+          @csrf_secret_generated = true
+        else
+          @csrf_secret_generated = false
+        end
       end
 
       # Enable CSRF (Cross-Site Request Forgery) protection
@@ -221,28 +231,41 @@ class Otto
         true
       end
 
-      def generate_csrf_token(session_id = nil)
-        base       = session_id || 'no-session'
-        token      = SecureRandom.hex(32)
-        hash_input = base + ':' + token
-        signature  = Digest::SHA256.hexdigest(hash_input)
-        csrf_token = "#{token}:#{signature}"
+      # Set the server-side secret used to sign (HMAC) CSRF tokens. Set this to
+      # a stable value (e.g. ENV['OTTO_CSRF_SECRET']) in multi-process or
+      # multi-host deployments so tokens stay valid across workers and restarts.
+      def csrf_secret=(secret)
+        raise FrozenError, 'Cannot modify frozen configuration' if frozen?
 
-        csrf_token
+        @csrf_secret           = secret
+        @csrf_secret_generated = false
       end
 
+      # Generate a CSRF token bound to the given session id and signed (HMAC-SHA256)
+      # with the server-side secret, so tokens cannot be self-minted and are not
+      # valid across sessions. A session binding is REQUIRED.
+      def generate_csrf_token(session_id = nil)
+        binding_id = session_id.to_s
+        raise ArgumentError, 'CSRF token generation requires a session binding' if binding_id.empty?
+
+        warn_generated_csrf_secret
+        token = SecureRandom.hex(32)
+        "#{token}:#{sign_csrf_token(binding_id, token)}"
+      end
+
+      # Verify a CSRF token against its session binding using a constant-time
+      # comparison. Returns false (never raises) for blank/malformed input.
       def verify_csrf_token(token, session_id = nil)
         return false if token.nil? || token.empty?
+
+        binding_id = session_id.to_s
+        return false if binding_id.empty?
 
         token_part, signature = token.split(':')
         return false if token_part.nil? || signature.nil?
 
-        base               = session_id || 'no-session'
-        hash_input         = "#{base}:#{token_part}"
-        expected_signature = Digest::SHA256.hexdigest(hash_input)
-        comparison_result  = secure_compare(signature, expected_signature)
-
-        comparison_result
+        expected_signature = sign_csrf_token(binding_id, token_part)
+        secure_compare(signature, expected_signature)
       end
 
       # Enable HTTP Strict Transport Security (HSTS) header
@@ -540,6 +563,30 @@ class Otto
         result                                = 0
         a.bytes.zip(b.bytes) { |x, y| result |= x ^ y }
         result == 0
+      end
+
+      # HMAC-SHA256 signature binding a token's random component to a session id
+      # and the server-side secret. Keyed HMAC (not a bare digest) is what prevents
+      # token self-minting.
+      def sign_csrf_token(session_id, token)
+        OpenSSL::HMAC.hexdigest('SHA256', @csrf_secret, "#{session_id}:#{token}")
+      end
+
+      # Warn once per config instance when CSRF tokens are being signed with a
+      # randomly-generated per-process secret. Such tokens do not survive process
+      # restarts and are not shared across workers; set OTTO_CSRF_SECRET (or
+      # config.csrf_secret=) for stable multi-process behavior.
+      def warn_generated_csrf_secret
+        return unless @csrf_secret_generated
+        return if @csrf_secret_warning_emitted
+
+        @csrf_secret_warning_emitted = true
+        Otto.logger&.warn(
+          '[Otto::Security::Config] CSRF tokens are signed with a randomly ' \
+          'generated per-process secret; they will not survive restarts or be ' \
+          'valid across workers. Set OTTO_CSRF_SECRET (or config.csrf_secret=) ' \
+          'for stable CSRF tokens in multi-process deployments.'
+        )
       end
 
       # Generate CSP directives for development environment

--- a/lib/otto/security/constant_resolver.rb
+++ b/lib/otto/security/constant_resolver.rb
@@ -48,9 +48,7 @@ class Otto
 
         raise ArgumentError, "Invalid class name format: #{class_name}" unless name.match?(CLASS_NAME_PATTERN)
 
-        if FORBIDDEN_CLASSES.include?(name) || name.start_with?('::')
-          raise ArgumentError, "Forbidden class name: #{class_name}"
-        end
+        raise ArgumentError, "Forbidden class name: #{class_name}" if FORBIDDEN_CLASSES.include?(name)
 
         fq_class_name = "::#{name.sub(/^::+/, '')}"
 

--- a/lib/otto/security/constant_resolver.rb
+++ b/lib/otto/security/constant_resolver.rb
@@ -1,0 +1,75 @@
+# lib/otto/security/constant_resolver.rb
+#
+# frozen_string_literal: true
+
+class Otto
+  module Security
+    # Shared, validated resolution of a class from its String name.
+    #
+    # Centralizes the class-name format check and the forbidden-class blocklist
+    # so every dispatch path that turns a route/handler string into a constant
+    # (Otto::Route, RouteHandlers::BaseHandler, and the MCP registry/server)
+    # enforces the SAME guards against code-injection via crafted class names.
+    module ConstantResolver
+      # A class name is a sequence of ::-separated, capitalized Ruby constant
+      # tokens. This also rejects leading "::" (a name must start with [A-Z]).
+      CLASS_NAME_PATTERN = /\A[A-Z][a-zA-Z0-9_]*(?:::[A-Z][a-zA-Z0-9_]*)*\z/
+
+      # Constants that must never be resolvable from untrusted route/handler
+      # strings, since dispatching to them enables arbitrary/dangerous behavior.
+      FORBIDDEN_CLASSES = %w[
+        Kernel Module Class Object BasicObject
+        File Dir IO Process System
+        Binding Proc Method UnboundMethod
+        Thread ThreadGroup Fiber
+        ObjectSpace GC
+      ].freeze
+
+      # The actual constant objects behind FORBIDDEN_CLASSES that exist in this
+      # runtime. The resolved constant is checked against these by identity so a
+      # forbidden class reached through a namespace prefix (e.g. "Object::Kernel")
+      # or via Ruby's trailing-segment constant inheritance (e.g. "App::File"
+      # falling back to top-level ::File) is rejected even though its literal
+      # string is not listed in FORBIDDEN_CLASSES. An app's OWN class that merely
+      # shares a name (a distinct object) is unaffected.
+      FORBIDDEN_CONSTANTS = FORBIDDEN_CLASSES.filter_map do |const_name|
+        Object.const_get(const_name) if Object.const_defined?(const_name, false)
+      end.freeze
+
+      module_function
+
+      # Resolve a validated class name to its Class object.
+      #
+      # @param class_name [String] fully-qualified class name (e.g. "App::Users")
+      # @return [Class, Module] the resolved constant
+      # @raise [ArgumentError] if the name is malformed, forbidden, or not found
+      def safe_const_get(class_name)
+        name = class_name.to_s
+
+        raise ArgumentError, "Invalid class name format: #{class_name}" unless name.match?(CLASS_NAME_PATTERN)
+
+        if FORBIDDEN_CLASSES.include?(name) || name.start_with?('::')
+          raise ArgumentError, "Forbidden class name: #{class_name}"
+        end
+
+        fq_class_name = "::#{name.sub(/^::+/, '')}"
+
+        resolved =
+          begin
+            Object.const_get(fq_class_name)
+          rescue NameError => e
+            raise ArgumentError, "Class not found: #{fq_class_name} - #{e.message}"
+          end
+
+        # Reject forbidden constants reached via a namespace prefix or Ruby's
+        # trailing-segment constant inheritance, which the literal-name check
+        # above cannot see (e.g. "Object::Kernel", or "App::File" -> ::File).
+        if FORBIDDEN_CONSTANTS.any? { |forbidden| resolved.equal?(forbidden) }
+          raise ArgumentError, "Forbidden class name: #{class_name}"
+        end
+
+        resolved
+      end
+    end
+  end
+end

--- a/lib/otto/security/middleware/csrf_middleware.rb
+++ b/lib/otto/security/middleware/csrf_middleware.rb
@@ -93,9 +93,10 @@ class Otto
           # Inject meta tag into HTML head
           body_content = body.respond_to?(:join) ? body.join : body.to_s
 
-          if body_content.match?(/<head>/i)
+          head_open_tag = /<head(?:\s[^>]*)?>/i
+          if body_content.match?(head_open_tag)
             meta_tag     = %(<meta name="csrf-token" content="#{csrf_token}">)
-            body_content = body_content.sub(/<head>/i, "<head>\n#{meta_tag}")
+            body_content = body_content.sub(head_open_tag) { |tag| "#{tag}\n#{meta_tag}" }
 
             # Update content length if present
             content_length_key          = headers.keys.find { |k| k.downcase == 'content-length' }

--- a/lib/otto/security/middleware/validation_middleware.rb
+++ b/lib/otto/security/middleware/validation_middleware.rb
@@ -17,9 +17,14 @@ class Otto
 
         # HTML/XSS sanitization is handled by Loofah library for better security coverage
 
+        # Best-effort, defense-in-depth signatures for obviously-malicious payloads.
+        # These are NOT a substitute for SQL-injection protection: the real defense is
+        # parameterized queries / prepared statements at the data-access layer. A bare
+        # SQL-keyword substring blocklist was intentionally removed because it produced
+        # false positives on legitimate input (e.g. "selection", "updated_at") while
+        # remaining trivially bypassable.
         SQL_INJECTION_PATTERNS = [
           /('|(\\')|(;)|(\\)|(--)|(%27)|(%3B)|(%3D))/i,
-          /(union|select|insert|update|delete|drop|create|alter|exec|execute)/i,
           /(or|and)\s+\w+\s*=\s*\w+/i,
           /\d+\s*(=|>|<|>=|<=|<>|!=)\s*\d+/i,
         ].freeze

--- a/lib/otto/security/middleware/validation_middleware.rb
+++ b/lib/otto/security/middleware/validation_middleware.rb
@@ -16,18 +16,11 @@ class Otto
         NULL_BYTE          = /\0/
 
         # HTML/XSS sanitization is handled by Loofah library for better security coverage
-
-        # Best-effort, defense-in-depth signatures for obviously-malicious payloads.
-        # These are NOT a substitute for SQL-injection protection: the real defense is
-        # parameterized queries / prepared statements at the data-access layer. A bare
-        # SQL-keyword substring blocklist was intentionally removed because it produced
-        # false positives on legitimate input (e.g. "selection", "updated_at") while
-        # remaining trivially bypassable.
-        SQL_INJECTION_PATTERNS = [
-          /('|(\\')|(;)|(\\)|(--)|(%27)|(%3B)|(%3D))/i,
-          /(or|and)\s+\w+\s*=\s*\w+/i,
-          /\d+\s*(=|>|<|>=|<=|<>|!=)\s*\d+/i,
-        ].freeze
+        #
+        # NOTE: There is deliberately no SQL-injection pattern matching here.
+        # Input-validation blocklists for SQL are bypassable theater and produce
+        # false positives on legitimate input; the correct defense is
+        # parameterized queries / prepared statements at the data-access layer.
 
         def initialize(app, config = nil)
           @app    = app
@@ -186,14 +179,7 @@ class Otto
           sanitized = Loofah.fragment(original).scrub!(:whitewash).to_s
 
           # Remove control characters (sanitize, don't block)
-          sanitized = sanitized.gsub(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/, '')
-
-          # Check for SQL injection patterns
-          SQL_INJECTION_PATTERNS.each do |pattern|
-            raise Otto::Security::ValidationError, 'Potential SQL injection detected' if sanitized.match?(pattern)
-          end
-
-          sanitized
+          sanitized.gsub(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/, '')
         end
 
         include Otto::Security::ValidationHelpers

--- a/spec/otto/mcp/token_auth_spec.rb
+++ b/spec/otto/mcp/token_auth_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+
+RSpec.describe Otto::MCP::Auth::TokenAuth do
+  subject(:auth) { described_class.new(%w[abc def]) }
+
+  describe '#authenticate' do
+    it 'authenticates a valid bearer token' do
+      env = { 'HTTP_AUTHORIZATION' => 'Bearer def' }
+      expect(auth.authenticate(env)).to be(true)
+    end
+
+    it 'authenticates a valid X-MCP-Token header' do
+      env = { 'HTTP_X_MCP_TOKEN' => 'abc' }
+      expect(auth.authenticate(env)).to be(true)
+    end
+
+    it 'rejects an incorrect token' do
+      env = { 'HTTP_AUTHORIZATION' => 'Bearer nope' }
+      expect(auth.authenticate(env)).to be(false)
+    end
+
+    it 'rejects when no token is provided' do
+      expect(auth.authenticate({})).to be(false)
+    end
+
+    it 'rejects any token when no tokens are configured' do
+      empty_auth = described_class.new([])
+      env = { 'HTTP_AUTHORIZATION' => 'Bearer anything' }
+      expect(empty_auth.authenticate(env)).to be(false)
+    end
+  end
+end

--- a/spec/otto/route_handlers_spec.rb
+++ b/spec/otto/route_handlers_spec.rb
@@ -78,6 +78,41 @@ RSpec.describe Otto::RouteHandlers do
         end.to raise_error(NotImplementedError, /Subclasses must implement #invoke_target/)
       end
     end
+
+    describe 'safe class-name resolution (H-2)' do
+      # BaseHandler#target_class resolves route_definition.klass_name via the
+      # shared, validated Otto::Security::ConstantResolver. Forbidden and
+      # malformed class names must be rejected so a crafted route string cannot
+      # dispatch to dangerous constants like Kernel/Process.
+      it 'rejects forbidden class names (e.g. Kernel) with ArgumentError' do
+        forbidden_definition = Otto::RouteDefinition.new('GET', '/x', 'Kernel.system')
+        forbidden_handler = described_class.new(forbidden_definition)
+
+        expect do
+          forbidden_handler.send(:target_class)
+        end.to raise_error(ArgumentError, /Forbidden class name/)
+      end
+
+      it 'rejects forbidden class names (e.g. Process) with ArgumentError' do
+        forbidden_definition = Otto::RouteDefinition.new('GET', '/x', 'Process.kill')
+        forbidden_handler = described_class.new(forbidden_definition)
+
+        expect do
+          forbidden_handler.send(:target_class)
+        end.to raise_error(ArgumentError, /Forbidden class name/)
+      end
+
+      it 'rejects malformed class names with ArgumentError' do
+        # 'lowercase.method' parses into a klass_name of 'lowercase', which is a
+        # syntactically valid route target but an invalid Ruby constant name.
+        bad_definition = Otto::RouteDefinition.new('GET', '/x', 'lowercase.method')
+        bad_handler = described_class.new(bad_definition)
+
+        expect do
+          bad_handler.send(:target_class)
+        end.to raise_error(ArgumentError, /Invalid class name format/)
+      end
+    end
   end
 
   describe Otto::RouteHandlers::LogicClassHandler do

--- a/spec/otto/security/authentication/strategies/api_key_strategy_spec.rb
+++ b/spec/otto/security/authentication/strategies/api_key_strategy_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require_relative '../../../../spec_helper'
+
+RSpec.describe Otto::Security::Authentication::Strategies::APIKeyStrategy do
+  def env_with_header(value)
+    { 'HTTP_X_API_KEY' => value }
+  end
+
+  describe '#authenticate' do
+    context 'with configured API keys' do
+      subject(:strategy) { described_class.new(api_keys: %w[key-one key-two]) }
+
+      it 'authenticates a correct API key' do
+        result = strategy.authenticate(env_with_header('key-two'), nil)
+        expect(result.authenticated?).to be(true)
+        expect(result.user[:api_key]).to eq('key-two')
+      end
+
+      it 'rejects an incorrect API key' do
+        result = strategy.authenticate(env_with_header('wrong-key'), nil)
+        expect(result.authenticated?).to be(false)
+      end
+
+      it 'rejects a request with no API key' do
+        result = strategy.authenticate({}, nil)
+        expect(result.authenticated?).to be(false)
+      end
+    end
+
+    context 'with no API keys configured' do
+      subject(:strategy) { described_class.new(api_keys: []) }
+
+      it 'accepts any provided API key' do
+        result = strategy.authenticate(env_with_header('anything-goes'), nil)
+        expect(result.authenticated?).to be(true)
+        expect(result.user[:api_key]).to eq('anything-goes')
+      end
+    end
+  end
+end

--- a/spec/otto/security/constant_resolver_spec.rb
+++ b/spec/otto/security/constant_resolver_spec.rb
@@ -1,0 +1,74 @@
+# spec/otto/security/constant_resolver_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Otto::Security::ConstantResolver do
+  describe '.safe_const_get' do
+    context 'with valid class names' do
+      it 'resolves a top-level class' do
+        expect(described_class.safe_const_get('String')).to eq(String)
+      end
+
+      it 'resolves a namespaced class' do
+        expect(described_class.safe_const_get('Otto::Route')).to eq(Otto::Route)
+      end
+    end
+
+    context 'with malformed names' do
+      [
+        'lowercase',
+        'has space',
+        '::LeadingColons',
+        'Trailing::',
+        '1Numeric',
+        'Has-Dash',
+        "New\nLine",
+        '',
+      ].each do |bad|
+        it "rejects #{bad.inspect} with an invalid-format error" do
+          expect { described_class.safe_const_get(bad) }
+            .to raise_error(ArgumentError, /Invalid class name format|Forbidden class name/)
+        end
+      end
+    end
+
+    context 'with forbidden classes named directly' do
+      %w[Kernel Module Class Object BasicObject File Dir IO Process Binding Proc Method Thread Fiber ObjectSpace GC].each do |forbidden|
+        it "rejects #{forbidden}" do
+          expect { described_class.safe_const_get(forbidden) }
+            .to raise_error(ArgumentError, /Forbidden class name/)
+        end
+      end
+    end
+
+    context 'with forbidden classes reached via a namespace prefix (bypass hardening)' do
+      # These resolve to the SAME forbidden constant object through Object's
+      # namespace / constant inheritance, so a literal-string blocklist misses
+      # them. The resolved-constant identity check must still reject them.
+      %w[Object::Kernel Object::File Object::Process Object::IO Object::Dir Object::Object].each do |bypass|
+        it "rejects #{bypass}" do
+          expect { described_class.safe_const_get(bypass) }
+            .to raise_error(ArgumentError, /Forbidden class name/)
+        end
+      end
+    end
+
+    context 'with unknown classes' do
+      it 'raises a class-not-found error' do
+        expect { described_class.safe_const_get('Otto::DefinitelyNotAClass123') }
+          .to raise_error(ArgumentError, /Class not found/)
+      end
+    end
+
+    context "with an app's own class that merely shares a forbidden name" do
+      it 'allows a distinct constant object that is not the forbidden built-in' do
+        stub_const('SafeResolverApp::File', Class.new)
+        expect(described_class.safe_const_get('SafeResolverApp::File'))
+          .to eq(SafeResolverApp::File)
+        expect(described_class.safe_const_get('SafeResolverApp::File')).not_to eq(::File)
+      end
+    end
+  end
+end

--- a/spec/security_config_spec.rb
+++ b/spec/security_config_spec.rb
@@ -98,14 +98,14 @@ RSpec.describe Otto::Security::Config do
       before { config.enable_csrf_protection! }
 
       it 'generates valid CSRF tokens' do
-        token = config.generate_csrf_token
+        token = config.generate_csrf_token('test_session')
         expect(token).to be_a(String)
         expect(token).to include(':')
 
         parts = token.split(':')
         expect(parts.length).to eq(2)
         expect(parts[0]).to match(/\A[a-f0-9]{64}\z/) # 32 bytes = 64 hex chars
-        expect(parts[1]).to match(/\A[a-f0-9]{64}\z/) # SHA256 = 64 hex chars
+        expect(parts[1]).to match(/\A[a-f0-9]{64}\z/) # HMAC-SHA256 = 64 hex chars
 
         puts "\n=== DEBUG: CSRF Token ==="
         puts "Token: #{token}"
@@ -115,9 +115,48 @@ RSpec.describe Otto::Security::Config do
       end
 
       it 'generates different tokens on each call' do
-        token1 = config.generate_csrf_token
-        token2 = config.generate_csrf_token
+        token1 = config.generate_csrf_token('test_session')
+        token2 = config.generate_csrf_token('test_session')
         expect(token1).not_to eq(token2)
+      end
+
+      it 'raises ArgumentError when called without a session id' do
+        expect { config.generate_csrf_token }
+          .to raise_error(ArgumentError, /requires a session binding/)
+      end
+
+      it 'raises ArgumentError when called with an empty session id' do
+        expect { config.generate_csrf_token('') }
+          .to raise_error(ArgumentError, /requires a session binding/)
+      end
+
+      it 'rejects a token forged with the old static no-session scheme' do
+        t = SecureRandom.hex(32)
+        forged = "#{t}:#{Digest::SHA256.hexdigest("no-session:#{t}")}"
+
+        expect(config.verify_csrf_token(forged, 'no-session')).to be false
+      end
+
+      it 'does not accept tokens signed with a different secret' do
+        config_a = described_class.new
+        config_b = described_class.new
+        config_a.csrf_secret = 'a' * 64
+        config_b.csrf_secret = 'b' * 64
+
+        session_id = 'shared_session'
+        token_a = config_a.generate_csrf_token(session_id)
+        token_b = config_b.generate_csrf_token(session_id)
+
+        expect(config_b.verify_csrf_token(token_a, session_id)).to be false
+        expect(config_a.verify_csrf_token(token_b, session_id)).to be false
+      end
+
+      it 'round-trips generate/verify after setting csrf_secret' do
+        config.csrf_secret = 'c' * 64
+        session_id = 'round_trip_session'
+        token = config.generate_csrf_token(session_id)
+
+        expect(config.verify_csrf_token(token, session_id)).to be true
       end
 
       it 'verifies valid tokens' do

--- a/spec/security_config_spec.rb
+++ b/spec/security_config_spec.rb
@@ -159,6 +159,50 @@ RSpec.describe Otto::Security::Config do
         expect(config.verify_csrf_token(token, session_id)).to be true
       end
 
+      describe 'production secret guard' do
+        around do |example|
+          original = ENV.fetch('RACK_ENV', nil)
+          example.run
+        ensure
+          ENV['RACK_ENV'] = original
+        end
+
+        it 'refuses to generate a token in production with a generated secret' do
+          ENV['RACK_ENV'] = 'production'
+          prod_config = described_class.new # generated per-process secret
+          prod_config.enable_csrf_protection!
+
+          expect { prod_config.generate_csrf_token('session_prod') }
+            .to raise_error(ArgumentError, /without a configured secret/)
+        end
+
+        it 'allows generation in production once a secret is configured' do
+          ENV['RACK_ENV'] = 'production'
+          prod_config = described_class.new
+          prod_config.enable_csrf_protection!
+          prod_config.csrf_secret = SecureRandom.hex(32)
+
+          expect { prod_config.generate_csrf_token('session_prod') }.not_to raise_error
+        end
+
+        it 'refuses to freeze a production config that enables CSRF without a secret' do
+          ENV['RACK_ENV'] = 'production'
+          prod_config = described_class.new
+          prod_config.enable_csrf_protection!
+
+          expect { prod_config.deep_freeze! }
+            .to raise_error(ArgumentError, /without a configured secret/)
+        end
+
+        it 'keeps the zero-config generated-secret fallback outside production' do
+          ENV['RACK_ENV'] = 'development'
+          dev_config = described_class.new
+          dev_config.enable_csrf_protection!
+
+          expect { dev_config.generate_csrf_token('session_dev') }.not_to raise_error
+        end
+      end
+
       it 'verifies valid tokens' do
         session_id = 'test_session_123'
         token = config.generate_csrf_token(session_id)

--- a/spec/security_validation_spec.rb
+++ b/spec/security_validation_spec.rb
@@ -293,15 +293,20 @@ RSpec.describe Otto::Security::ValidationMiddleware do
     end
 
     let(:sql_injection_patterns) do
+      # These payloads are still caught by the remaining best-effort signatures
+      # (quote/semicolon/comment, OR/AND x=y, numeric comparison). A bare
+      # SQL-keyword substring blocklist was intentionally removed (L-4), so
+      # keyword-only payloads such as "UNION SELECT * FROM passwords" or
+      # "INSERT INTO users VALUES" are no longer rejected by the input
+      # validator. See the "allows legitimate values containing SQL-like
+      # keywords" example below for the false-positive fix.
       [
         "1' OR '1'='1",
         "'; DROP TABLE users; --",
-        'UNION SELECT * FROM passwords',
         '1=1',
         "admin'--",
         '%27 OR %271%27=%271',
         '1 AND 1=1',
-        'INSERT INTO users VALUES',
       ]
     end
 
@@ -321,6 +326,28 @@ RSpec.describe Otto::Security::ValidationMiddleware do
         puts "Status: #{response[0]}"
         puts "Error: #{body['message']}"
         puts "==================================\n"
+      end
+    end
+
+    it 'allows legitimate values containing SQL-like keywords (L-4 false-positive fix)' do
+      # The bare SQL-keyword substring blocklist was removed because it rejected
+      # legitimate input while being trivially bypassable. These values contain
+      # SQL keywords/substrings but no quote/semicolon/comment/= /numeric
+      # comparison, so they must pass validation.
+      legitimate_values = [
+        'updated_at',
+        'selection',
+        'creative writing',
+        'SELECT * FROM users',
+        'INSERT INTO users VALUES',
+      ]
+
+      legitimate_values.each do |value|
+        params = { 'query' => value }
+        env = mock_rack_env(method: 'POST', path: '/', params: params)
+
+        response = middleware.call(env)
+        expect(response[0]).to eq(200), "expected #{value.inspect} to be allowed, got #{response[0]}"
       end
     end
 
@@ -648,12 +675,21 @@ RSpec.describe Otto::Security::ValidationHelpers do
       dangerous_inputs = [
         '<script>alert(1)</script>',
         'javascript:alert(1)',
-        'SELECT * FROM users',
+        "'; DROP TABLE users; --",
       ]
 
       dangerous_inputs.each do |input|
         expect { mock_response.validate_input(input) }
           .to raise_error(Otto::Security::ValidationError)
+      end
+    end
+
+    it 'allows legitimate values containing SQL-like keywords (L-4 false-positive fix)' do
+      # The bare SQL-keyword substring blocklist was removed; a value that
+      # merely contains a keyword (without quote/semicolon/comment/= /numeric
+      # comparison) is no longer rejected by the input validator.
+      ['SELECT * FROM users', 'updated_at', 'selection'].each do |input|
+        expect(mock_response.validate_input(input)).to eq(input)
       end
     end
 

--- a/spec/security_validation_spec.rb
+++ b/spec/security_validation_spec.rb
@@ -292,48 +292,30 @@ RSpec.describe Otto::Security::ValidationMiddleware do
       end
     end
 
-    let(:sql_injection_patterns) do
-      # These payloads are still caught by the remaining best-effort signatures
-      # (quote/semicolon/comment, OR/AND x=y, numeric comparison). A bare
-      # SQL-keyword substring blocklist was intentionally removed (L-4), so
-      # keyword-only payloads such as "UNION SELECT * FROM passwords" or
-      # "INSERT INTO users VALUES" are no longer rejected by the input
-      # validator. See the "allows legitimate values containing SQL-like
-      # keywords" example below for the false-positive fix.
-      [
+    it 'does not block SQL-injection-shaped input (defense is parameterized queries)' do
+      # SQL-injection defense intentionally lives at the data-access layer
+      # (parameterized queries), NOT here: input-validation blocklists are
+      # bypassable theater and reject legitimate input. These shapes now pass
+      # the validator; XSS/script/null-byte checks still apply separately.
+      sql_shaped = [
         "1' OR '1'='1",
         "'; DROP TABLE users; --",
         '1=1',
         "admin'--",
-        '%27 OR %271%27=%271',
+        'UNION SELECT * FROM passwords',
         '1 AND 1=1',
       ]
-    end
 
-    it 'detects SQL injection pattern' do
-      sql_injection_patterns.each do |pattern|
-        params = { 'query' => pattern }
-        env = mock_rack_env(method: 'POST', path: '/', params: params)
-
+      sql_shaped.each do |value|
+        env = mock_rack_env(method: 'POST', path: '/', params: { 'query' => value })
         response = middleware.call(env)
-        expect(response[0]).to eq(400)
-
-        body = JSON.parse(response[2].join)
-        expect(body['message']).to include('Potential SQL injection detected')
-
-        puts "\n=== DEBUG: SQL Injection Detection ==="
-        puts "Pattern: #{pattern}"
-        puts "Status: #{response[0]}"
-        puts "Error: #{body['message']}"
-        puts "==================================\n"
+        expect(response[0]).to eq(200), "expected #{value.inspect} to pass validation, got #{response[0]}"
       end
     end
 
-    it 'allows legitimate values containing SQL-like keywords (L-4 false-positive fix)' do
-      # The bare SQL-keyword substring blocklist was removed because it rejected
-      # legitimate input while being trivially bypassable. These values contain
-      # SQL keywords/substrings but no quote/semicolon/comment/= /numeric
-      # comparison, so they must pass validation.
+    it 'allows legitimate values that merely contain SQL-like keywords' do
+      # SQL-keyword inspection was removed entirely, so benign values that
+      # happen to contain SQL-ish substrings are no longer false-positives.
       legitimate_values = [
         'updated_at',
         'selection',
@@ -343,9 +325,7 @@ RSpec.describe Otto::Security::ValidationMiddleware do
       ]
 
       legitimate_values.each do |value|
-        params = { 'query' => value }
-        env = mock_rack_env(method: 'POST', path: '/', params: params)
-
+        env = mock_rack_env(method: 'POST', path: '/', params: { 'query' => value })
         response = middleware.call(env)
         expect(response[0]).to eq(200), "expected #{value.inspect} to be allowed, got #{response[0]}"
       end
@@ -675,7 +655,6 @@ RSpec.describe Otto::Security::ValidationHelpers do
       dangerous_inputs = [
         '<script>alert(1)</script>',
         'javascript:alert(1)',
-        "'; DROP TABLE users; --",
       ]
 
       dangerous_inputs.each do |input|
@@ -684,10 +663,10 @@ RSpec.describe Otto::Security::ValidationHelpers do
       end
     end
 
-    it 'allows legitimate values containing SQL-like keywords (L-4 false-positive fix)' do
-      # The bare SQL-keyword substring blocklist was removed; a value that
-      # merely contains a keyword (without quote/semicolon/comment/= /numeric
-      # comparison) is no longer rejected by the input validator.
+    it 'allows values that merely contain SQL-like keywords' do
+      # SQL-keyword inspection was removed entirely; a value that merely
+      # contains a keyword is no longer rejected by the input validator. SQL
+      # injection is defended at the data-access layer with parameterized queries.
       ['SELECT * FROM users', 'updated_at', 'selection'].each do |input|
         expect(mock_response.validate_input(input)).to eq(input)
       end
@@ -697,12 +676,6 @@ RSpec.describe Otto::Security::ValidationHelpers do
       html_input = '<p>This is <strong>safe</strong> HTML</p>'
       result = mock_response.validate_input(html_input, allow_html: true)
       expect(result).to eq(html_input)
-    end
-
-    it 'still checks for SQL injection even when HTML is allowed' do
-      sql_injection = "'; DROP TABLE users; --"
-      expect { mock_response.validate_input(sql_injection, allow_html: true) }
-        .to raise_error(Otto::Security::ValidationError, /SQL injection/)
     end
 
     it 'handles nil and empty input gracefully' do


### PR DESCRIPTION
## Summary

This PR hardens Otto's security posture across three critical areas: CSRF token generation and validation, class-name resolution for route/handler dispatch, and authentication token comparison.

## Key Changes

### CSRF Token Signing & Session Binding
- CSRF tokens are now signed with HMAC-SHA256 using a server-side secret, preventing self-minting and replay across sessions
- Tokens are bound to the session ID; generation now requires an explicit session binding (raises `ArgumentError` if omitted or empty)
- Server-side secret is configurable via `OTTO_CSRF_SECRET` environment variable or `Otto::Security::Config#csrf_secret=`
- In production, enabling CSRF without an explicitly configured secret now raises at freeze time (prevents silent per-process secret fallback that breaks across workers/restarts)
- Development/test environments retain zero-config generated-secret fallback for convenience
- Updated token generation/verification to use HMAC instead of plain SHA256 digest

### Centralized Constant Resolution (ConstantResolver)
- Extracted class-name validation logic into a new `Otto::Security::ConstantResolver` module to enforce consistent guards across all dispatch paths
- All route/handler class-name resolution now goes through `safe_const_get`, including:
  - `Otto::Route` initialization
  - `RouteHandlers::BaseHandler#target_class`
  - MCP registry and server tool/resource registration
- Enhanced forbidden-class detection to reject constants reached via namespace prefixes (e.g., `Object::Kernel`) or Ruby's trailing-segment constant inheritance (e.g., `App::File` → `::File`)
- Validates class-name format (must match `/\A[A-Z][a-zA-Z0-9_]*(?:::[A-Z][a-zA-Z0-9_]*)*\z/`)
- Raises `ArgumentError` (not `NameError`) for unresolvable/forbidden names for consistent error handling

### Constant-Time Authentication Comparisons
- MCP bearer tokens and API keys are now compared using `Rack::Utils.secure_compare` in constant time
- Comparison iterates over all configured tokens without short-circuiting, preventing timing-based leaks of token position or membership

### Input Validation Cleanup
- Removed SQL-injection pattern matching from `ValidationMiddleware` and `validate_input` helper
- SQL injection is defended at the data-access layer with parameterized queries; input-validation blocklists are bypassable and produce false positives on legitimate input (e.g., `'updated_at'`, `'selection'`)

### Minor Improvements
- Consolidated repeated frozen-check logic into `ensure_not_frozen!` helper method
- `Otto.logger` now never returns `nil` (lazy `$stdout` default); assign `Otto.logger=` to override or silence
- Fixed CSRF `<meta>` tag injection to work with `<head>` tags that carry attributes, not only bare `<head>`
- Improved error messages for proxy configuration conflicts using heredoc formatting

## Testing

- Added comprehensive test coverage for CSRF token signing, session binding, and production secret validation
- Added `ConstantResolver` spec with tests for malformed names, forbidden classes, namespace-prefix bypasses, and app-owned classes that share forbidden names
- Added constant-time comparison tests for MCP tokens and API keys
- Updated existing validation tests to reflect removal of SQL-injection pattern matching

https://claude.ai/code/session_012xjVY1ACeen8eLqg6XerNv