### PR TITLE
ci: workflow standardization (RuboCop lint, YARD docs, fork/bot guard)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,10 +24,21 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     runs-on: ubuntu-latest
-    if: |
-      (github.event.action == 'opened') ||
-      (github.event.action == 'labeled' && github.event.label.name == 'claude-review') ||
-      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'claude-review'))
+    # Run only when ALL of the following hold:
+    #   1. Author is not a bot (renovate, dependabot, etc. surface as 'name[bot]').
+    #   2. PR head is not from a fork. Fork PRs run without repository secrets, so
+    #      CLAUDE_CODE_OAUTH_TOKEN is empty and the action would fail.
+    #   3. The event is a freshly opened PR, a 'claude-review' label add, or a push
+    #      to a PR that already carries the 'claude-review' label.
+    if: ${{
+      !endsWith(github.actor, '[bot]') &&
+      !github.event.pull_request.head.repo.fork &&
+      (
+        (github.event.action == 'opened') ||
+        (github.event.action == 'labeled' && github.event.label.name == 'claude-review') ||
+        (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'claude-review'))
+      )
+      }}
 
     permissions:
       contents: read

--- a/.github/workflows/ruby-lint.yml
+++ b/.github/workflows/ruby-lint.yml
@@ -1,0 +1,66 @@
+# .github/workflows/ruby-lint.yml
+
+name: Ruby Lint
+
+# Runs RuboCop across the supported Ruby versions. Linting is informational:
+# every dependency/lint step is continue-on-error, so style findings surface as
+# annotations without blocking merges.
+
+on:
+  push:
+    branches:
+      - fix/*
+      - rel/*
+  pull_request:
+    branches:
+      - main
+      - develop
+      - feature/*
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    timeout-minutes: 10 # prevent hung jobs
+
+    runs-on: ubuntu-24.04
+
+    strategy:
+      fail-fast: true
+      matrix:
+        ruby: ['3.2', '3.3', '3.4', '3.5', '4.0']
+        continue-on-error: [true]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.3
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@7b6a61a73bbb9793cb80ad69b8dd8ac19261834c # v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+        with:
+          detached: true
+
+      - name: Install dependencies
+        continue-on-error: ${{ matrix.continue-on-error }}
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+
+      - name: Run Rubocop
+        continue-on-error: ${{ matrix.continue-on-error }}
+        run: |
+          bundle exec rubocop --config .rubocop.yml --format json --fail-level warning

--- a/.github/workflows/yardoc.yml
+++ b/.github/workflows/yardoc.yml
@@ -1,0 +1,110 @@
+name: Generate and Deploy YARD Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'lib/**/*'
+      - 'docs/**/*'
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - 'CHANGELOG.rst'
+      - 'LICENSE.txt'
+      - '.yardopts'
+      - '.github/workflows/yardoc.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run
+# in-progress and latest queued. Do NOT cancel in-progress runs so production
+# deployments can complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build-docs:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    name: Generate YARD Documentation
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Ruby environment
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+
+      - name: Generate documentation
+        # Uses the repository's committed .yardopts as the single source of
+        # truth for the output dir, includes/excludes, markup, and tags.
+        run: |
+          echo "::group::YARD Documentation Generation"
+          bundle exec yard stats --list-undoc || true
+          bundle exec yard doc
+          echo "::endgroup::"
+
+      - name: Disable Jekyll processing
+        # YARD emits files and directories that begin with underscores; the
+        # .nojekyll marker stops GitHub Pages from stripping them.
+        run: touch doc/.nojekyll
+
+      - name: Validate documentation output
+        run: |
+          echo "::group::Documentation Validation"
+          if [ ! -d "doc" ]; then
+            echo "Error: documentation directory 'doc' was not generated." >&2
+            echo "Ensure .yardopts sets '--output-dir doc'." >&2
+            exit 1
+          fi
+          if [ ! -f "doc/index.html" ]; then
+            echo "Warning: doc/index.html not found"
+          fi
+          echo "Generated HTML files: $(find doc -name '*.html' | wc -l)"
+          echo "Total documentation size: $(du -sh doc/ | cut -f1)"
+          echo "::endgroup::"
+
+      - name: Setup GitHub Pages configuration
+        uses: actions/configure-pages@v4
+
+      - name: Upload documentation artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './doc'
+
+  deploy-pages:
+    timeout-minutes: 10
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build-docs
+    outputs:
+      page_url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+  notify-completion:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    needs: [build-docs, deploy-pages]
+    if: success()
+
+    steps:
+      - name: Documentation deployment summary
+        run: |
+          echo "::notice title=Documentation Deployed::YARD documentation successfully deployed to GitHub Pages"
+          echo "::notice title=Access URL::Documentation available at: ${{ needs.deploy-pages.outputs.page_url }}"

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,15 @@
+--readme README.md
+--title "Otto Ruby Library Documentation"
+--protected
+--no-private
+--markup markdown
+--markup-provider kramdown
+--output-dir doc
+--exclude lib/otto/version.rb
+lib/**/*.rb
+-
+README.md
+CHANGELOG.rst
+LICENSE.txt
+docs/**/*.md
+examples/*.rb

--- a/Gemfile
+++ b/Gemfile
@@ -36,4 +36,6 @@ group :development do
   gem 'stackprof', require: false
   gem 'syntax_tree', require: false
   gem 'tryouts', '~> 3.7.1', require: false
+  gem 'yard', '~> 0.9', require: false # API docs for yardoc.yml
+  gem 'kramdown', require: false # Markdown provider for YARD
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,8 @@ GEM
       hana (~> 1.3)
       regexp_parser (~> 2.0)
       simpleidn (~> 0.2)
+    kramdown (2.5.2)
+      rexml (>= 3.4.4)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -197,6 +199,7 @@ GEM
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
     user_agent_parser (2.21.0)
+    yard (0.9.44)
     zeitwerk (2.7.3)
 
 PLATFORMS
@@ -213,6 +216,7 @@ DEPENDENCIES
   benchmark
   debug
   json_schemer
+  kramdown
   otto!
   rack-attack
   rack-test
@@ -229,6 +233,7 @@ DEPENDENCIES
   syntax_tree
   tryouts (~> 3.7.1)
   user_agent_parser (~> 2.18)
+  yard (~> 0.9)
 
 BUNDLED WITH
    2.7.1


### PR DESCRIPTION
## Summary

Follow-up to #162 (merged). That PR landed the Ruby 3.2 floor + Claude model config; this one carries the **workflow standardization** that hadn't been split into its own PR yet.

## Changes
- **`ruby-lint.yml`** (new) — RuboCop across Ruby 3.2–4.0, informational (`continue-on-error`). The repo shipped a `.rubocop.yml` but never ran it in CI.
- **`yardoc.yml` + `.yardopts`** (new) — build and deploy YARD API docs to GitHub Pages, matching familia/rhales. Adds `yard` + `kramdown` to the dev bundle. Verified locally: `yard 0.9.44` emits `doc/index.html` + 123 HTML files (78.6% documented).
- **`claude-code-review.yml`** — port the **fork/bot guard** (skip `*[bot]` actors and fork PRs that lack secrets).

## ⚠️ Action required for docs
GitHub Pages must be enabled for the deploy job to succeed: **Settings → Pages → Source: GitHub Actions**. Until then `build-docs` passes but `deploy-pages` fails on pushes to `main`.

Part of a 3-repo set (familia/otto/rhales). Squash-merge recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9DBMriY9snxDUEAG7EJE4

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9DBMriY9snxDUEAG7EJE4)_