### PR TITLE
Fix release-gem workflow: install rake from the optional :development group

### DIFF
--- a/.github/workflows/release-gem.yml
+++ b/.github/workflows/release-gem.yml
@@ -114,6 +114,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
+    # `rake` lives in the optional :development group (see Gemfile), so a plain
+    # `bundle install` skips it and rubygems/release-gem's `bundle exec rake
+    # release` dies with "rake is not currently included in the bundle". Opt the
+    # group in for the whole job: setup-ruby's cached `bundle install` reads
+    # BUNDLE_WITH so rake is installed, and the release step's `bundle exec`
+    # reads it too so rake stays in the resolved bundle. This mirrors the
+    # `bundle config set --local with` that ci.yml uses for the same groups.
+    env:
+      BUNDLE_WITH: development
+
     environment:
       name: rubygems.org
       url: https://rubygems.org/gems/otto


### PR DESCRIPTION
## Summary

The `Release Gem` workflow fails before it can publish:

```
Run bundle exec rake release
bundler: failed to load command: rake
can't find executable rake for gem rake. rake is not currently included in the
bundle, perhaps you meant to add it to your Gemfile? (Gem::Exception)
```

`rubygems/release-gem` runs `bundle exec rake release`, but `rake` lives in
otto's **optional** `:development` group. The Gemfile marks `:development` /
`:test` optional (`group :development, :test, optional: true`), and Bundler
applies optionality per *group name* — so a plain `bundle install` skips the
group entirely. `ruby/setup-ruby`'s `bundler-cache: true` runs exactly such a
plain install, so `rake` was never in the bundle.

This is by design in otto: every workflow that needs those gems opts in
explicitly. `ci.yml` does it with `bundle config set --local with
'development test'`. The release workflow simply never opted in. (For contrast,
`onetimesecret/rhales` uses the same `rubygems/release-gem` flow with `rake` in
`:development`, but its groups are *not* optional, so a default install picks
rake up — which is why it works.)

## Fix

Set `BUNDLE_WITH: development` at the **job** level in `release-gem.yml`.

Job level (not step level) is required because the value must be present in two
places:

1. when `ruby/setup-ruby` runs its cached `bundle install` (so rake gets
   installed), and
2. when `rubygems/release-gem` later runs `bundle exec rake release` (so rake
   stays in the resolved bundle — otherwise Bundler re-excludes the optional
   group at exec time and the same error returns).

Only `development` is requested (rake + `bundler/gem_tasks` is all `rake
release` needs); the `:test` gems are not pulled in.

## Notes

- The earlier commit "Add rake + Rakefile…" put rake in `:development` on the
  assumption that was sufficient, but because that group is optional it was
  never installed in the release job. This change is what actually makes rake
  reachable.
- Verified locally: a default `bundle install` resolves 11 runtime gems with no
  rake; `BUNDLE_WITH=development` brings rake into the bundle. The workflow
  itself only runs on `release: published`, so the end-to-end proof is the next
  published release. Happy to add a `workflow_dispatch` trigger for a dry run if
  you'd like one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169yDYRtaiDaKC6k7T3twks

---
_Generated by [Claude Code](https://claude.ai/code/session_0169yDYRtaiDaKC6k7T3twks)_