### PR TITLE
Fix Rack SPEC violations in IPPrivacyMiddleware (issue #167)

### DIFF
--- a/changelog.d/20260624_000000_claude_issue-167.rst
+++ b/changelog.d/20260624_000000_claude_issue-167.rst
@@ -1,0 +1,22 @@
+Fixed
+-----
+
+- ``IPPrivacyMiddleware`` no longer writes ``nil`` to CGI-style Rack env keys
+  when redacting request data. Assigning ``nil`` to a period-less key (e.g.
+  ``HTTP_REFERER``, ``HTTP_USER_AGENT``, ``REMOTE_ADDR``) violates the Rack SPEC
+  and trips ``Rack::Lint`` (commonly enabled in development). When the
+  anonymized ``Referer`` / ``User-Agent`` is empty the key is now deleted
+  instead of set to ``nil`` — semantically identical to "cleared", and
+  marginally more private since an absent header is indistinguishable from one
+  never sent. A request with no resolvable client IP (absent or blank
+  ``REMOTE_ADDR``) is also no longer rewritten to a present-but-``nil``
+  ``REMOTE_ADDR``; masking is skipped, leaving the value untouched.
+  (delano/otto#167)
+
+AI Assistance
+-------------
+
+- Diagnosed the Rack SPEC violation and, after fixing the reported
+  ``Referer`` / ``User-Agent`` case, swept the middleware for sibling
+  ``nil``-into-CGI-key bugs — surfacing and fixing the ``REMOTE_ADDR`` masking
+  path — with AI assistance, including ``Rack::Lint`` integration test coverage.

--- a/lib/otto/security/middleware/ip_privacy_middleware.rb
+++ b/lib/otto/security/middleware/ip_privacy_middleware.rb
@@ -85,6 +85,19 @@ class Otto
 
           Otto.logger.debug "[IPPrivacyMiddleware] Resolved client IP: #{client_ip}" if Otto.debug
 
+          # No resolvable client IP (REMOTE_ADDR absent or blank, and no trusted
+          # forwarded value). There is nothing to mask, and masking would derive
+          # a nil masked IP (IPPrivacy.mask_ip returns nil for nil/empty input).
+          # Writing that nil back to REMOTE_ADDR / forwarded headers would leave
+          # present-but-nil CGI keys, which violate the Rack SPEC and trip
+          # Rack::Lint — the same class of bug as the User-Agent/Referer case
+          # above (issue #167). Bail out, leaving REMOTE_ADDR untouched (an
+          # absent key stays absent; an empty string stays an empty string).
+          if client_ip.to_s.empty?
+            Otto.logger.debug '[IPPrivacyMiddleware] No resolvable client IP; skipping masking' if Otto.debug
+            return
+          end
+
           # Skip masking for private/localhost IPs unless explicitly configured to mask them
           # This provides better DX for development while still protecting public IPs
           unless @config.mask_private_ips
@@ -122,13 +135,18 @@ class Otto
           # Privacy-safe: holds the masked value, never the original public IP.
           env['otto.client_ip'] = fingerprint.masked_ip
 
-          # Replace User-Agent with anonymized version (consistent with IP masking)
-          # CRITICAL: Always replace, even if nil, to clear original sensitive data
-          env['HTTP_USER_AGENT'] = fingerprint.anonymized_ua
+          # Replace User-Agent with anonymized version (consistent with IP masking).
+          # CRITICAL: Always clear original sensitive data. When anonymization
+          # yields nil (no/empty UA), DELETE the key rather than assigning nil:
+          # the Rack SPEC requires CGI-style keys (no period) to hold String
+          # values, and a present-but-nil HTTP_USER_AGENT trips Rack::Lint.
+          # Deleting is also marginally more private — an absent header is
+          # indistinguishable from one that was never sent.
+          replace_or_delete(env, 'HTTP_USER_AGENT', fingerprint.anonymized_ua)
 
-          # Replace Referer with anonymized version (query params stripped)
-          # CRITICAL: Always replace, even if nil, to clear original sensitive data
-          env['HTTP_REFERER'] = fingerprint.referer
+          # Replace Referer with anonymized version (query params stripped).
+          # Same Rack SPEC concern as User-Agent above: delete on nil.
+          replace_or_delete(env, 'HTTP_REFERER', fingerprint.referer)
 
           # Mask X-Forwarded-For headers to prevent leakage
           # Replace with masked IP so proxy resolution logic finds the masked IP
@@ -140,6 +158,25 @@ class Otto
           # or env['otto.original_referer']. This prevents accidental leakage of the real values.
         end
 
+
+        # Set or clear a Rack env header in a SPEC-compliant way.
+        #
+        # CGI-style keys (those without a period) must hold String values per
+        # the Rack SPEC; a present-but-nil value trips Rack::Lint. So when the
+        # anonymized replacement is nil, delete the key entirely instead of
+        # assigning nil — semantically identical to "cleared" for downstream
+        # readers, and SPEC-compliant.
+        #
+        # @param env [Hash] Rack environment
+        # @param key [String] Env key to set or delete
+        # @param value [String, nil] Replacement value, or nil to clear the key
+        def replace_or_delete(env, key, value)
+          if value.nil?
+            env.delete(key)
+          else
+            env[key] = value
+          end
+        end
 
         # Resolve the actual client IP address from the request.
         #

--- a/lib/otto/security/middleware/ip_privacy_middleware.rb
+++ b/lib/otto/security/middleware/ip_privacy_middleware.rb
@@ -91,10 +91,18 @@ class Otto
           # Writing that nil back to REMOTE_ADDR / forwarded headers would leave
           # present-but-nil CGI keys, which violate the Rack SPEC and trip
           # Rack::Lint — the same class of bug as the User-Agent/Referer case
-          # above (issue #167). Bail out, leaving REMOTE_ADDR untouched (an
-          # absent key stays absent; an empty string stays an empty string).
+          # below (issue #167). Skip the IP-masking work, leaving REMOTE_ADDR
+          # untouched (an absent key stays absent; an empty string stays an
+          # empty string).
+          #
+          # The User-Agent/Referer redaction, however, is independent of the
+          # client IP, and this middleware's contract is to ALWAYS clear the
+          # original sensitive data. So still scrub those headers before
+          # bailing — a request with no resolvable IP must not leak an
+          # un-anonymized User-Agent or Referer.
           if client_ip.to_s.empty?
-            Otto.logger.debug '[IPPrivacyMiddleware] No resolvable client IP; skipping masking' if Otto.debug
+            Otto.logger.debug '[IPPrivacyMiddleware] No resolvable client IP; skipping IP masking' if Otto.debug
+            scrub_sensitive_headers(env, Otto::Privacy::RedactedFingerprint.new(env, @config))
             return
           end
 
@@ -135,18 +143,10 @@ class Otto
           # Privacy-safe: holds the masked value, never the original public IP.
           env['otto.client_ip'] = fingerprint.masked_ip
 
-          # Replace User-Agent with anonymized version (consistent with IP masking).
-          # CRITICAL: Always clear original sensitive data. When anonymization
-          # yields nil (no/empty UA), DELETE the key rather than assigning nil:
-          # the Rack SPEC requires CGI-style keys (no period) to hold String
-          # values, and a present-but-nil HTTP_USER_AGENT trips Rack::Lint.
-          # Deleting is also marginally more private — an absent header is
-          # indistinguishable from one that was never sent.
-          replace_or_delete(env, 'HTTP_USER_AGENT', fingerprint.anonymized_ua)
-
-          # Replace Referer with anonymized version (query params stripped).
-          # Same Rack SPEC concern as User-Agent above: delete on nil.
-          replace_or_delete(env, 'HTTP_REFERER', fingerprint.referer)
+          # Replace User-Agent / Referer with anonymized versions (consistent
+          # with IP masking). See scrub_sensitive_headers — also reached by the
+          # no-resolvable-IP path so these headers are always cleared.
+          scrub_sensitive_headers(env, fingerprint)
 
           # Mask X-Forwarded-For headers to prevent leakage
           # Replace with masked IP so proxy resolution logic finds the masked IP
@@ -176,6 +176,26 @@ class Otto
           else
             env[key] = value
           end
+        end
+
+        # Redact the request's sensitive non-IP headers in place.
+        #
+        # User-Agent and Referer carry identifying information independent of
+        # the client IP, so they are scrubbed on every privacy-enabled request
+        # — including ones with no resolvable IP, where IP masking is skipped.
+        # Each header is replaced with the fingerprint's anonymized value, or
+        # DELETED when that value is nil (no/empty header): CGI-style keys must
+        # hold String values per the Rack SPEC, so a present-but-nil
+        # HTTP_USER_AGENT/HTTP_REFERER would trip Rack::Lint (issue #167).
+        # Deleting is also marginally more private — an absent header is
+        # indistinguishable from one that was never sent.
+        #
+        # @param env [Hash] Rack environment
+        # @param fingerprint [Otto::Privacy::RedactedFingerprint] source of the
+        #   anonymized header values
+        def scrub_sensitive_headers(env, fingerprint)
+          replace_or_delete(env, 'HTTP_USER_AGENT', fingerprint.anonymized_ua)
+          replace_or_delete(env, 'HTTP_REFERER', fingerprint.referer)
         end
 
         # Resolve the actual client IP address from the request.

--- a/lib/otto/security/middleware/ip_privacy_middleware.rb
+++ b/lib/otto/security/middleware/ip_privacy_middleware.rb
@@ -199,6 +199,14 @@ class Otto
         # @param env [Hash] Rack environment
         # @param masked_ip [String] The masked IP to use as replacement
         def mask_forwarded_headers(env, masked_ip)
+          # Defensive: never write a nil replacement into these CGI-style headers
+          # (the Rack SPEC requires String values; a nil trips Rack::Lint — see
+          # issue #167). apply_privacy's early "no client IP" guard already
+          # guarantees a non-nil masked_ip here, but keep this method
+          # self-contained so a future caller change can't reintroduce a
+          # present-but-nil HTTP_X_FORWARDED_FOR.
+          return if masked_ip.nil?
+
           # Replace X-Forwarded-For with masked IP
           # This prevents Rack::Request#ip from finding the real IP
           env['HTTP_X_FORWARDED_FOR'] = masked_ip if env['HTTP_X_FORWARDED_FOR']

--- a/spec/otto/ip_privacy_spec.rb
+++ b/spec/otto/ip_privacy_spec.rb
@@ -1032,6 +1032,37 @@ RSpec.describe 'IP Privacy Features' do
         expect(env['HTTP_REFERER']).to eq('https://example.com/page')
         expect(env['HTTP_USER_AGENT']).to include('*.*')
       end
+
+      # Regression (PR #168 review): the no-resolvable-IP guard skips IP
+      # masking, but User-Agent / Referer redaction is independent of the IP
+      # and must still happen — otherwise a request with no REMOTE_ADDR would
+      # leak an un-anonymized User-Agent and a query-bearing Referer.
+      it 'still anonymizes Referer and User-Agent when REMOTE_ADDR is absent' do
+        env = lint_valid_env(  # no REMOTE_ADDR
+          'HTTP_USER_AGENT' => 'Mozilla/5.0 Chrome/141.0',
+          'HTTP_REFERER'    => 'https://example.com/page?token=secret'
+        )
+
+        expect { lint_middleware.call(env) }.not_to raise_error
+        # IP masking is skipped (no IP to mask), but sensitive headers are scrubbed
+        expect(env).not_to have_key('REMOTE_ADDR')
+        expect(env['HTTP_REFERER']).to eq('https://example.com/page')
+        expect(env['HTTP_USER_AGENT']).to include('*.*')
+        expect(env['HTTP_USER_AGENT']).not_to include('141.0')
+      end
+
+      it 'deletes empty Referer / User-Agent when REMOTE_ADDR is absent' do
+        env = lint_valid_env(  # no REMOTE_ADDR
+          'HTTP_USER_AGENT' => '',
+          'HTTP_REFERER'    => ''
+        )
+
+        expect { lint_middleware.call(env) }.not_to raise_error
+        # Anonymizing an empty header yields nil; the key must be deleted, not
+        # left present-but-nil (Rack SPEC / issue #167).
+        expect(env).not_to have_key('HTTP_USER_AGENT')
+        expect(env).not_to have_key('HTTP_REFERER')
+      end
     end
   end
 

--- a/spec/otto/ip_privacy_spec.rb
+++ b/spec/otto/ip_privacy_spec.rb
@@ -545,11 +545,29 @@ RSpec.describe 'IP Privacy Features' do
           expect(env['HTTP_USER_AGENT']).to be_nil
         end
 
+        it 'deletes the key (rather than writing nil) when there is no User-Agent' do
+          # Rack SPEC requires CGI-style keys to hold String values; a
+          # present-but-nil HTTP_USER_AGENT trips Rack::Lint (issue #167).
+          env = { 'REMOTE_ADDR' => '9.9.9.9' }
+          middleware.call(env)
+
+          expect(env).not_to have_key('HTTP_USER_AGENT')
+        end
+
         it 'handles nil Referer gracefully' do
           env = { 'REMOTE_ADDR' => '9.9.9.9' }
           middleware.call(env)
 
           expect(env['HTTP_REFERER']).to be_nil
+        end
+
+        it 'deletes the key (rather than writing nil) when there is no Referer' do
+          # Rack SPEC requires CGI-style keys to hold String values; a
+          # present-but-nil HTTP_REFERER trips Rack::Lint (issue #167).
+          env = { 'REMOTE_ADDR' => '9.9.9.9' }
+          middleware.call(env)
+
+          expect(env).not_to have_key('HTTP_REFERER')
         end
 
         it 'clears original User-Agent when anonymization returns empty string' do
@@ -559,8 +577,9 @@ RSpec.describe 'IP Privacy Features' do
           }
           middleware.call(env)
 
-          # CRITICAL: env['HTTP_USER_AGENT'] should be nil (cleared), not empty string
+          # CRITICAL: the key must be deleted, not left present-but-nil (Rack SPEC)
           expect(env['HTTP_USER_AGENT']).to be_nil
+          expect(env).not_to have_key('HTTP_USER_AGENT')
           expect(env).not_to have_key('otto.original_user_agent')
         end
 
@@ -571,8 +590,9 @@ RSpec.describe 'IP Privacy Features' do
           }
           middleware.call(env)
 
-          # CRITICAL: env['HTTP_REFERER'] should be nil (cleared), not empty string
+          # CRITICAL: the key must be deleted, not left present-but-nil (Rack SPEC)
           expect(env['HTTP_REFERER']).to be_nil
+          expect(env).not_to have_key('HTTP_REFERER')
           expect(env).not_to have_key('otto.original_referer')
         end
 
@@ -925,6 +945,92 @@ RSpec.describe 'IP Privacy Features' do
         # Original values available for legitimate use cases
         expect(env['otto.original_user_agent']).to eq('Mozilla/5.0 Chrome/141.0')
         expect(env['otto.original_referer']).to eq('https://example.com/page?secret=value')
+      end
+    end
+
+    # Rack SPEC compliance (issue #167): every CGI-style env key (one without a
+    # period) must hold a String value. The middleware must never leave a
+    # present-but-nil CGI key behind when clearing/masking request data, or it
+    # trips Rack::Lint and breaks spec-strict downstream middleware.
+    context 'Rack SPEC compliance (no nil-valued CGI keys)' do
+      require 'rack/lint'
+
+      # Build a minimal but fully Rack-SPEC-valid env. rack.input must be
+      # opened in binary mode (ASCII-8BIT) or Rack::Lint rejects it.
+      def lint_valid_env(overrides = {})
+        {
+          'REQUEST_METHOD'  => 'GET',
+          'SCRIPT_NAME'     => '',
+          'PATH_INFO'       => '/some/path',
+          'QUERY_STRING'    => '',
+          'SERVER_NAME'     => 'app.example',
+          'SERVER_PORT'     => '443',
+          'SERVER_PROTOCOL' => 'HTTP/1.1',
+          'rack.input'      => StringIO.new(''.b),
+          'rack.errors'     => StringIO.new,
+          'rack.url_scheme' => 'https'
+        }.merge(overrides)
+      end
+
+      # Wrap a passthrough app in Rack::Lint so that the env the middleware
+      # forwards downstream is validated against the Rack SPEC.
+      def lint_middleware
+        downstream = ->(_env) { [200, { 'content-type' => 'text/plain' }, ['OK']] }
+        Otto::Security::Middleware::IPPrivacyMiddleware.new(
+          Rack::Lint.new(downstream), security_config
+        )
+      end
+
+      it 'does not write a nil REMOTE_ADDR when REMOTE_ADDR is absent' do
+        env = { 'PATH_INFO' => '/x' }  # no REMOTE_ADDR at all
+        middleware.call(env)
+
+        # Must not introduce a present-but-nil REMOTE_ADDR key
+        expect(env).not_to have_key('REMOTE_ADDR')
+      end
+
+      it 'does not corrupt an empty REMOTE_ADDR into nil' do
+        env = { 'REMOTE_ADDR' => '' }
+        middleware.call(env)
+
+        # Empty string is a valid String per the Rack SPEC; must stay a String
+        expect(env['REMOTE_ADDR']).to eq('')
+        expect(env['REMOTE_ADDR']).not_to be_nil
+      end
+
+      it 'passes Rack::Lint with no Referer or User-Agent (public IP)' do
+        env = lint_valid_env('REMOTE_ADDR' => '9.9.9.9')
+
+        expect { lint_middleware.call(env) }.not_to raise_error
+      end
+
+      it 'passes Rack::Lint with empty Referer and User-Agent (public IP)' do
+        env = lint_valid_env(
+          'REMOTE_ADDR'     => '9.9.9.9',
+          'HTTP_USER_AGENT' => '',
+          'HTTP_REFERER'    => ''
+        )
+
+        expect { lint_middleware.call(env) }.not_to raise_error
+      end
+
+      it 'passes Rack::Lint when REMOTE_ADDR is absent' do
+        env = lint_valid_env  # no REMOTE_ADDR
+
+        expect { lint_middleware.call(env) }.not_to raise_error
+      end
+
+      it 'passes Rack::Lint with real Referer and User-Agent (still masked)' do
+        env = lint_valid_env(
+          'REMOTE_ADDR'     => '9.9.9.9',
+          'HTTP_USER_AGENT' => 'Mozilla/5.0 Chrome/141.0',
+          'HTTP_REFERER'    => 'https://example.com/page?token=secret'
+        )
+
+        expect { lint_middleware.call(env) }.not_to raise_error
+        # And the values were still anonymized
+        expect(env['HTTP_REFERER']).to eq('https://example.com/page')
+        expect(env['HTTP_USER_AGENT']).to include('*.*')
       end
     end
   end


### PR DESCRIPTION
## Summary

Fixed `IPPrivacyMiddleware` to comply with the Rack SPEC by never writing `nil` values to CGI-style environment keys (those without a period). The middleware now deletes keys instead of assigning `nil` when clearing sensitive request data, and skips IP masking when no resolvable client IP is available.

## Key Changes

- **User-Agent and Referer handling**: When anonymization yields `nil` (empty or absent header), the key is now deleted from the env instead of being set to `nil`. This satisfies the Rack SPEC requirement that CGI-style keys hold String values, preventing `Rack::Lint` violations.

- **IP masking path**: Added a guard to skip masking when `REMOTE_ADDR` is absent or blank. Previously, this would attempt to mask a `nil`/empty IP and write the result back to `REMOTE_ADDR`, creating a present-but-`nil` key.

- **New helper method**: Introduced `replace_or_delete()` to encapsulate the pattern of setting a key to a value or deleting it if the value is `nil`, ensuring consistent SPEC-compliant behavior across the middleware.

- **Comprehensive test coverage**: Added tests validating:
  - Keys are deleted (not set to `nil`) when headers are absent or empty
  - The middleware passes `Rack::Lint` validation in various scenarios
  - Existing anonymization behavior is preserved while fixing the SPEC violation

## Implementation Details

The fix addresses a class of bugs where the middleware would leave present-but-`nil` CGI keys in the Rack environment. Per the Rack SPEC, such keys must hold String values. Deleting the key entirely is semantically equivalent to "cleared" for downstream readers and is marginally more private — an absent header is indistinguishable from one never sent.

The IP masking path now explicitly checks for empty/absent client IPs and bails out early, preventing the derivation and assignment of `nil` masked values.

https://claude.ai/code/session_019PZ17fyRHFw6c4qrKqcgS8