### PR TITLE
ci: fix YARD docs build — install dev gems (yard/kramdown) via BUNDLE_WITH

### DIFF
--- a/.github/workflows/yardoc.yml
+++ b/.github/workflows/yardoc.yml
@@ -32,6 +32,13 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     name: Generate YARD Documentation
+    env:
+      # otto declares yard/kramdown in a `group :development` whose name also
+      # appears in an `optional: true` block, so Bundler treats `development`
+      # as optional and the default `bundle install` skips it (yard never
+      # installs -> `bundle exec yard` is "command not found"). Mirror otto's
+      # ci.yml convention so setup-ruby installs the dev/test gems.
+      BUNDLE_WITH: "development:test"
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Hotfix for the docs deploy that broke after #163 merged. The post‑merge `Generate and Deploy YARD Documentation` run [failed](https://github.com/delano/otto/actions/runs/28002836694) with:

```
bundler: command not found: yard
```

## Root cause

otto declares `yard` + `kramdown` in `group :development`, but that group name **also** appears in an `optional: true` block, so Bundler treats `development` as optional. The default `bundle install` (run by `setup-ruby` with `bundler-cache: true`) therefore **skips** it — only 11 gems install, `yard` not among them. `ci.yml` already works around this with `bundle config set --local with 'development test'`.

familia and rhales install `yard` by default (no optional‑group collision), so their docs deploys succeeded — this is otto‑specific.

## Fix

Set `BUNDLE_WITH: "development:test"` on the `build-docs` job so `setup-ruby`'s bundle install includes the dev/test gems.

**Verified locally** (Bundler 2.7.1): `bundle install` → 78 gems, then `bundle exec yard doc` → `doc/index.html` + 123 HTML files (78.6% documented).

## Note
This only fixes the **build**. The `deploy-pages` step still needs **Settings → Pages → Source: GitHub Actions** enabled on otto; once this is merged and Pages is set, docs publish to `delanotes.com/otto`. I'll re-check after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9DBMriY9snxDUEAG7EJE4

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9DBMriY9snxDUEAG7EJE4)_