### PR TITLE
Depth mode: configurable forwarded header (RFC 7239 Forwarded / Both) (#150)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -51,7 +51,7 @@ jobs:
             - Security concerns
             - Test coverage
 
-            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+            Use the repository's CLAUDE.md or AGENTS.md for guidance on style and conventions. Be constructive and helpful in your feedback.
 
           # Use sticky comments to reuse the same comment on subsequent pushes to the same PR
           use_sticky_comment: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,9 +32,14 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Fall back to Sonnet when the primary model is unavailable/overloaded.
+          # Without this, an unavailable primary surfaces as "Claude encountered
+          # an error" and fails the claude-review check.
+          fallback_model: "claude-sonnet-4-6"
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :development do
   gem 'benchmark'
   gem 'debug'
   gem 'rackup' # Used to boot examples/ apps; not needed by specs
+  gem 'rake', '~> 13.0', require: false # Provides `rake release` for release-gem.yml
   gem 'rubocop', '~> 1.86.2', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rspec', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,7 @@ GEM
     rackup (2.3.1)
       rack (>= 3)
     rainbow (3.1.1)
+    rake (13.1.0)
     rbs (4.0.2)
       logger
       prism (>= 1.6.0)
@@ -216,6 +217,7 @@ DEPENDENCIES
   rack-attack
   rack-test
   rackup
+  rake (~> 13.0)
   reek (~> 6.5)
   rspec (~> 3.13)
   rubocop (~> 1.86.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    otto (2.3.0)
+    otto (2.3.1)
       concurrent-ruby (~> 1.3, < 2.0)
       logger (~> 1, < 2.0)
       loofah (~> 2.20)

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,21 @@
+# Rakefile
+#
+# frozen_string_literal: true
+
+# `bundler/gem_tasks` defines the build/install/release tasks the
+# release-gem.yml workflow drives via `bundle exec rake release`
+# (RubyGems Trusted Publishing). `rake release` builds the gem, pushes the
+# git tag (a no-op when the release tag already exists), and publishes to
+# RubyGems.
+require 'bundler/gem_tasks'
+
+# Make `rake` (no task) run the specs, mirroring CI's `bundle exec rspec`.
+# Guarded so `rake release` still works in an install without the test
+# group (rspec lives in the :test group).
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+  task default: :spec
+rescue LoadError
+  # rspec unavailable (e.g. a production/release-only bundle); skip the task.
+end

--- a/changelog.d/20260621_000000_claude_nice-goodall-g493f8.rst
+++ b/changelog.d/20260621_000000_claude_nice-goodall-g493f8.rst
@@ -1,0 +1,26 @@
+Added
+-----
+
+- Depth mode (``Otto::Security::Config#trusted_proxy_depth``) can now select
+  which forwarded header it counts hops from, via a new ``#trusted_proxy_header``
+  accessor: ``X-Forwarded-For`` (default), ``Forwarded`` (RFC 7239), or ``Both``
+  (RFC 7239 when it carries a ``for=``, otherwise ``X-Forwarded-For`` — a
+  fallback, never a merge). Settable through
+  ``Otto::Security::Configurator#configure`` (``trusted_proxy_header:``) and the
+  ``trusted_proxy_header`` option of ``Otto.new`` / ``configure_security``. The
+  RFC 7239 parser reads each forwarded-element's ``for=`` case-insensitively,
+  unquotes it, and handles quoted IPv6 with a port, obfuscated / ``unknown``
+  identifiers, and multiple/comma-joined ``Forwarded`` values. Depth's safety
+  properties are preserved across all modes: raw position counting (junk cannot
+  shift the index), short-chain → ``REMOTE_ADDR`` fallback, and the single-value
+  ``X-Real-IP`` / ``X-Client-IP`` headers still ignored. This reaches parity with
+  OneTimeSecret's ``site.network.trusted_proxy.header`` so the downstream depth
+  path can be deleted. (delano/otto#150, onetimesecret#3436)
+
+AI Assistance
+-------------
+
+- RFC 7239 ``Forwarded`` / ``Both`` depth-header support designed and implemented
+  with AI pair programming, grounded in the OneTimeSecret reference resolver, with
+  per-header / quoted-IPv6 / ``Both``-precedence / raw-position-counting test
+  coverage.

--- a/changelog.d/20260621_000000_claude_nice-goodall-g493f8.rst
+++ b/changelog.d/20260621_000000_claude_nice-goodall-g493f8.rst
@@ -10,12 +10,16 @@ Added
   ``trusted_proxy_header`` option of ``Otto.new`` / ``configure_security``. The
   RFC 7239 parser reads each forwarded-element's ``for=`` case-insensitively,
   unquotes it, and handles quoted IPv6 with a port, obfuscated / ``unknown``
-  identifiers, and multiple/comma-joined ``Forwarded`` values. Depth's safety
-  properties are preserved across all modes: raw position counting (junk cannot
-  shift the index), short-chain → ``REMOTE_ADDR`` fallback, and the single-value
-  ``X-Real-IP`` / ``X-Client-IP`` headers still ignored. This reaches parity with
-  OneTimeSecret's ``site.network.trusted_proxy.header`` so the downstream depth
-  path can be deleted. (delano/otto#150, onetimesecret#3436)
+  identifiers, and multiple/comma-joined ``Forwarded`` values. The
+  ``trusted_proxy_header`` value itself is matched case-insensitively (whitespace
+  ignored) and stored canonicalized, so a hand-edited ``forwarded`` / ``both``
+  works; a genuinely unrecognized value raises ``ArgumentError`` at assignment
+  rather than silently resolving from a default header, surfacing typos at config
+  time. Depth's safety properties are preserved across all modes: raw position
+  counting (junk cannot shift the index), short-chain → ``REMOTE_ADDR`` fallback,
+  and the single-value ``X-Real-IP`` / ``X-Client-IP`` headers still ignored. This
+  reaches parity with OneTimeSecret's ``site.network.trusted_proxy.header`` so the
+  downstream depth path can be deleted. (delano/otto#150, onetimesecret#3436)
 
 AI Assistance
 -------------

--- a/docs/migrating/v2.3.0.md
+++ b/docs/migrating/v2.3.0.md
@@ -234,8 +234,13 @@ Otto.new(routes, trusted_proxy_depth: 1, trusted_proxy_header: 'Forwarded')
   dropped before counting (an element without a `for=` still counts as a hop),
   so padding cannot shift the index; only the selected hop is validated.
 - **Depth mode only.** `trusted_proxy_header` is consulted solely in depth mode;
-  CIDR-walk is unaffected. Unrecognized values raise `ArgumentError` at
-  assignment.
+  CIDR-walk is unaffected.
+- **Lenient spelling, strict validation.** The value is matched
+  case-insensitively with surrounding whitespace ignored (`forwarded`, `both`,
+  `  X-Forwarded-For ` all work) and stored canonicalized. A genuinely
+  unrecognized value raises `ArgumentError` at assignment rather than silently
+  falling back to a default header — a typo surfaces at config time instead of
+  as subtly-wrong client IPs at request time.
 
 ### Security prerequisite: origin lockdown
 

--- a/docs/migrating/v2.3.0.md
+++ b/docs/migrating/v2.3.0.md
@@ -181,9 +181,11 @@ entry is not a valid IP, the resolver returns `REMOTE_ADDR` rather than a
 spoofable forwarded value. This is intentionally **stricter than Express**, which
 returns the leftmost (most spoofable) forwarded entry in that case.
 
-**`X-Forwarded-For` only.** Depth mode consults **only** `X-Forwarded-For`.
-`X-Real-IP` and `X-Client-IP` are single-value headers that cannot express a hop
-chain, so they are ignored in depth mode (CIDR-walk still consults them).
+**Single-value headers are never consulted.** `X-Real-IP` and `X-Client-IP`
+cannot express a hop chain, so depth mode ignores them (CIDR-walk still consults
+them). Which *multi-hop* header depth counts from — `X-Forwarded-For` (default),
+the RFC 7239 `Forwarded` header, or `Both` — is configurable as of 2.3.1; see
+*Selecting the forwarded header* below.
 
 **`secure?` is independent of depth.** Depth mode resolves the client **IP**
 only; it does **not** grant proxy trust for `X-Forwarded-Proto` / `X-Scheme`.
@@ -194,6 +196,46 @@ depth. Because depth mode and `trusted_proxies` are mutually exclusive, that
 check is `false` under depth, so `secure?` does not honor a forwarded proto and
 reflects only a direct TLS connection (`HTTPS=on` / port 443). This mirrors the
 downstream (OneTimeSecret) behavior: proto-trust is never derived from depth.
+
+### Selecting the forwarded header (added in 2.3.1)
+
+By default depth counts hops from `X-Forwarded-For`. Deployments fronted by a
+proxy that emits the RFC 7239 `Forwarded` header can change the source via
+`trusted_proxy_header`, mirroring OneTimeSecret's
+`site.network.trusted_proxy.header`:
+
+```ruby
+otto.security_config.trusted_proxy_header = 'Forwarded'   # RFC 7239 only
+
+# or via the facade / construction options, alongside the depth:
+otto.security.configure(trusted_proxy_depth: 1, trusted_proxy_header: 'Both')
+Otto.new(routes, trusted_proxy_depth: 1, trusted_proxy_header: 'Forwarded')
+```
+
+| Value | Chain source |
+|-------|--------------|
+| `'X-Forwarded-For'` (default) | `X-Forwarded-For` |
+| `'Forwarded'` | RFC 7239 `Forwarded` — the `for=` of each forwarded-element |
+| `'Both'` | `Forwarded` when it carries a `for=`, otherwise `X-Forwarded-For` |
+
+- **`Both` precedence is fallback, not merge.** If the `Forwarded` header carries
+  at least one `for=`, only its chain is used and `X-Forwarded-For` is ignored;
+  otherwise the `X-Forwarded-For` chain is used. The two chains are never
+  concatenated. (Matches OTS's
+  `extract_rfc7239_forwarded(env) || extract_x_forwarded_for(env)`.)
+- **RFC 7239 parsing.** Each comma-separated forwarded-element is one hop; its
+  `for=` parameter is read case-insensitively and unquoted. Quoted IPv6 with a
+  port (`for="[2001:db8::1]:443"`) resolves to `2001:db8::1`. Obfuscated
+  (`for=_hidden`) and `for=unknown` identifiers still occupy a hop position but
+  are not valid IPs, so if one is the selected hop the resolver falls back to
+  `REMOTE_ADDR`. Multiple `Forwarded` headers (joined by Rack into one
+  comma-separated value) are handled.
+- **Raw position counting is preserved** in all three modes: elements are never
+  dropped before counting (an element without a `for=` still counts as a hop),
+  so padding cannot shift the index; only the selected hop is validated.
+- **Depth mode only.** `trusted_proxy_header` is consulted solely in depth mode;
+  CIDR-walk is unaffected. Unrecognized values raise `ArgumentError` at
+  assignment.
 
 ### Security prerequisite: origin lockdown
 

--- a/lib/otto/core/configuration.rb
+++ b/lib/otto/core/configuration.rb
@@ -61,6 +61,10 @@ class Otto
         # with trusted_proxies; conflict validated at configuration freeze).
         @security_config.trusted_proxy_depth = opts[:trusted_proxy_depth] if opts[:trusted_proxy_depth]
 
+        # Select the forwarded header depth mode reads from ('X-Forwarded-For',
+        # 'Forwarded', or 'Both'). Only consulted in depth mode.
+        @security_config.trusted_proxy_header = opts[:trusted_proxy_header] if opts[:trusted_proxy_header]
+
         # Set custom security headers
         return unless opts[:security_headers]
 

--- a/lib/otto/core/configuration.rb
+++ b/lib/otto/core/configuration.rb
@@ -59,11 +59,15 @@ class Otto
 
         # Set count-based trusted-proxy depth if provided (mutually exclusive
         # with trusted_proxies; conflict validated at configuration freeze).
-        @security_config.trusted_proxy_depth = opts[:trusted_proxy_depth] if opts[:trusted_proxy_depth]
+        # Guard on presence (`unless nil?`), not truthiness, so an explicitly
+        # provided invalid value (e.g. `false`) reaches the validating setter
+        # and fails loud instead of being silently dropped.
+        @security_config.trusted_proxy_depth = opts[:trusted_proxy_depth] unless opts[:trusted_proxy_depth].nil?
 
         # Select the forwarded header depth mode reads from ('X-Forwarded-For',
-        # 'Forwarded', or 'Both'). Only consulted in depth mode.
-        @security_config.trusted_proxy_header = opts[:trusted_proxy_header] if opts[:trusted_proxy_header]
+        # 'Forwarded', or 'Both'). Only consulted in depth mode. Same presence
+        # guard: a provided-but-invalid value is validated, not ignored.
+        @security_config.trusted_proxy_header = opts[:trusted_proxy_header] unless opts[:trusted_proxy_header].nil?
 
         # Set custom security headers
         return unless opts[:security_headers]

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -37,6 +37,13 @@ class Otto
         hop count, not both.
       MSG
 
+      # Forwarded-header sources depth mode (#trusted_proxy_depth) can count
+      # hops from: X-Forwarded-For (default), the RFC 7239 Forwarded header, or
+      # Both (Forwarded when present, else X-Forwarded-For). Mirrors
+      # OneTimeSecret's site.network.trusted_proxy.header. Only consulted in
+      # depth mode; CIDR-walk is unaffected.
+      TRUSTED_PROXY_HEADERS = %w[X-Forwarded-For Forwarded Both].freeze
+
       # Error raised when CSRF protection is enabled in production without an
       # explicitly configured secret. A randomly-generated per-process secret
       # silently breaks token verification across workers and restarts, so we
@@ -56,7 +63,7 @@ class Otto
                   :trusted_proxies, :require_secure_cookies,
                   :security_headers,
                   :csp_nonce_enabled, :debug_csp, :mcp_auth,
-                  :ip_privacy_config, :trusted_proxy_depth
+                  :ip_privacy_config, :trusted_proxy_depth, :trusted_proxy_header
 
       # Initialize security configuration with safe defaults
       #
@@ -73,6 +80,7 @@ class Otto
         @trusted_proxies        = []
         @trusted_proxy_matchers = []
         @trusted_proxy_depth    = nil
+        @trusted_proxy_header   = 'X-Forwarded-For'
         @require_secure_cookies = false
         @security_headers       = default_security_headers
         @input_validation       = true
@@ -223,6 +231,24 @@ class Otto
         raise ArgumentError, PROXY_MODE_CONFLICT_MESSAGE if depth.to_i >= 1 && @trusted_proxies.any?
 
         @trusted_proxy_depth = depth
+      end
+
+      # Select which forwarded header depth mode counts hops from:
+      # 'X-Forwarded-For' (default), 'Forwarded' (RFC 7239), or 'Both'. Only
+      # consulted when depth mode is active (#trusted_proxy_depth_mode?);
+      # CIDR-walk always uses X-Forwarded-For / X-Real-IP / X-Client-IP.
+      #
+      # Validated eagerly (like #trusted_proxy_depth=) so a typo fails at
+      # assignment rather than silently resolving from the wrong header.
+      #
+      # @param header [String] one of TRUSTED_PROXY_HEADERS
+      # @raise [FrozenError] if configuration is frozen
+      # @raise [ArgumentError] if header is not a recognized value
+      def trusted_proxy_header=(header)
+        ensure_not_frozen!
+
+        validate_trusted_proxy_header!(header)
+        @trusted_proxy_header = header
       end
 
       # Validate that a request size is within acceptable limits
@@ -453,6 +479,22 @@ class Otto
         raise ArgumentError, "trusted_proxy_depth must be >= 0, got #{depth}" if depth.negative?
       end
 
+      # Validate a candidate trusted_proxy_header value against the allowed set.
+      #
+      # Shared by the eager #trusted_proxy_header= setter and the freeze-time
+      # backstop so an unrecognized header fails with a clear ArgumentError
+      # instead of silently mis-resolving the client IP at request time.
+      #
+      # @param header [Object] candidate value
+      # @raise [ArgumentError] if header is not one of TRUSTED_PROXY_HEADERS
+      # @return [void]
+      def validate_trusted_proxy_header!(header)
+        return if TRUSTED_PROXY_HEADERS.include?(header)
+
+        raise ArgumentError,
+              "trusted_proxy_header must be one of #{TRUSTED_PROXY_HEADERS.join(', ')}, got #{header.inspect}"
+      end
+
       # Validate trusted-proxy configuration coherence at freeze time.
       #
       # The eager setters (#trusted_proxy_depth=, #add_trusted_proxy) already
@@ -464,6 +506,7 @@ class Otto
       #   trusted_proxies and a depth >= 1 are configured
       # @return [void]
       def validate_trusted_proxy_config!
+        validate_trusted_proxy_header!(@trusted_proxy_header)
         validate_trusted_proxy_depth!(@trusted_proxy_depth)
         return if @trusted_proxy_depth.nil?
 

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -238,17 +238,20 @@ class Otto
       # consulted when depth mode is active (#trusted_proxy_depth_mode?);
       # CIDR-walk always uses X-Forwarded-For / X-Real-IP / X-Client-IP.
       #
-      # Validated eagerly (like #trusted_proxy_depth=) so a typo fails at
-      # assignment rather than silently resolving from the wrong header.
+      # The value is matched case-insensitively (surrounding whitespace ignored)
+      # and stored in its canonical spelling, so a hand-edited config can write
+      # `forwarded` or `both` without surprise. A genuinely unrecognized value
+      # fails loud at assignment (rather than silently resolving from the wrong
+      # header, the way a permissive default would), so a typo surfaces at config
+      # time instead of as subtly-wrong client IPs at request time.
       #
-      # @param header [String] one of TRUSTED_PROXY_HEADERS
+      # @param header [String] one of TRUSTED_PROXY_HEADERS (case-insensitive)
       # @raise [FrozenError] if configuration is frozen
       # @raise [ArgumentError] if header is not a recognized value
       def trusted_proxy_header=(header)
         ensure_not_frozen!
 
-        validate_trusted_proxy_header!(header)
-        @trusted_proxy_header = header
+        @trusted_proxy_header = canonicalize_trusted_proxy_header(header)
       end
 
       # Validate that a request size is within acceptable limits
@@ -479,11 +482,31 @@ class Otto
         raise ArgumentError, "trusted_proxy_depth must be >= 0, got #{depth}" if depth.negative?
       end
 
-      # Validate a candidate trusted_proxy_header value against the allowed set.
+      # Canonicalize a candidate trusted_proxy_header value: match it
+      # case-insensitively (ignoring surrounding whitespace) against the
+      # recognized set and return the canonical spelling. Liberal in the spelling
+      # it accepts (e.g. 'forwarded' => 'Forwarded') but fail-loud on a genuinely
+      # unrecognized value, so a typo is caught at config time rather than
+      # silently resolving the client IP from the wrong header.
       #
-      # Shared by the eager #trusted_proxy_header= setter and the freeze-time
-      # backstop so an unrecognized header fails with a clear ArgumentError
-      # instead of silently mis-resolving the client IP at request time.
+      # @param header [Object] candidate value
+      # @raise [ArgumentError] if header is not one of TRUSTED_PROXY_HEADERS
+      # @return [String] the canonical header value
+      def canonicalize_trusted_proxy_header(header)
+        candidate = header.to_s.strip
+        canonical = TRUSTED_PROXY_HEADERS.find { |allowed| allowed.casecmp?(candidate) }
+        return canonical if canonical
+
+        raise ArgumentError,
+              "trusted_proxy_header must be one of #{TRUSTED_PROXY_HEADERS.join(', ')}, got #{header.inspect}"
+      end
+
+      # Strictly validate a stored trusted_proxy_header value against the allowed
+      # set. The eager #trusted_proxy_header= setter already canonicalizes, so by
+      # freeze time the value is canonical; this freeze-time backstop catches a
+      # value smuggled in through a direct-ivar path that bypassed the setter,
+      # failing loud rather than silently mis-resolving the client IP at request
+      # time.
       #
       # @param header [Object] candidate value
       # @raise [ArgumentError] if header is not one of TRUSTED_PROXY_HEADERS

--- a/lib/otto/security/configurator.rb
+++ b/lib/otto/security/configurator.rb
@@ -39,6 +39,9 @@ class Otto
       # @param trusted_proxy_depth [Integer, nil] Count-based proxy depth ("trust
       #   the last N hops") for non-enumerable proxy tiers; mutually exclusive
       #   with trusted_proxies (validated at configuration freeze)
+      # @param trusted_proxy_header [String, nil] Forwarded header depth mode
+      #   counts hops from: 'X-Forwarded-For' (default), 'Forwarded' (RFC 7239),
+      #   or 'Both'. Only consulted in depth mode.
       # @param security_headers [Hash] Custom security headers to merge with defaults
       # @param hsts [Boolean] Enable HTTP Strict Transport Security
       # @param csp [Boolean, String] Enable Content Security Policy
@@ -62,6 +65,7 @@ class Otto
         rate_limiting: false,
         trusted_proxies: [],
         trusted_proxy_depth: nil,
+        trusted_proxy_header: nil,
         security_headers: {},
         hsts: false,
         csp: false,
@@ -74,6 +78,7 @@ class Otto
 
         Array(trusted_proxies).each { |proxy| add_trusted_proxy(proxy) }
         self.trusted_proxy_depth = trusted_proxy_depth unless trusted_proxy_depth.nil?
+        self.trusted_proxy_header = trusted_proxy_header unless trusted_proxy_header.nil?
         self.security_headers = security_headers unless security_headers.empty?
 
         enable_hsts! if hsts
@@ -140,6 +145,16 @@ class Otto
       # @param depth [Integer, nil] number of trusted hops (nil/0 disables depth mode)
       def trusted_proxy_depth=(depth)
         @security_config.trusted_proxy_depth = depth
+      end
+
+      # Select which forwarded header depth mode counts hops from:
+      # 'X-Forwarded-For' (default), 'Forwarded' (RFC 7239), or 'Both'. Only
+      # consulted when depth mode is active. Mirrors OneTimeSecret's
+      # site.network.trusted_proxy.header.
+      #
+      # @param header [String] one of Otto::Security::Config::TRUSTED_PROXY_HEADERS
+      def trusted_proxy_header=(header)
+        @security_config.trusted_proxy_header = header
       end
 
       # Set custom security headers that will be added to all responses.

--- a/lib/otto/utils.rb
+++ b/lib/otto/utils.rb
@@ -226,6 +226,9 @@ class Otto
     # Obfuscated (`for=_hidden`) and `for=unknown` identifiers are preserved as
     # positions but normalize to nil (→ REMOTE_ADDR fallback if selected).
     # Commas separate forwarded-elements (and join multiple Forwarded headers).
+    # A nil/blank header splits to [] (not ['']), so an absent Forwarded header
+    # yields an empty chain and depth's explicit short-chain guard returns
+    # REMOTE_ADDR — symmetric with xff_chain.
     #
     # @param value [String, nil] raw Forwarded header value
     # @return [Array<String>] one `for=` token per forwarded-element
@@ -236,23 +239,26 @@ class Otto
     # Pull the `for=` token out of a single RFC 7239 forwarded-element. The value
     # is a quoted-string (which may itself legally contain ';') or an unquoted
     # token ending at the next ';'. The quoted form is matched first so a ';'
-    # inside quotes is NOT treated as a parameter separator — otherwise a value
+    # inside DQUOTEs is NOT treated as a parameter separator — otherwise a value
     # like for="1.2.3.4;junk" would be truncated to a valid-looking IP instead of
-    # being rejected. Both DQUOTE and — non-RFC, but accepted for parity with
-    # OneTimeSecret's resolver — single-quote wrappers are stripped; the raw
-    # value (port / IPv6 brackets intact) is left for normalize_ip when the entry
-    # is selected, so a stripped value that is not a valid IP is still rejected.
-    # Returns '' when the element carries no `for=` parameter, preserving the hop
-    # position. The `for=` pair may be the element's first pair or follow a ';';
-    # leading whitespace (e.g. after a comma split) is tolerated.
+    # being rejected. Only DQUOTE wrappers are stripped: RFC 7239 quoted-strings
+    # use DQUOTE exclusively, so a value like for='1.2.3.4' keeps its quotes,
+    # fails normalize_ip, and safely falls back to REMOTE_ADDR rather than being
+    # permissively accepted. This is deliberately stricter than OTS (which strips
+    # both ['"]), consistent with depth's other intentionally-not-reconciled-down
+    # safety properties. The raw value (port / IPv6 brackets intact) is left for
+    # normalize_ip when the entry is selected. Returns '' when the element carries
+    # no `for=` parameter, preserving the hop position. The `for=` pair may be the
+    # element's first pair or follow a ';'; leading whitespace (e.g. after a comma
+    # split) is tolerated.
     #
     # @param element [String] one forwarded-element (e.g. 'for=1.2.3.4;proto=https')
     # @return [String]
     def rfc7239_for_value(element)
-      match = element.match(/(?:\A|;)\s*for=(?:"([^"]*)"|'([^']*)'|([^;]+))/i)
+      match = element.match(/(?:\A|;)\s*for=(?:"([^"]*)"|([^;]+))/i)
       return '' unless match
 
-      (match[1] || match[2] || match[3]).strip
+      (match[1] || match[2]).strip
     end
 
     # Whether an address is non-public: RFC1918 private, loopback, link-local,

--- a/lib/otto/utils.rb
+++ b/lib/otto/utils.rb
@@ -233,19 +233,25 @@ class Otto
       value.to_s.split(',', -1).map { |element| rfc7239_for_value(element) }
     end
 
-    # Pull the `for=` token out of a single RFC 7239 forwarded-element, unquoting
-    # a surrounding DQUOTE. Returns '' when the element carries no `for=`
-    # parameter, preserving the hop position.
+    # Pull the `for=` token out of a single RFC 7239 forwarded-element. The value
+    # is either a quoted-string (which may itself legally contain ';') or an
+    # unquoted token ending at the next ';'. The quoted form is matched first so
+    # a ';' inside DQUOTEs is NOT treated as a parameter separator — otherwise a
+    # quoted value like for="1.2.3.4;junk" would be truncated to a valid-looking
+    # IP instead of being rejected. The surrounding DQUOTEs are stripped; the
+    # raw value (port / IPv6 brackets intact) is left for normalize_ip when the
+    # entry is selected. Returns '' when the element carries no `for=` parameter,
+    # preserving the hop position. The `for=` pair may be the element's first
+    # pair or follow a ';'; leading whitespace (e.g. after a comma split) is
+    # tolerated.
     #
     # @param element [String] one forwarded-element (e.g. 'for=1.2.3.4;proto=https')
     # @return [String]
     def rfc7239_for_value(element)
-      element.split(';').each do |param|
-        next unless (match = param.strip.match(/\Afor=(.+)\z/i))
+      match = element.match(/(?:\A|;)\s*for=(?:"([^"]*)"|([^;]*))/i)
+      return '' unless match
 
-        return match[1].strip.gsub(/\A["']|["']\z/, '')
-      end
-      ''
+      (match[1] || match[2]).to_s.strip
     end
 
     # Whether an address is non-public: RFC1918 private, loopback, link-local,

--- a/lib/otto/utils.rb
+++ b/lib/otto/utils.rb
@@ -234,24 +234,25 @@ class Otto
     end
 
     # Pull the `for=` token out of a single RFC 7239 forwarded-element. The value
-    # is either a quoted-string (which may itself legally contain ';') or an
-    # unquoted token ending at the next ';'. The quoted form is matched first so
-    # a ';' inside DQUOTEs is NOT treated as a parameter separator — otherwise a
-    # quoted value like for="1.2.3.4;junk" would be truncated to a valid-looking
-    # IP instead of being rejected. The surrounding DQUOTEs are stripped; the
-    # raw value (port / IPv6 brackets intact) is left for normalize_ip when the
-    # entry is selected. Returns '' when the element carries no `for=` parameter,
-    # preserving the hop position. The `for=` pair may be the element's first
-    # pair or follow a ';'; leading whitespace (e.g. after a comma split) is
-    # tolerated.
+    # is a quoted-string (which may itself legally contain ';') or an unquoted
+    # token ending at the next ';'. The quoted form is matched first so a ';'
+    # inside quotes is NOT treated as a parameter separator — otherwise a value
+    # like for="1.2.3.4;junk" would be truncated to a valid-looking IP instead of
+    # being rejected. Both DQUOTE and — non-RFC, but accepted for parity with
+    # OneTimeSecret's resolver — single-quote wrappers are stripped; the raw
+    # value (port / IPv6 brackets intact) is left for normalize_ip when the entry
+    # is selected, so a stripped value that is not a valid IP is still rejected.
+    # Returns '' when the element carries no `for=` parameter, preserving the hop
+    # position. The `for=` pair may be the element's first pair or follow a ';';
+    # leading whitespace (e.g. after a comma split) is tolerated.
     #
     # @param element [String] one forwarded-element (e.g. 'for=1.2.3.4;proto=https')
     # @return [String]
     def rfc7239_for_value(element)
-      match = element.match(/(?:\A|;)\s*for=(?:"([^"]*)"|([^;]*))/i)
+      match = element.match(/(?:\A|;)\s*for=(?:"([^"]*)"|'([^']*)'|([^;]+))/i)
       return '' unless match
 
-      (match[1] || match[2]).to_s.strip
+      (match[1] || match[2] || match[3]).strip
     end
 
     # Whether an address is non-public: RFC1918 private, loopback, link-local,

--- a/lib/otto/utils.rb
+++ b/lib/otto/utils.rb
@@ -143,43 +143,109 @@ class Otto
     # from the right of the forwarded chain (Express `trust proxy = N`). Used
     # when the proxy tier's addresses cannot be enumerated as CIDRs.
     #
-    # The chain is X-Forwarded-For (leftmost = client .. rightmost = nearest
-    # proxy) plus REMOTE_ADDR (the direct peer). With depth N the client is
-    # chain[-(N+1)] — exactly N trusted hops from the right, equivalent to
-    # Express's addrs[N]. This is robust to X-Forwarded-For padding: a forged
-    # leftmost entry is never reached.
+    # The chain is the configured forwarded header (leftmost = client ..
+    # rightmost = nearest proxy) plus REMOTE_ADDR (the direct peer). With depth
+    # N the client is chain[-(N+1)] — exactly N trusted hops from the right,
+    # equivalent to Express's addrs[N]. This is robust to forwarded-header
+    # padding: a forged leftmost entry is never reached.
     #
     # SECURITY: depth trust ASSUMES ORIGIN LOCKDOWN — the app must be
     # unreachable except through the proxy tier. Without it, a direct client
-    # could pad X-Forwarded-For to land a forged value at the target index.
+    # could pad the forwarded header to land a forged value at the target index.
     # This is the inherent trade vs CIDR-walk (a fixed hop count instead of
     # enumerable proxy addresses).
     #
-    # Only X-Forwarded-For is consulted; X-Real-IP / X-Client-IP are
-    # single-value and cannot express a hop chain. Positions are counted raw
-    # (never dropped), so junk padding cannot shift the index; only the
-    # selected entry is validated. If the chain is shorter than N+1 (a request
-    # that may have bypassed the proxy tier) or the selected entry is invalid,
-    # REMOTE_ADDR is returned rather than a spoofable forwarded value.
+    # The forwarded chain is selected by security_config.trusted_proxy_header:
+    # 'X-Forwarded-For' (default), 'Forwarded' (RFC 7239), or 'Both' (RFC 7239
+    # when it carries a `for=`, otherwise X-Forwarded-For — mirrors
+    # OneTimeSecret's site.network.trusted_proxy.header). X-Real-IP / X-Client-IP
+    # are single-value and cannot express a hop chain, so they are never
+    # consulted in depth mode. Positions are counted raw (never dropped), so junk
+    # padding cannot shift the index; only the selected entry is validated. If
+    # the chain is shorter than N+1 (a request that may have bypassed the proxy
+    # tier) or the selected entry is invalid, REMOTE_ADDR is returned rather than
+    # a spoofable forwarded value.
     #
     # @param env [Hash] Rack environment
-    # @param security_config [Otto::Security::Config] config exposing #trusted_proxy_depth
+    # @param security_config [Otto::Security::Config] config exposing #trusted_proxy_depth and #trusted_proxy_header
     # @return [String, nil] resolved client IP (REMOTE_ADDR on short chain / invalid target)
     def resolve_client_ip_by_depth(env, security_config)
       remote_addr = env['REMOTE_ADDR']
       depth       = security_config.trusted_proxy_depth.to_i
 
-      # Split on commas keeping every position (-1 preserves trailing empty
-      # fields) so a malformed hop still counts as a position. The client must
-      # be located by counting from the right; dropping entries here would let
-      # padding shift the index.
-      forwarded = env['HTTP_X_FORWARDED_FOR'].to_s.split(',', -1)
+      # Build the positional hop chain from the configured header, keeping every
+      # position (junk/empty entries included) so the client can be located by
+      # counting from the right; dropping entries would let padding shift the
+      # index. REMOTE_ADDR (the direct peer) is the rightmost hop.
+      forwarded = forwarded_chain_for_depth(env, security_config.trusted_proxy_header)
       chain     = forwarded + [remote_addr]
 
       index = chain.length - (depth + 1)
       return remote_addr if index.negative? # chain shorter than depth + 1
 
       normalize_ip(chain[index].to_s.strip) || remote_addr
+    end
+
+    # Positional forwarded-hop chain for depth resolution, selected by header
+    # mode. Each element is one hop (preserving count); values are raw — only the
+    # finally-selected entry is normalized. Mirrors OneTimeSecret's
+    # site.network.trusted_proxy.header semantics.
+    #
+    # @param env [Hash] Rack environment
+    # @param header_mode [String] 'X-Forwarded-For', 'Forwarded', or 'Both'
+    # @return [Array<String>] one entry per hop (may include blank/invalid entries)
+    def forwarded_chain_for_depth(env, header_mode)
+      case header_mode
+      when 'Forwarded'
+        rfc7239_for_chain(env['HTTP_FORWARDED'])
+      when 'Both'
+        # RFC 7239 wins when it carries at least one `for=`; otherwise fall back
+        # to X-Forwarded-For. The chains are NOT merged (matches OTS's
+        # `extract_rfc7239_forwarded(env) || extract_x_forwarded_for(env)`).
+        forwarded = rfc7239_for_chain(env['HTTP_FORWARDED'])
+        forwarded.any? { |entry| !entry.empty? } ? forwarded : xff_chain(env['HTTP_X_FORWARDED_FOR'])
+      else
+        xff_chain(env['HTTP_X_FORWARDED_FOR'])
+      end
+    end
+
+    # Split X-Forwarded-For into raw positional entries. `-1` keeps trailing
+    # empty fields so a malformed/empty hop still counts as a position.
+    #
+    # @param value [String, nil] raw X-Forwarded-For header value
+    # @return [Array<String>]
+    def xff_chain(value)
+      value.to_s.split(',', -1)
+    end
+
+    # Extract the per-hop `for=` chain from an RFC 7239 Forwarded header,
+    # preserving one position per forwarded-element. Elements without a `for=`
+    # parameter yield a blank placeholder so they still occupy a hop position
+    # (raw position counting). The extracted token is only unquoted here; port
+    # and IPv6 brackets are left for normalize_ip when the entry is selected.
+    # Obfuscated (`for=_hidden`) and `for=unknown` identifiers are preserved as
+    # positions but normalize to nil (→ REMOTE_ADDR fallback if selected).
+    # Commas separate forwarded-elements (and join multiple Forwarded headers).
+    #
+    # @param value [String, nil] raw Forwarded header value
+    # @return [Array<String>] one `for=` token per forwarded-element
+    def rfc7239_for_chain(value)
+      value.to_s.split(',', -1).map { |element| rfc7239_for_value(element) }
+    end
+
+    # Pull the `for=` token out of a single RFC 7239 forwarded-element, unquoting
+    # a surrounding DQUOTE. Returns '' when the element carries no `for=`
+    # parameter, preserving the hop position.
+    #
+    # @param element [String] one forwarded-element (e.g. 'for=1.2.3.4;proto=https')
+    # @return [String]
+    def rfc7239_for_value(element)
+      element.split(';').each do |param|
+        next unless (match = param.strip.match(/\Afor=(.+)\z/i))
+
+        return match[1].strip.gsub(/\A["']|["']\z/, '')
+      end
+      ''
     end
 
     # Whether an address is non-public: RFC1918 private, loopback, link-local,

--- a/lib/otto/version.rb
+++ b/lib/otto/version.rb
@@ -3,5 +3,5 @@
 # frozen_string_literal: true
 
 class Otto
-  VERSION = '2.3.0'
+  VERSION = '2.3.1'
 end

--- a/spec/otto/initialization_spec.rb
+++ b/spec/otto/initialization_spec.rb
@@ -131,6 +131,30 @@ RSpec.describe Otto, 'initialization' do
     end
   end
 
+  context 'with trusted-proxy depth-header options' do
+    let(:routes_file) { create_test_routes_file('test_routes_depth.txt', test_routes) }
+
+    it 'wires trusted_proxy_header through Otto.new' do
+      otto = described_class.new(routes_file, trusted_proxy_depth: 1, trusted_proxy_header: 'Forwarded')
+      expect(otto.security_config.trusted_proxy_header).to eq('Forwarded')
+    end
+
+    it 'canonicalizes a case-insensitive trusted_proxy_header from Otto.new' do
+      otto = described_class.new(routes_file, trusted_proxy_depth: 1, trusted_proxy_header: 'both')
+      expect(otto.security_config.trusted_proxy_header).to eq('Both')
+    end
+
+    it 'fails loud on an invalid trusted_proxy_header rather than silently ignoring it' do
+      expect { described_class.new(routes_file, trusted_proxy_depth: 1, trusted_proxy_header: false) }
+        .to raise_error(ArgumentError, /must be one of/)
+    end
+
+    it 'fails loud on an invalid trusted_proxy_depth rather than silently ignoring it' do
+      expect { described_class.new(routes_file, trusted_proxy_depth: false) }
+        .to raise_error(ArgumentError, /must be an Integer/)
+    end
+  end
+
   describe 'configuration isolation' do
     it 'maintains separate configurations between instances' do
       otto1 = Otto.new(nil, csrf_protection: true, security_headers: { 'strict-transport-security' => 'max-age=31536000; includeSubDomains' })

--- a/spec/otto/security/configurator_spec.rb
+++ b/spec/otto/security/configurator_spec.rb
@@ -109,6 +109,20 @@ RSpec.describe Otto::Security::Configurator do
       expect(security_config.security_headers).to eq(original_headers)
     end
 
+    it 'wires count-based depth and its forwarded header' do
+      configurator.configure(trusted_proxy_depth: 2, trusted_proxy_header: 'Forwarded')
+
+      expect(security_config.trusted_proxy_depth).to eq(2)
+      expect(security_config.trusted_proxy_depth_mode?).to be true
+      expect(security_config.trusted_proxy_header).to eq('Forwarded')
+    end
+
+    it 'leaves the forwarded header at its default when not specified' do
+      configurator.configure(trusted_proxy_depth: 1)
+
+      expect(security_config.trusted_proxy_header).to eq('X-Forwarded-For')
+    end
+
     it 'configures only specified options' do
       configurator.configure(csrf_protection: true)
 

--- a/spec/otto/security_spec.rb
+++ b/spec/otto/security_spec.rb
@@ -140,5 +140,13 @@ RSpec.describe Otto, 'security features' do
         expect(otto.security_config.trusted_proxies).to include('172.16.')
       end
     end
+
+    describe 'depth-mode configuration' do
+      it 'raises ArgumentError when passed an invalid trusted_proxy_header via options' do
+        expect {
+          Otto.new(nil, trusted_proxy_depth: 1, trusted_proxy_header: false)
+        }.to raise_error(ArgumentError, /trusted_proxy_header must be one of/)
+      end
+    end
   end
 end

--- a/spec/otto/utils_spec.rb
+++ b/spec/otto/utils_spec.rb
@@ -393,6 +393,11 @@ RSpec.describe Otto::Utils do
         expect(Otto::Utils.resolve_client_ip(env, depth_config(1, "Forwarded"))).to eq("203.0.113.50")
       end
 
+      it "strips a single-quoted for= value (non-RFC, accepted for OTS parity)" do
+        env = { "REMOTE_ADDR" => "10.0.0.1", "HTTP_FORWARDED" => "for='203.0.113.50'" }
+        expect(Otto::Utils.resolve_client_ip(env, depth_config(1, "Forwarded"))).to eq("203.0.113.50")
+      end
+
       it "ignores a forged leftmost entry (padding-robust, counts from right)" do
         env = {
           "REMOTE_ADDR" => "10.0.0.1",

--- a/spec/otto/utils_spec.rb
+++ b/spec/otto/utils_spec.rb
@@ -466,5 +466,12 @@ RSpec.describe Otto::Utils do
       env = { "REMOTE_ADDR" => "10.0.0.1", "HTTP_X_FORWARDED_FOR" => "203.0.113.50" }
       expect(Otto::Utils.resolve_client_ip(env, cfg)).to eq("203.0.113.50")
     end
+
+    it "resolves from the Forwarded header when configured case-insensitively" do
+      # 'forwarded' is canonicalized to 'Forwarded' at assignment, so the
+      # resolver still reads the RFC 7239 header.
+      env = { "REMOTE_ADDR" => "10.0.0.1", "HTTP_FORWARDED" => "for=203.0.113.50" }
+      expect(Otto::Utils.resolve_client_ip(env, depth_config(1, "forwarded"))).to eq("203.0.113.50")
+    end
   end
 end

--- a/spec/otto/utils_spec.rb
+++ b/spec/otto/utils_spec.rb
@@ -393,9 +393,12 @@ RSpec.describe Otto::Utils do
         expect(Otto::Utils.resolve_client_ip(env, depth_config(1, "Forwarded"))).to eq("203.0.113.50")
       end
 
-      it "strips a single-quoted for= value (non-RFC, accepted for OTS parity)" do
+      it "rejects a single-quoted for= value (RFC 7239 uses DQUOTE only)" do
+        # Single quotes are not RFC 7239 quoted-string syntax, so the quotes stay
+        # on the value, which fails normalize_ip → REMOTE_ADDR. Deliberately
+        # stricter than OTS (which strips both ['"]).
         env = { "REMOTE_ADDR" => "10.0.0.1", "HTTP_FORWARDED" => "for='203.0.113.50'" }
-        expect(Otto::Utils.resolve_client_ip(env, depth_config(1, "Forwarded"))).to eq("203.0.113.50")
+        expect(Otto::Utils.resolve_client_ip(env, depth_config(1, "Forwarded"))).to eq("10.0.0.1")
       end
 
       it "ignores a forged leftmost entry (padding-robust, counts from right)" do

--- a/spec/otto/utils_spec.rb
+++ b/spec/otto/utils_spec.rb
@@ -341,4 +341,130 @@ RSpec.describe Otto::Utils do
       expect(Otto::Utils.resolve_client_ip(env, cfg)).to eq("203.0.113.50")
     end
   end
+
+  describe "#resolve_client_ip in depth mode with a configurable header" do
+    def depth_config(depth, header)
+      cfg = Otto::Security::Config.new
+      cfg.trusted_proxy_depth = depth
+      cfg.trusted_proxy_header = header
+      cfg
+    end
+
+    context "header = 'Forwarded' (RFC 7239)" do
+      it "resolves the for= entry one hop from the right (depth 1)" do
+        env = { "REMOTE_ADDR" => "10.0.0.1", "HTTP_FORWARDED" => "for=203.0.113.50" }
+        expect(Otto::Utils.resolve_client_ip(env, depth_config(1, "Forwarded"))).to eq("203.0.113.50")
+      end
+
+      it "trusts two hops through an intermediate proxy (depth 2)" do
+        env = {
+          "REMOTE_ADDR" => "10.0.0.1",
+          "HTTP_FORWARDED" => "for=203.0.113.50, for=10.0.0.9",
+        }
+        expect(Otto::Utils.resolve_client_ip(env, depth_config(2, "Forwarded"))).to eq("203.0.113.50")
+      end
+
+      it "unwraps a quoted IPv6 for= with brackets and port" do
+        env = {
+          "REMOTE_ADDR" => "2001:db8::1",
+          "HTTP_FORWARDED" => 'for="[2606:4700:4700::1111]:443"',
+        }
+        expect(Otto::Utils.resolve_client_ip(env, depth_config(1, "Forwarded"))).to eq("2606:4700:4700::1111")
+      end
+
+      it "ignores other params and is case-insensitive about the for= key" do
+        env = {
+          "REMOTE_ADDR" => "10.0.0.1",
+          "HTTP_FORWARDED" => "For=203.0.113.50;proto=https;by=10.0.0.1",
+        }
+        expect(Otto::Utils.resolve_client_ip(env, depth_config(1, "Forwarded"))).to eq("203.0.113.50")
+      end
+
+      it "ignores a forged leftmost entry (padding-robust, counts from right)" do
+        env = {
+          "REMOTE_ADDR" => "10.0.0.1",
+          "HTTP_FORWARDED" => "for=9.9.9.9, for=203.0.113.50",
+        }
+        expect(Otto::Utils.resolve_client_ip(env, depth_config(1, "Forwarded"))).to eq("203.0.113.50")
+      end
+
+      it "counts elements without a for= as raw positions (no index shift)" do
+        env = {
+          "REMOTE_ADDR" => "10.0.0.1",
+          "HTTP_FORWARDED" => "proto=https, for=203.0.113.50",
+        }
+        expect(Otto::Utils.resolve_client_ip(env, depth_config(1, "Forwarded"))).to eq("203.0.113.50")
+      end
+
+      it "falls back to REMOTE_ADDR when the selected entry is obfuscated/unknown" do
+        env = {
+          "REMOTE_ADDR" => "10.0.0.1",
+          "HTTP_FORWARDED" => "for=203.0.113.50, for=_hidden",
+        }
+        expect(Otto::Utils.resolve_client_ip(env, depth_config(1, "Forwarded"))).to eq("10.0.0.1")
+      end
+
+      it "falls back to REMOTE_ADDR on a short chain" do
+        env = { "REMOTE_ADDR" => "10.0.0.1", "HTTP_FORWARDED" => "for=203.0.113.50" }
+        expect(Otto::Utils.resolve_client_ip(env, depth_config(2, "Forwarded"))).to eq("10.0.0.1")
+      end
+
+      it "falls back to REMOTE_ADDR when the Forwarded header is absent" do
+        env = { "REMOTE_ADDR" => "10.0.0.1", "HTTP_X_FORWARDED_FOR" => "203.0.113.50" }
+        expect(Otto::Utils.resolve_client_ip(env, depth_config(1, "Forwarded"))).to eq("10.0.0.1")
+      end
+
+      it "ignores X-Forwarded-For entirely (Forwarded only)" do
+        env = {
+          "REMOTE_ADDR" => "10.0.0.1",
+          "HTTP_FORWARDED" => "for=203.0.113.50",
+          "HTTP_X_FORWARDED_FOR" => "9.9.9.9",
+        }
+        expect(Otto::Utils.resolve_client_ip(env, depth_config(1, "Forwarded"))).to eq("203.0.113.50")
+      end
+    end
+
+    context "header = 'Both'" do
+      it "prefers the Forwarded header when it carries a for=" do
+        env = {
+          "REMOTE_ADDR" => "10.0.0.1",
+          "HTTP_FORWARDED" => "for=203.0.113.50",
+          "HTTP_X_FORWARDED_FOR" => "9.9.9.9, 8.8.8.8",
+        }
+        expect(Otto::Utils.resolve_client_ip(env, depth_config(1, "Both"))).to eq("203.0.113.50")
+      end
+
+      it "falls back to X-Forwarded-For when Forwarded is absent" do
+        env = { "REMOTE_ADDR" => "10.0.0.1", "HTTP_X_FORWARDED_FOR" => "203.0.113.50" }
+        expect(Otto::Utils.resolve_client_ip(env, depth_config(1, "Both"))).to eq("203.0.113.50")
+      end
+
+      it "falls back to X-Forwarded-For when Forwarded has no for= param" do
+        env = {
+          "REMOTE_ADDR" => "10.0.0.1",
+          "HTTP_FORWARDED" => "proto=https",
+          "HTTP_X_FORWARDED_FOR" => "203.0.113.50",
+        }
+        expect(Otto::Utils.resolve_client_ip(env, depth_config(1, "Both"))).to eq("203.0.113.50")
+      end
+
+      it "does not merge chains: a present Forwarded shadows X-Forwarded-For" do
+        # depth 2 against Forwarded alone (1 hop + peer) is a short chain → peer,
+        # proving XFF was not appended to extend the Forwarded chain.
+        env = {
+          "REMOTE_ADDR" => "10.0.0.1",
+          "HTTP_FORWARDED" => "for=203.0.113.50",
+          "HTTP_X_FORWARDED_FOR" => "198.51.100.7, 198.51.100.8",
+        }
+        expect(Otto::Utils.resolve_client_ip(env, depth_config(2, "Both"))).to eq("10.0.0.1")
+      end
+    end
+
+    it "defaults to X-Forwarded-For when no header is configured" do
+      cfg = Otto::Security::Config.new
+      cfg.trusted_proxy_depth = 1
+      env = { "REMOTE_ADDR" => "10.0.0.1", "HTTP_X_FORWARDED_FOR" => "203.0.113.50" }
+      expect(Otto::Utils.resolve_client_ip(env, cfg)).to eq("203.0.113.50")
+    end
+  end
 end

--- a/spec/otto/utils_spec.rb
+++ b/spec/otto/utils_spec.rb
@@ -380,6 +380,19 @@ RSpec.describe Otto::Utils do
         expect(Otto::Utils.resolve_client_ip(env, depth_config(1, "Forwarded"))).to eq("203.0.113.50")
       end
 
+      it "does not truncate a quoted for= whose value contains a semicolon" do
+        # The ';' is inside the DQUOTEs, so the value is '203.0.113.50;ext' — not
+        # a valid IP. It must fall back to REMOTE_ADDR, not be truncated to a
+        # valid-looking '203.0.113.50'.
+        env = { "REMOTE_ADDR" => "10.0.0.1", "HTTP_FORWARDED" => 'for="203.0.113.50;ext"' }
+        expect(Otto::Utils.resolve_client_ip(env, depth_config(1, "Forwarded"))).to eq("10.0.0.1")
+      end
+
+      it "parses a real ;-separated param following a quoted for=" do
+        env = { "REMOTE_ADDR" => "10.0.0.1", "HTTP_FORWARDED" => 'for="203.0.113.50";proto=https' }
+        expect(Otto::Utils.resolve_client_ip(env, depth_config(1, "Forwarded"))).to eq("203.0.113.50")
+      end
+
       it "ignores a forged leftmost entry (padding-robust, counts from right)" do
         env = {
           "REMOTE_ADDR" => "10.0.0.1",

--- a/spec/security_config_spec.rb
+++ b/spec/security_config_spec.rb
@@ -435,6 +435,22 @@ RSpec.describe Otto::Security::Config do
       end
     end
 
+    it 'matches case-insensitively and canonicalizes the stored spelling' do
+      {
+        'forwarded' => 'Forwarded',
+        'BOTH' => 'Both',
+        'x-forwarded-for' => 'X-Forwarded-For',
+      }.each do |input, canonical|
+        config.trusted_proxy_header = input
+        expect(config.trusted_proxy_header).to eq(canonical)
+      end
+    end
+
+    it 'ignores surrounding whitespace when canonicalizing' do
+      config.trusted_proxy_header = '  Both  '
+      expect(config.trusted_proxy_header).to eq('Both')
+    end
+
     it 'rejects an unrecognized header at assignment' do
       expect { config.trusted_proxy_header = 'X-Real-IP' }
         .to raise_error(ArgumentError, /must be one of/)

--- a/spec/security_config_spec.rb
+++ b/spec/security_config_spec.rb
@@ -423,6 +423,45 @@ RSpec.describe Otto::Security::Config do
     end
   end
 
+  describe 'trusted_proxy_header (depth-mode forwarded header)' do
+    it 'defaults to X-Forwarded-For' do
+      expect(config.trusted_proxy_header).to eq('X-Forwarded-For')
+    end
+
+    it 'reads back each recognized value' do
+      %w[X-Forwarded-For Forwarded Both].each do |header|
+        config.trusted_proxy_header = header
+        expect(config.trusted_proxy_header).to eq(header)
+      end
+    end
+
+    it 'rejects an unrecognized header at assignment' do
+      expect { config.trusted_proxy_header = 'X-Real-IP' }
+        .to raise_error(ArgumentError, /must be one of/)
+    end
+
+    it 'rejects a nil header at assignment' do
+      expect { config.trusted_proxy_header = nil }
+        .to raise_error(ArgumentError, /must be one of/)
+    end
+
+    it 'raises FrozenError when assigned after deep_freeze!' do
+      config.deep_freeze!
+      expect { config.trusted_proxy_header = 'Forwarded' }.to raise_error(FrozenError)
+    end
+
+    it 'backstops an invalid header set via a direct ivar path at freeze' do
+      config.instance_variable_set(:@trusted_proxy_header, 'bogus') # bypass the eager setter
+      expect { config.deep_freeze! }
+        .to raise_error(ArgumentError, /must be one of/)
+    end
+
+    it 'is exposed as TRUSTED_PROXY_HEADERS' do
+      expect(Otto::Security::Config::TRUSTED_PROXY_HEADERS)
+        .to contain_exactly('X-Forwarded-For', 'Forwarded', 'Both')
+    end
+  end
+
   describe 'request size validation' do
     describe '#validate_request_size' do
       it 'accepts requests within size limit' do


### PR DESCRIPTION
## Summary

Closes #150. Brings otto's count-based **depth** client-IP resolution to parity with OneTimeSecret's `site.network.trusted_proxy.header`, so the downstream `ClientIpHelpers` / `ConfigureTrustedProxy` depth path can be deleted (onetimesecret#3436).

Two logical changes on this branch:

### 1. RFC 7239 `Forwarded` / `Both` header support in depth mode (#150)

Depth previously counted hops only from `X-Forwarded-For`. It can now read from a configurable header.

- **`Otto::Security::Config#trusted_proxy_header`** — `X-Forwarded-For` (default), `Forwarded` (RFC 7239), or `Both`. Eager validation, `FrozenError` guard, freeze-time backstop, and a `TRUSTED_PROXY_HEADERS` constant, mirroring `#trusted_proxy_depth`.
- **`Otto::Utils.resolve_client_ip_by_depth`** selects the hop chain by header. RFC 7239 parsing extracts each forwarded-element's `for=` (case-insensitive, unquoted) and handles quoted IPv6 with a port (`for="[2001:db8::1]:443"`), obfuscated (`for=_hidden`) / `for=unknown` identifiers, and multiple / comma-joined `Forwarded` values.
- **`Both` precedence (fallback, not merge):** `Forwarded` when it carries a `for=`, otherwise `X-Forwarded-For`; the two chains are never concatenated — matches OTS's `extract_rfc7239_forwarded(env) || extract_x_forwarded_for(env)`.
- Wired through `Configurator#configure` (`trusted_proxy_header:`) and the top-level `Otto.new` / `configure_security` option, alongside `trusted_proxy_depth`.
- **Depth safety properties preserved across all modes** (intentionally *not* reconciled down to OTS, per #3436/#150): raw position counting (junk can't shift the index), short-chain → `REMOTE_ADDR` fallback, and single-value `X-Real-IP` / `X-Client-IP` still ignored. The depth off-by-one (#151) remains an OTS-side `+1` remap.

### 2. Release-workflow fix (`bundle exec rake release`)

`release-gem.yml` (`rubygems/release-gem`) runs `bundle exec rake release`, which failed with *"can't find executable rake for gem rake"* — the repo had neither `rake` in the bundle nor a `Rakefile` defining the release task.

- Add `rake` to the Gemfile dev group and lock it (`rake 13.1.0`), keeping `BUNDLED WITH` at `2.7.1` so CI's bundler is unchanged and the locked install stays a no-op (keeps `release:guard_clean` clean).
- Add a `Rakefile` (`bundler/gem_tasks` + a guarded RSpec default task).

## Versioning

Bumps `Otto::VERSION` to **2.3.1** (this feature ships in 2.3.1; 2.3.0 is being released manually) and syncs the `Gemfile.lock` path version.

## Testing

- New specs: per-header resolution, quoted IPv6, `Both` precedence (incl. no-merge), multi-element / raw-position counting, short-chain & obfuscated fallback (`spec/otto/utils_spec.rb`); header validation + freeze backstop (`spec/security_config_spec.rb`); configurator wiring (`spec/otto/security/configurator_spec.rb`).
- The full rspec suite was not run in the authoring sandbox (no bundle install available); behavior was verified against the real source via standalone harnesses (17/17 resolver scenarios, 10/10 config checks) and every changed file passes `ruby -c`. CI runs the suite.

Refs: #150, #151, onetimesecret#3436, onetimesecret#3116

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GK6GKxagpw7fr7aiRS47S5)_