### PR TITLE
Harden nonce-CSP emission onto one casing-safe apply core (#179)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,39 @@ app = Otto.new("./routes", {
 
 Security features include CSRF protection, input validation, security headers, and trusted proxy configuration.
 
+### Nonce-based CSP Emission
+
+With `enable_csp_with_nonce!`, Otto emits a per-request nonce-based
+Content-Security-Policy. There are two ways to apply it, both routed through
+one case-insensitive core (`Otto::Security::Config#write_nonce_csp`), so a
+canonically-cased `Content-Type` / `Content-Security-Policy` from a downstream
+app can never silently drop the CSP or produce a duplicate header:
+
+```ruby
+# 1. Deliberate, per-route: overrides any existing CSP (clobber: true)
+def show(req, res)
+  nonce = SecureRandom.base64(16)
+  res.send_csp_headers('text/html; charset=utf-8', nonce)
+end
+
+# 2. Passive chokepoint: mount the middleware and every HTML response gets the
+#    CSP, deferring to any policy the app already set (clobber: false).
+app.use Otto::Security::CSP::EmitMiddleware
+# The middleware ensures env['otto.nonce'] before calling the app, so views can
+# embed the same nonce the header carries. Apps with their own convention can
+# point it at theirs: use Otto::Security::CSP::EmitMiddleware, nonce_key: 'myapp.nonce'
+```
+
+Downstream applications applying a CSP at a raw response-tuple boundary can call
+the core directly — note it RETURNS the headers to use (a plain `Hash` is
+wrapped in `Rack::Headers`, which copies):
+
+```ruby
+status, headers, body = @app.call(env)
+headers = security_config.write_nonce_csp(headers, env['myapp.nonce'])
+[status, headers, body]
+```
+
 ### CSP Violation Reporting
 
 Otto can both emit Content-Security-Policy headers and receive the violation

--- a/changelog.d/20260701_220000_claude_issue-179.rst
+++ b/changelog.d/20260701_220000_claude_issue-179.rst
@@ -1,0 +1,32 @@
+Added
+-----
+
+- ``Otto::Security::Config#write_nonce_csp``: a single, case-insensitive
+  nonce-CSP apply core for Rack response headers. All lookups and writes go
+  through ``Rack::Headers``, so a canonically-cased ``Content-Type`` /
+  ``Content-Security-Policy`` at a raw response-tuple boundary can never
+  silently drop the CSP or emit a duplicate header. ``clobber:`` selects
+  between overriding an existing CSP (deliberate call) and deferring to one
+  (passive backstop). (#179)
+- ``Otto::Security::CSP::EmitMiddleware``: a mountable web chokepoint that
+  ensures a per-request nonce in ``env['otto.nonce']`` (key configurable via
+  ``nonce_key:``) and applies the nonce CSP to HTML responses via
+  ``write_nonce_csp`` with ``clobber: false``, so downstream apps no longer
+  hand-roll the HTML-only / don't-clobber / needs-nonce guards. Inert unless
+  ``csp_nonce_enabled?``. (#179)
+
+Changed
+-------
+
+- ``Otto::Response#send_csp_headers`` now routes its apply through
+  ``write_nonce_csp`` (with ``clobber: true``), keeping its default
+  content-type, override warning, and debug logging. As a result it no longer
+  emits a broken ``'nonce-'`` policy for a blank nonce, and no longer emits a
+  CSP for non-HTML content types. (#179)
+
+AI Assistance
+-------------
+
+- Shared casing-safe nonce-CSP apply core designed and implemented with AI
+  assistance, consolidating guard logic previously duplicated across
+  ``Otto::Response`` and downstream application middleware.

--- a/lib/otto/core/middleware_stack.rb
+++ b/lib/otto/core/middleware_stack.rb
@@ -275,6 +275,7 @@ class Otto
           Otto::Security::Middleware::RateLimitMiddleware,
           Otto::Security::Middleware::IPPrivacyMiddleware,
           Otto::Security::CSP::ReportMiddleware,
+          Otto::Security::CSP::EmitMiddleware,
         ].include?(middleware_class)
       end
     end

--- a/lib/otto/env_keys.rb
+++ b/lib/otto/env_keys.rb
@@ -72,6 +72,14 @@ class Otto
     #   without depending on the (masked) REMOTE_ADDR
     VIA_TRUSTED_PROXY = 'otto.via_trusted_proxy'
 
+    # Per-request CSP nonce (default key; configurable via nonce_key:)
+    # Type: String (base64)
+    # Set by: Otto::Security::CSP::EmitMiddleware (generated when absent;
+    #   an existing value — set upstream or by the application — is respected)
+    # Used by: views/templates embedding the nonce, EmitMiddleware when
+    #   applying the Content-Security-Policy header on the response
+    NONCE = 'otto.nonce'
+
     # =========================================================================
     # LOCALIZATION (I18N)
     # =========================================================================

--- a/lib/otto/response.rb
+++ b/lib/otto/response.rb
@@ -103,6 +103,12 @@ class Otto
     # following the same usage pattern as send_cookie methods. The CSP policy
     # is generated dynamically based on the security configuration and environment.
     #
+    # The apply itself is delegated to the shared, casing-safe core
+    # {Otto::Security::Config#write_nonce_csp} with `clobber: true`: an existing
+    # CSP header is deliberately overridden (with a warning), while a blank
+    # nonce or a non-HTML content type skips emission rather than producing a
+    # broken or pointless policy.
+    #
     # @param content_type [String] Content-Type header value to set
     # @param nonce [String] Nonce value to include in CSP directives
     # @param opts [Hash] Options for CSP generation
@@ -135,18 +141,17 @@ class Otto
       # Skip if CSP nonce support is not enabled
       return unless security_config&.csp_nonce_enabled?
 
-      # Generate CSP policy with nonce
-      development_mode = opts[:development_mode] || false
-      csp_policy       = security_config.generate_nonce_csp(nonce, development_mode: development_mode)
-
-      # Debug logging if enabled
-      debug_enabled = opts[:debug] || security_config.debug_csp?
-      if debug_enabled && defined?(Otto.logger)
-        Otto.logger.debug "[CSP] #{csp_policy}"
-      end
-
-      # Set the CSP header
-      headers['content-security-policy'] = csp_policy
+      # Apply through the shared, casing-safe core. #headers is a Rack::Headers
+      # (Rack 3.1+), so it is mutated in place; clobber: true preserves this
+      # helper's override-an-existing-CSP behavior. The core also skips blank
+      # nonces and non-HTML content types.
+      before = headers['content-security-policy']
+      security_config.write_nonce_csp(
+        headers, nonce,
+        development_mode: opts[:development_mode] || false,
+        clobber: true
+      )
+      log_csp_debug(security_config, opts[:debug], before)
     end
 
     # Set cache control headers to prevent caching
@@ -186,6 +191,19 @@ class Otto
       paths = paths.flatten.compact
       paths.unshift(request.env['SCRIPT_NAME']) if request&.env&.[]('SCRIPT_NAME')
       paths.join('/').gsub('//', '/')
+    end
+
+    private
+
+    # Log the CSP policy written by #send_csp_headers when debug logging is
+    # enabled. `before` is the header value prior to the apply; the shared core
+    # may have skipped (blank nonce, non-HTML), in which case nothing is logged.
+    def log_csp_debug(security_config, debug_opt, before)
+      csp_policy = headers['content-security-policy']
+      return if csp_policy.nil? || csp_policy.equal?(before)
+      return unless debug_opt || security_config.debug_csp?
+
+      Otto.logger.debug "[CSP] #{csp_policy}" if defined?(Otto.logger)
     end
   end
 end

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -6,6 +6,7 @@ require 'securerandom'
 require 'digest'
 require 'openssl'
 require 'ipaddr'
+require 'rack/headers'
 require_relative '../core/freezable'
 
 class Otto
@@ -516,6 +517,51 @@ class Otto
         directives += ["#{report_uri_directive};"] if report_uri_directive
         directives += ["#{report_to_directive};"] if report_to_directive
         directives.join(' ')
+      end
+
+      # Apply a nonce-based CSP to a Rack response-headers hash, case-insensitively.
+      #
+      # This is the single apply core shared by {Otto::Response#send_csp_headers},
+      # {Otto::Security::CSP::EmitMiddleware}, and downstream applications that
+      # apply a nonce CSP at a raw response-tuple boundary (`@app.call(env)`).
+      # A plain Hash from a downstream app can carry canonically-cased keys
+      # (`Content-Type`, `Content-Security-Policy`); every lookup and write here
+      # goes through {Rack::Headers}, so casing can never silently drop the CSP
+      # or emit a duplicate header.
+      #
+      # RETURN-VALUE CONTRACT: a plain Hash is wrapped in {Rack::Headers}, which
+      # COPIES the hash — writes never reach the original. Callers MUST use the
+      # returned object (e.g. put it in the response tuple), not the argument. A
+      # {Rack::Headers} input (such as {Rack::Response#headers}) is mutated in
+      # place and returned as the same object.
+      #
+      # The CSP is only applied when all of these hold, mirroring the guards
+      # previously copy-pasted at each emission site:
+      # - nonce support is enabled ({#csp_nonce_enabled?})
+      # - the nonce is present (non-nil, non-empty)
+      # - the response is HTML (`content-type` starts with `text/html`)
+      # - no CSP header is already set, unless `clobber: true`
+      #
+      # `clobber` preserves the existing split between Otto's two emission
+      # paths: a deliberate per-request call ({Otto::Response#send_csp_headers})
+      # OVERWRITES an existing CSP, while a passive backstop middleware DEFERS
+      # to one.
+      #
+      # @param headers [Hash, Rack::Headers] response headers to apply the CSP to
+      # @param nonce [String, nil] the per-request nonce; nil/empty skips
+      # @param development_mode [Boolean] use development-friendly directives
+      # @param clobber [Boolean] overwrite an existing CSP header (default: false)
+      # @return [Hash, Rack::Headers] the headers object the caller must use
+      def write_nonce_csp(headers, nonce, development_mode: false, clobber: false)
+        return headers unless csp_nonce_enabled?
+        return headers if nonce.to_s.empty?
+
+        h = headers.is_a?(Rack::Headers) ? headers : Rack::Headers[headers]
+        return h unless h['content-type']&.start_with?('text/html')
+        return h if !clobber && h['content-security-policy']
+
+        h['content-security-policy'] = generate_nonce_csp(nonce, development_mode: development_mode)
+        h
       end
 
       # Enable X-Frame-Options header to prevent clickjacking

--- a/lib/otto/security/csp.rb
+++ b/lib/otto/security/csp.rb
@@ -3,17 +3,19 @@
 # frozen_string_literal: true
 
 #
-# Index file for Content-Security-Policy violation reporting components.
+# Index file for Content-Security-Policy components.
 #
 # Otto emits CSP headers via Otto::Security::Config (static #enable_csp! and
-# nonce-based #generate_nonce_csp / Otto::Response#send_csp_headers). This
-# module adds the receiving half: a turnkey violation-report endpoint plus a
-# callback API, so an application can collect CSP reports with a few lines of
-# config instead of hand-rolling a parser, size cap, and CSRF exemption.
+# nonce-based #write_nonce_csp / Otto::Response#send_csp_headers, plus the
+# EmitMiddleware chokepoint for raw response tuples). This module also adds
+# the receiving half: a turnkey violation-report endpoint plus a callback API,
+# so an application can collect CSP reports with a few lines of config instead
+# of hand-rolling a parser, size cap, and CSRF exemption.
 #
-# See Otto::Security::Core#enable_csp_reporting! for the primary entry point and
-# delano/otto#174 for the design.
+# See Otto::Security::Core#enable_csp_reporting! for the reporting entry point
+# (delano/otto#174) and delano/otto#179 for the shared nonce-CSP apply core.
 
 require_relative 'csp/report'
 require_relative 'csp/parser'
 require_relative 'csp/report_middleware'
+require_relative 'csp/emit_middleware'

--- a/lib/otto/security/csp/emit_middleware.rb
+++ b/lib/otto/security/csp/emit_middleware.rb
@@ -1,0 +1,75 @@
+# lib/otto/security/csp/emit_middleware.rb
+#
+# frozen_string_literal: true
+
+require 'securerandom'
+
+require_relative '../config'
+
+class Otto
+  module Security
+    module CSP
+      # Rack middleware that applies a nonce-based Content-Security-Policy to
+      # HTML responses at the raw response-tuple boundary.
+      #
+      # This is the reusable "web chokepoint" for nonce-CSP emission: instead of
+      # every application hand-rolling the HTML-only / don't-clobber /
+      # needs-nonce guards around `@app.call(env)`, mount this middleware and
+      # the apply goes through the single casing-safe core
+      # {Otto::Security::Config#write_nonce_csp}. A downstream app that returns
+      # canonically-cased headers (`Content-Type`, `Content-Security-Policy`)
+      # can therefore never silently lose its CSP or end up with a duplicate
+      # header. Sibling to {Otto::Security::CSP::ReportMiddleware}, which is the
+      # receiving half of Otto's CSP support.
+      #
+      # Behavior:
+      #
+      # - INERT unless {Otto::Security::Config#csp_nonce_enabled?} — a
+      #   transparent pass-through that touches neither env nor response.
+      # - Ensures a per-request nonce in `env[nonce_key]` BEFORE calling the
+      #   inner app, so views can embed the same nonce the header will carry. A
+      #   nonce already present (set upstream or by the application) is
+      #   respected, and the key is configurable so apps with their own
+      #   convention (e.g. `env['myapp.nonce']`) can point Otto at it.
+      # - Applies the CSP with `clobber: false`: this is a passive backstop
+      #   that DEFERS to any CSP the application already set (e.g. via
+      #   {Otto::Response#send_csp_headers}, which deliberately overrides).
+      # - Only HTML responses (`content-type` starting `text/html`) receive the
+      #   header; everything else passes through untouched.
+      class EmitMiddleware
+        # Default env key the per-request nonce is stored under. Documented in
+        # {Otto::EnvKeys::NONCE}.
+        NONCE_KEY = 'otto.nonce'
+
+        # @param app [#call] inner Rack app
+        # @param config [Otto::Security::Config, nil] security config; the Otto
+        #   middleware stack injects the instance's config automatically
+        # @param nonce_key [String] env key to read/store the per-request nonce
+        # @param development_mode [Boolean] emit development-friendly directives
+        def initialize(app, config = nil, nonce_key: NONCE_KEY, development_mode: false)
+          @app              = app
+          @config           = config || Otto::Security::Config.new
+          @nonce_key        = nonce_key
+          @development_mode = development_mode
+        end
+
+        def call(env)
+          return @app.call(env) unless @config.csp_nonce_enabled?
+
+          nonce = (env[@nonce_key] ||= SecureRandom.base64(16))
+          status, headers, body = @app.call(env)
+
+          # write_nonce_csp wraps a plain Hash in Rack::Headers, which COPIES —
+          # the returned object is the one that carries the header, so it (not
+          # the original) goes into the tuple.
+          headers = @config.write_nonce_csp(
+            headers, nonce,
+            development_mode: @development_mode,
+            clobber: false
+          )
+          [status, headers, body]
+        end
+      end
+    end
+  end
+end

--- a/spec/otto/response_csp_spec.rb
+++ b/spec/otto/response_csp_spec.rb
@@ -70,4 +70,28 @@ RSpec.describe Otto::Response, '#send_csp_headers' do
     # Development allows inline scripts alongside the nonce; production does not.
     expect(csp).to include("script-src 'nonce-devnonce' 'unsafe-inline'")
   end
+
+  # The apply is delegated to the shared core (Config#write_nonce_csp), whose
+  # guards now also protect this helper: no policy is emitted for a blank nonce
+  # (previously a broken 'nonce-' policy) or a non-HTML content type.
+  describe 'shared-core guards (delano/otto#179)' do
+    it 'does not emit a broken policy for a nil nonce' do
+      response.send_csp_headers('text/html', nil, security_config: nonce_config)
+
+      expect(response.headers).not_to have_key('content-security-policy')
+    end
+
+    it 'does not emit a broken policy for an empty nonce' do
+      response.send_csp_headers('text/html', '', security_config: nonce_config)
+
+      expect(response.headers).not_to have_key('content-security-policy')
+    end
+
+    it 'does not emit a CSP for a non-HTML content type' do
+      response.send_csp_headers('application/json', 'abc123', security_config: nonce_config)
+
+      expect(response.headers['content-type']).to eq('application/json')
+      expect(response.headers).not_to have_key('content-security-policy')
+    end
+  end
 end

--- a/spec/otto/security/csp/emit_middleware_spec.rb
+++ b/spec/otto/security/csp/emit_middleware_spec.rb
@@ -1,0 +1,145 @@
+# spec/otto/security/csp/emit_middleware_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Otto::Security::CSP::EmitMiddleware do
+  let(:app_headers) { { 'content-type' => 'text/html' } }
+  let(:seen_env) { {} }
+  let(:app) do
+    lambda do |env|
+      seen_env.merge!(env)
+      [200, app_headers.dup, ['<html></html>']]
+    end
+  end
+
+  let(:config) do
+    config = Otto::Security::Config.new
+    config.enable_csp_with_nonce!
+    config
+  end
+
+  let(:middleware) { described_class.new(app, config) }
+
+  def get_env
+    { 'REQUEST_METHOD' => 'GET', 'PATH_INFO' => '/' }
+  end
+
+  describe 'inert until configured' do
+    it 'passes through untouched when nonce support is not enabled' do
+      mw  = described_class.new(app, Otto::Security::Config.new)
+      env = get_env
+
+      _status, headers, = mw.call(env)
+
+      expect(env).not_to have_key('otto.nonce')
+      expect(headers).not_to have_key('content-security-policy')
+    end
+  end
+
+  describe 'nonce exposure to the inner app' do
+    it 'generates a nonce and exposes it in env BEFORE calling the app' do
+      middleware.call(get_env)
+
+      expect(seen_env['otto.nonce']).to be_a(String)
+      expect(seen_env['otto.nonce']).not_to be_empty
+    end
+
+    it 'respects a nonce already present in env' do
+      env = get_env.merge('otto.nonce' => 'upstream-nonce')
+
+      _status, headers, = middleware.call(env)
+
+      expect(seen_env['otto.nonce']).to eq('upstream-nonce')
+      expect(headers['content-security-policy']).to include("'nonce-upstream-nonce'")
+    end
+
+    it 'reads/stores the nonce under a configurable key' do
+      mw  = described_class.new(app, config, nonce_key: 'myapp.nonce')
+      env = get_env
+
+      _status, headers, = mw.call(env)
+
+      expect(env['myapp.nonce']).to be_a(String)
+      expect(env).not_to have_key('otto.nonce')
+      expect(headers['content-security-policy']).to include("'nonce-#{env['myapp.nonce']}'")
+    end
+
+    it 'emits a header that agrees with the nonce views see' do
+      env = get_env
+
+      _status, headers, = middleware.call(env)
+
+      expect(headers['content-security-policy']).to include("'nonce-#{env['otto.nonce']}'")
+    end
+  end
+
+  describe 'applying the CSP at the raw-tuple boundary' do
+    it 'applies the CSP to an HTML response' do
+      _status, headers, body = middleware.call(get_env)
+
+      expect(headers['content-security-policy']).to include('script-src')
+      expect(body).to eq(['<html></html>'])
+    end
+
+    context 'when the downstream app uses canonically-cased headers' do
+      let(:app_headers) { { 'Content-Type' => 'text/html; charset=utf-8' } }
+
+      it 'still applies the CSP, without a duplicate header' do
+        _status, headers, = middleware.call(get_env)
+
+        expect(headers['content-security-policy']).to include('script-src')
+        csp_keys = headers.keys.select { |k| k.casecmp?('content-security-policy') }
+        expect(csp_keys.length).to eq(1)
+      end
+    end
+
+    context 'when the app already set a CSP (canonically cased)' do
+      let(:app_headers) do
+        { 'Content-Type' => 'text/html', 'Content-Security-Policy' => "default-src 'self'" }
+      end
+
+      it 'defers to it (clobber: false) and does not emit a duplicate' do
+        _status, headers, = middleware.call(get_env)
+
+        expect(headers['content-security-policy']).to eq("default-src 'self'")
+        csp_keys = headers.keys.select { |k| k.casecmp?('content-security-policy') }
+        expect(csp_keys.length).to eq(1)
+      end
+    end
+
+    context 'when the response is not HTML' do
+      let(:app_headers) { { 'content-type' => 'application/json' } }
+
+      it 'does not apply the CSP' do
+        _status, headers, = middleware.call(get_env)
+
+        expect(headers).not_to have_key('content-security-policy')
+      end
+    end
+
+    it 'uses development directives when development_mode is set' do
+      mw = described_class.new(app, config, development_mode: true)
+
+      _status, headers, = mw.call(get_env)
+
+      expect(headers['content-security-policy']).to include("'unsafe-inline'")
+    end
+  end
+
+  describe 'integration with the Otto middleware stack' do
+    it 'is injected with the Otto instance security config' do
+      stack = Otto::Core::MiddlewareStack.new
+      stack.add(described_class)
+
+      base_app = ->(_env) { [200, { 'Content-Type' => 'text/html' }, ['ok']] }
+      wrapped  = stack.wrap(base_app, config)
+
+      env = get_env
+      _status, headers, = wrapped.call(env)
+
+      expect(headers['content-security-policy']).to include("'nonce-#{env['otto.nonce']}'")
+    end
+  end
+end

--- a/spec/otto/security/write_nonce_csp_spec.rb
+++ b/spec/otto/security/write_nonce_csp_spec.rb
@@ -1,0 +1,142 @@
+# spec/otto/security/write_nonce_csp_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Unit coverage for Otto::Security::Config#write_nonce_csp — the single,
+# casing-safe nonce-CSP apply core shared by Otto::Response#send_csp_headers,
+# Otto::Security::CSP::EmitMiddleware, and downstream raw-tuple boundaries
+# (delano/otto#179). Pins the guard logic (enabled / nonce present / HTML-only /
+# don't-clobber), the case-insensitive lookups, and the return-value contract
+# (plain Hash in -> Rack::Headers COPY out; Rack::Headers in -> same object).
+RSpec.describe Otto::Security::Config, '#write_nonce_csp' do
+  subject(:config) do
+    config = described_class.new
+    config.enable_csp_with_nonce!
+    config
+  end
+
+  let(:nonce) { 'abc123' }
+
+  describe 'casing safety at a raw-tuple boundary' do
+    it 'emits for a plain Hash with a canonically-cased Content-Type' do
+      headers = { 'Content-Type' => 'text/html; charset=utf-8' }
+
+      result = config.write_nonce_csp(headers, nonce)
+
+      expect(result['content-security-policy']).to include("'nonce-abc123'")
+    end
+
+    it 'defers to a canonically-cased Content-Security-Policy without duplicating it' do
+      headers = {
+        'Content-Type' => 'text/html',
+        'Content-Security-Policy' => "default-src 'self'",
+      }
+
+      result = config.write_nonce_csp(headers, nonce)
+
+      expect(result['content-security-policy']).to eq("default-src 'self'")
+      csp_keys = result.keys.select { |k| k.casecmp?('content-security-policy') }
+      expect(csp_keys.length).to eq(1)
+    end
+
+    it 'overrides a canonically-cased CSP with clobber: true, still without a duplicate' do
+      headers = {
+        'Content-Type' => 'text/html',
+        'Content-Security-Policy' => "default-src 'self'",
+      }
+
+      result = config.write_nonce_csp(headers, nonce, clobber: true)
+
+      expect(result['content-security-policy']).to include("'nonce-abc123'")
+      csp_keys = result.keys.select { |k| k.casecmp?('content-security-policy') }
+      expect(csp_keys.length).to eq(1)
+    end
+  end
+
+  describe 'guards' do
+    it 'skips (headers unchanged) when nonce support is not enabled' do
+      disabled = described_class.new
+      headers  = { 'content-type' => 'text/html' }
+
+      result = disabled.write_nonce_csp(headers, nonce)
+
+      expect(result).to equal(headers)
+      expect(result).not_to have_key('content-security-policy')
+    end
+
+    it 'skips when the nonce is nil' do
+      headers = { 'content-type' => 'text/html' }
+
+      result = config.write_nonce_csp(headers, nil)
+
+      expect(result).to equal(headers)
+      expect(result).not_to have_key('content-security-policy')
+    end
+
+    it 'skips when the nonce is empty' do
+      headers = { 'content-type' => 'text/html' }
+
+      result = config.write_nonce_csp(headers, '')
+
+      expect(result).to equal(headers)
+      expect(result).not_to have_key('content-security-policy')
+    end
+
+    it 'skips non-HTML responses' do
+      headers = { 'content-type' => 'application/json' }
+
+      result = config.write_nonce_csp(headers, nonce)
+
+      expect(result).not_to have_key('content-security-policy')
+    end
+
+    it 'skips when there is no content-type at all' do
+      result = config.write_nonce_csp({}, nonce)
+
+      expect(result).not_to have_key('content-security-policy')
+    end
+  end
+
+  describe 'return-value contract' do
+    it 'wraps a plain Hash in Rack::Headers, leaving the original untouched (COPY)' do
+      headers = { 'Content-Type' => 'text/html' }
+
+      result = config.write_nonce_csp(headers, nonce)
+
+      expect(result).to be_a(Rack::Headers)
+      expect(result).not_to equal(headers)
+      expect(headers).not_to have_key('content-security-policy')
+      expect(headers).not_to have_key('Content-Security-Policy')
+    end
+
+    it 'mutates and returns the SAME object for Rack::Headers input' do
+      headers = Rack::Headers['content-type' => 'text/html']
+
+      result = config.write_nonce_csp(headers, nonce)
+
+      expect(result).to equal(headers)
+      expect(headers['content-security-policy']).to include("'nonce-abc123'")
+    end
+  end
+
+  describe 'policy generation' do
+    it 'uses development directives when development_mode is set' do
+      headers = { 'content-type' => 'text/html' }
+
+      result = config.write_nonce_csp(headers, nonce, development_mode: true)
+
+      expect(result['content-security-policy'])
+        .to include("script-src 'nonce-abc123' 'unsafe-inline'")
+    end
+
+    it 'matches generate_nonce_csp output exactly' do
+      headers = { 'content-type' => 'text/html' }
+
+      result = config.write_nonce_csp(headers, nonce)
+
+      expect(result['content-security-policy']).to eq(config.generate_nonce_csp(nonce))
+    end
+  end
+end


### PR DESCRIPTION
Based on #179 (which was superseded by #180). Closing this PR. 

Add Otto::Security::Config#write_nonce_csp, a single case-insensitive apply core for nonce-based CSP emission. All header lookups and writes go through Rack::Headers, so a canonically-cased Content-Type / Content-Security-Policy at a raw response-tuple boundary can never silently drop the CSP or emit a duplicate header. The clobber: flag preserves the existing split between the two emission styles: a deliberate per-request call overrides an existing CSP, a passive backstop defers to one.

- Otto::Response#send_csp_headers now delegates its apply to the core with clobber: true, keeping its default content-type, override warning, and debug logging. Via the shared guards it no longer emits a broken 'nonce-' policy for a blank nonce or a CSP for non-HTML content types.
- New Otto::Security::CSP::EmitMiddleware (sibling to ReportMiddleware) gives apps the raw-tuple web chokepoint for free: ensures a per-request nonce in env['otto.nonce'] (configurable via nonce_key:) before calling the app so views and the header agree, then applies the CSP to HTML responses with clobber: false. Inert unless csp_nonce_enabled?; receives the instance security config when used in Otto's middleware stack.
- Document the return-value contract (a plain Hash is wrapped in Rack::Headers, which copies — callers must use the returned object), register 'otto.nonce' in EnvKeys, and cover the guards, casing safety, and both middleware paths with specs.

Additive and backward-compatible; targets Otto 2.5.0. Downstream adoption (onetimesecret/onetimesecret#3603) is sequenced after release.


Claude-Session: https://claude.ai/code/session_01UfkEkgdBsznGQoWoPCx5nj