### PR TITLE
ci: Ruby 3.2 floor, Claude model selection + workflow standardization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
         # `require_relative 'file/write.rb'` against a file deleted in
         # the same release, the reason 2.0.2 exists.
         include:
+          - ruby: "3.2"
+            experimental: false
+            lockfile: "locked"
           - ruby: "3.3"
             experimental: false
             lockfile: "locked"
@@ -49,6 +52,9 @@ jobs:
           - ruby: "4.0"
             experimental: true
             lockfile: "locked"
+          - ruby: "3.2"
+            experimental: false
+            lockfile: "unlocked"
           - ruby: "3.3"
             experimental: false
             lockfile: "unlocked"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,6 +4,16 @@ on:
   pull_request:
     types: [opened, synchronize, labeled]
   workflow_dispatch:
+    inputs:
+      model:
+        description: "Claude model for this run (overrides the CLAUDE_MODEL repo variable)"
+        type: choice
+        required: false
+        default: claude-opus-4-6
+        options:
+          - claude-opus-4-6
+          - claude-sonnet-4-6
+          - claude-haiku-4-5-20251001
 
 jobs:
   claude-review:
@@ -37,10 +47,12 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Fall back to Sonnet when the primary model is unavailable/overloaded.
-          # Without this, an unavailable primary surfaces as "Claude encountered
-          # an error" and fails the claude-review check.
-          fallback_model: "claude-sonnet-4-6"
+          # Primary model precedence: the workflow_dispatch "model" input (manual
+          # runs) -> the CLAUDE_MODEL repo variable -> this built-in default.
+          # Pinning a current id avoids the action's frozen default, which 404s
+          # ("model: claude-sonnet-4-20250514"). Fall back to Sonnet on overload.
+          model: "${{ inputs.model || vars.CLAUDE_MODEL || 'claude-opus-4-6' }}"
+          fallback_model: "${{ vars.CLAUDE_FALLBACK_MODEL || 'claude-sonnet-4-6' }}"
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,10 +36,12 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Fall back to Sonnet when the primary model is unavailable/overloaded.
-          # Without this, an unavailable primary surfaces as "Claude encountered
-          # an error" and fails the claude-review check.
-          fallback_model: "claude-sonnet-4-6"
+          # Primary model: set the CLAUDE_MODEL repo variable to override without
+          # editing this file. Pinning a current id avoids the action's frozen
+          # default, which 404s ("model: claude-sonnet-4-20250514"). Fall back to
+          # Sonnet if the primary is unavailable or overloaded.
+          model: "${{ vars.CLAUDE_MODEL || 'claude-opus-4-6' }}"
+          fallback_model: "${{ vars.CLAUDE_FALLBACK_MODEL || 'claude-sonnet-4-6' }}"
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Summary

Three parts.

### 1. Ruby 3.2 floor
- `ci.yml` — add Ruby `3.2` (locked + unlocked, non-experimental). The gemspec declares `required_ruby_version = ['>= 3.2', '< 4.1']` but CI only ran `3.3`+. Alternative if 3.2 isn't really supported: bump the gemspec floor to `>= 3.3`.

### 2. Claude model selection
- `claude.yml` / `claude-code-review.yml` — pin a primary `model` via `CLAUDE_MODEL` (default `claude-opus-4-6`), drive `fallback_model` from `CLAUDE_FALLBACK_MODEL`, add a `workflow_dispatch` model choice input on the review workflow.

### 3. Workflow standardization (shared with familia/rhales)
- **`ruby-lint.yml`** (new) — RuboCop across Ruby 3.2–4.0, informational (`continue-on-error`). The repo shipped a `.rubocop.yml` but never ran it in CI.
- **`yardoc.yml` + `.yardopts`** (new) — build and deploy YARD API docs to GitHub Pages, matching familia/rhales. Adds `yard` + `kramdown` to the dev bundle.
- **`claude-code-review.yml`** — port the **fork/bot guard** (skip bot actors and fork PRs that lack secrets).

## ⚠️ Action required for docs
GitHub Pages must be enabled for the deploy job to succeed: **Settings → Pages → Source: GitHub Actions**. Until then the `build-docs` job passes but `deploy-pages` will fail on pushes to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9DBMriY9snxDUEAG7EJE4