### PR TITLE
Refactor CSP emission into a single apply core with Writer, Policy, and EmitMiddleware

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,76 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.1.0/>`
 
    <!--scriv-insert-here-->
 
+.. _changelog-2.5.0:
+
+2.5.0 — 2026-07-02
+==================
+
+Added
+-----
+
+- ``Otto::Security::CSP::Writer.apply(headers, nonce, config:, mode:,
+  development_mode:)`` — the single structural apply core for nonce-based CSP
+  emission. Writes are in-place and key-scoped (case-variant keys are corrected
+  to Rack 3's lowercase in the caller's hash; a frozen headers hash fails loud).
+  Returns a ``Result`` (``applied?``, ``policy``, ``skip_reason`` of
+  ``:disabled`` / ``:blank_nonce`` / ``:non_html`` / ``:existing_csp``). Named
+  modes ``:override`` (deliberate, replaces) and ``:backstop`` (passive,
+  defers). (delano/otto#180)
+
+- Framework-owned lazy nonce: ``Otto::Request#csp_nonce`` /
+  ``Otto::Security::CSP.nonce(env)`` generate on first access and memoize into
+  ``env['otto.nonce']`` (registered as ``Otto::EnvKeys::NONCE``), so views and
+  the header read one value. Configurable env key via
+  ``Otto::Security::Config#csp_nonce_key`` for apps with an existing convention.
+
+- ``Otto::Security::CSP::EmitMiddleware`` and ``Otto#enable_csp_emission!`` — a
+  passive backstop that emits a nonce CSP for HTML responses whose request
+  consumed a nonce (emit-if-consumed default), never clobbering an existing
+  policy. Optional ``eager:`` mode and a per-request ``development_mode:``
+  callable.
+
+- ``Otto::Response#apply_csp(nonce, mode: :override)`` — the one emission helper,
+  routed through the apply core.
+
+- ``Otto::Security::CSP::Policy`` — CSP policy building (directive sets,
+  report-uri/report-to assembly) extracted from ``Otto::Security::Config`` into
+  its own home beside the parser and middlewares; ``Config`` delegates with
+  byte-identical output.
+
+Deprecated
+----------
+
+- ``Otto::Response#send_csp_headers`` — use ``#apply_csp`` or
+  ``#enable_csp_emission!``. Retained as a thin shim over the apply core (logs a
+  one-time ``Otto.logger`` deprecation notice).
+
+Fixed
+-----
+
+- ``#send_csp_headers`` no longer emits a broken ``script-src 'nonce-'`` for a
+  blank/nil nonce (it skips) and no longer emits a CSP for non-HTML responses —
+  both via the shared apply core. Its bare ``warn`` to stderr when overwriting an
+  existing CSP is also gone: replacement is deliberate in ``:override`` mode, and
+  the shim instead logs a one-time deprecation notice through ``Otto.logger``.
+
+Security
+--------
+
+- Nonce-CSP emission now detects and normalizes CSP / Content-Type headers
+  case-insensitively, so a canonical-/mixed-cased header from a downstream layer
+  is recognized (and the CSP key rewritten to lowercase) rather than silently
+  duplicated — de-duplicating the hand-rolled, case-sensitive guards adopters
+  previously re-implemented at each raw-tuple boundary. (delano/otto#180)
+
+AI Assistance
+-------------
+
+- The nonce-CSP emission redesign — the ``Writer`` apply core, the
+  framework-owned lazy nonce, the ``EmitMiddleware`` backstop, and the
+  ``Policy`` extraction — was designed and implemented with AI assistance.
+  (delano/otto#180)
+
 .. _changelog-2.4.0:
 
 2.4.0 — 2026-07-01

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    otto (2.4.0)
+    otto (2.5.0)
       concurrent-ruby (~> 1.3, < 2.0)
       logger (~> 1, < 2.0)
       loofah (~> 2.20)

--- a/README.md
+++ b/README.md
@@ -84,6 +84,60 @@ app = Otto.new("./routes", {
 
 Security features include CSRF protection, input validation, security headers, and trusted proxy configuration.
 
+### Content Security Policy (nonce-based emission)
+
+Otto owns the nonce lifecycle so the header and your views can never drift. A
+request-scoped nonce is minted lazily on first access and memoized in the env;
+your views read it to stamp `<script>`/`<link>` tags, and the framework reads
+the *same* value to emit the `script-src 'nonce-…'` header.
+
+```ruby
+app = Otto.new("./routes")
+app.enable_csp_with_nonce!    # turn on nonce-based CSP
+app.enable_csp_emission!      # mount the backstop that writes the header
+
+# In a view/handler:
+def show(req, res)
+  res['content-type'] = 'text/html; charset=utf-8'
+  res.write(%(<script nonce="#{req.csp_nonce}">/* inline */</script>))
+end
+```
+
+`enable_csp_emission!` mounts `Otto::Security::CSP::EmitMiddleware`, a passive
+**backstop**:
+
+- **Emit-if-consumed** (default): it emits a policy only for a response whose
+  request actually consumed a nonce (a view called `req.csp_nonce`). A nonce-only
+  `script-src` on an HTML page that never stamped the nonce would block every
+  script, so "CSP responses whose request consumed a nonce" is the only safe
+  blanket default. Pass `eager: true` to mint-and-emit for every eligible HTML
+  response (see the caveat in the middleware docs).
+- **Never clobbers**: it defers to any CSP a route already set.
+- **HTML only**, and inert unless `enable_csp_with_nonce!` is on.
+- `development_mode:` accepts a per-request callable, e.g.
+  `->(env) { ENV['RACK_ENV'] == 'development' }`, to switch directive sets.
+
+To set a policy explicitly from a handler instead, use the one emission helper —
+it routes through the same apply core:
+
+```ruby
+res['content-type'] = 'text/html; charset=utf-8'
+result = res.apply_csp(req.csp_nonce)          # mode: :override by default
+result.applied?        # => true
+result.skip_reason     # => nil (or :disabled / :blank_nonce / :non_html / :existing_csp)
+```
+
+Apps with an existing nonce env-key convention can point the accessor at it with
+`app.security_config.csp_nonce_key = 'onetime.nonce'` — the views and the header
+still share one value.
+
+> [!NOTE]
+> `res.send_csp_headers(content_type, nonce)` is **deprecated** in favour of
+> `res.apply_csp` / `enable_csp_emission!`. It remains as a thin shim over the
+> same apply core (so its old quirks — a broken `'nonce-'` on a blank nonce, a
+> CSP on non-HTML responses, a `warn` to stderr — are now fixed) and logs a
+> one-time deprecation notice.
+
 ### CSP Violation Reporting
 
 Otto can both emit Content-Security-Policy headers and receive the violation

--- a/lib/otto/core/middleware_stack.rb
+++ b/lib/otto/core/middleware_stack.rb
@@ -275,6 +275,7 @@ class Otto
           Otto::Security::Middleware::RateLimitMiddleware,
           Otto::Security::Middleware::IPPrivacyMiddleware,
           Otto::Security::CSP::ReportMiddleware,
+          Otto::Security::CSP::EmitMiddleware,
         ].include?(middleware_class)
       end
     end

--- a/lib/otto/env_keys.rb
+++ b/lib/otto/env_keys.rb
@@ -61,6 +61,16 @@ class Otto
     # Used by: All security middleware (CSRF, Headers, Validation)
     SECURITY_CONFIG = 'otto.security_config'
 
+    # Per-request CSP nonce, minted lazily on first access and memoized here.
+    # Type: String (base64)
+    # Set by: Otto::Security::CSP.nonce / Otto::Request#csp_nonce (first touch)
+    # Used by: views (stamping script/style nonces) and
+    #   Otto::Security::CSP::EmitMiddleware (emit-if-consumed)
+    # Note: this is the DEFAULT key. Apps with an existing convention can point
+    #   the accessor at their own key via Otto::Security::Config#csp_nonce_key
+    #   (e.g. 'onetime.nonce'), so the header and views still share one value.
+    NONCE = 'otto.nonce'
+
     # Whether the request arrived via a trusted proxy.
     # Type: Boolean
     # Set by: IPPrivacyMiddleware (every request, evaluated on the original

--- a/lib/otto/request.rb
+++ b/lib/otto/request.rb
@@ -24,6 +24,20 @@ class Otto
       env['HTTP_USER_AGENT']
     end
 
+    # Framework-owned, request-scoped CSP nonce, generated lazily on first
+    # access and memoized into the request env. Views call this to stamp
+    # `nonce="…"` onto their inline `<script>`/`<link>` tags; the same value is
+    # what {Otto::Security::CSP::EmitMiddleware} writes into the `script-src
+    # 'nonce-…'` header — so the header and the views agree structurally, not by
+    # convention. An untouched request generates nothing.
+    #
+    # The env key is configurable via {Otto::Security::Config#csp_nonce_key}.
+    #
+    # @return [String] this request's nonce (base64)
+    def csp_nonce
+      Otto::Security::CSP.nonce(env)
+    end
+
     # Canonical client IP for the request.
     #
     # Prefers env['otto.client_ip'] — the value resolved once, early, by

--- a/lib/otto/response.rb
+++ b/lib/otto/response.rb
@@ -207,6 +207,12 @@ class Otto
 
     # Emit the #send_csp_headers deprecation notice at most once per process
     # (Response is per-request, so the guard lives on the class).
+    #
+    # The check-then-set on the class flag is deliberately unsynchronized: the
+    # race is benign — worst case, two threads racing on the very first call each
+    # log the notice once. The flag gates only a log line, never any behavior, so
+    # a mutex would add contention on a hot path to save at most a couple of
+    # duplicate deprecation lines at startup.
     def warn_send_csp_headers_deprecated
       return if self.class.send_csp_headers_deprecation_warned
       return unless defined?(Otto.logger) && Otto.logger

--- a/lib/otto/response.rb
+++ b/lib/otto/response.rb
@@ -14,12 +14,18 @@ class Otto
   # @example Using Otto's response in route handlers
   #   def show(req, res)
   #     res.send_secure_cookie('session_id', token, 3600)
-  #     res.send_csp_headers('text/html', nonce)
+  #     res.apply_csp(req.csp_nonce)
   #     res.no_cache!
   #   end
   #
   # @see Otto#register_response_helpers
   class Response < Rack::Response
+    # One-time-per-process guard for the #send_csp_headers deprecation warning.
+    @send_csp_headers_deprecation_warned = false
+    class << self
+      attr_accessor :send_csp_headers_deprecation_warned # rubocop:disable ThreadSafety/ClassAndModuleAttributes
+    end
+
     # Reference to the request object (needed by some response helpers)
     # @return [Otto::Request]
     attr_accessor :request
@@ -97,56 +103,65 @@ class Otto
       headers
     end
 
-    # Set Content Security Policy (CSP) headers with nonce support
+    # Apply a nonce-based Content-Security-Policy to this response.
     #
-    # This method generates and sets CSP headers with the provided nonce value,
-    # following the same usage pattern as send_cookie methods. The CSP policy
-    # is generated dynamically based on the security configuration and environment.
+    # This is THE emission helper: it routes through the single apply core
+    # ({Otto::Security::CSP::Writer}), so all the invariants — enabled-only,
+    # nonce-present, HTML-only, lowercase key, no duplicate — hold here exactly as
+    # they do in the middleware, with no guard logic duplicated. The response's
+    # Content-Type must already be set (it decides HTML-only); this helper does
+    # NOT set it.
     #
-    # @param content_type [String] Content-Type header value to set
+    # `mode: :override` (the default) is the deliberate per-request call: it
+    # REPLACES any existing CSP. Pass `mode: :backstop` to defer to an existing
+    # policy instead.
+    #
+    # @param nonce [String] the per-request nonce (typically {Otto::Request#csp_nonce})
+    # @param mode [Symbol] `:override` or `:backstop` (see {Otto::Security::CSP::Writer::MODES})
+    # @param development_mode [Boolean] use development-friendly CSP directives
+    # @param security_config [Otto::Security::Config, nil] config to use; resolved
+    #   from the request env when omitted
+    # @return [Otto::Security::CSP::Writer::Result] the outcome (applied?, policy,
+    #   skip_reason) for uniform observability
+    #
+    # @example
+    #   res['content-type'] = 'text/html; charset=utf-8'
+    #   res.apply_csp(req.csp_nonce)
+    def apply_csp(nonce, mode: :override, development_mode: false, security_config: nil)
+      config = security_config || (request&.env && request.env['otto.security_config'])
+      Otto::Security::CSP::Writer.apply(
+        headers, nonce,
+        config: config, mode: mode, development_mode: development_mode
+      )
+    end
+
+    # @deprecated Use {#apply_csp} instead. Retained as a thin shim over the apply
+    #   core so existing callers keep working while its historical quirks are
+    #   fixed: a nil/empty nonce no longer emits a broken `script-src 'nonce-'`
+    #   (it skips), a CSP is no longer emitted for non-HTML responses, and the
+    #   override notice goes through {Otto.logger} instead of a bare `warn` to
+    #   stderr. Unlike {#apply_csp}, it still sets the Content-Type for you and
+    #   emits in `:override` mode.
+    #
+    # @param content_type [String] Content-Type to set if not already set
     # @param nonce [String] Nonce value to include in CSP directives
-    # @param opts [Hash] Options for CSP generation
+    # @param opts [Hash] Options
     # @option opts [Otto::Security::Config] :security_config Security config to use
     # @option opts [Boolean] :development_mode Use development-friendly CSP directives
-    # @option opts [Boolean] :debug Enable debug logging for this request
-    # @return [void]
-    #
-    # @example Basic usage
-    #   nonce = SecureRandom.base64(16)
-    #   res.send_csp_headers('text/html; charset=utf-8', nonce)
-    #
-    # @example With options
-    #   res.send_csp_headers('text/html; charset=utf-8', nonce, {
-    #     development_mode: Rails.env.development?,
-    #     debug: true
-    #   })
+    # @return [Otto::Security::CSP::Writer::Result]
     def send_csp_headers(content_type, nonce, opts = {})
-      # Set content type if not already set
+      warn_send_csp_headers_deprecated
+
+      # Historical behavior the shim keeps (apply_csp does not): default the
+      # Content-Type so an HTML response is recognized as HTML.
       headers['content-type'] ||= content_type
 
-      # Warn if CSP header already exists but don't skip
-      warn 'CSP header already set, overriding with nonce-based policy' if headers['content-security-policy']
-
-      # Get security configuration
-      security_config = opts[:security_config] ||
-                        (request&.env && request.env['otto.security_config']) ||
-                        nil
-
-      # Skip if CSP nonce support is not enabled
-      return unless security_config&.csp_nonce_enabled?
-
-      # Generate CSP policy with nonce
-      development_mode = opts[:development_mode] || false
-      csp_policy       = security_config.generate_nonce_csp(nonce, development_mode: development_mode)
-
-      # Debug logging if enabled
-      debug_enabled = opts[:debug] || security_config.debug_csp?
-      if debug_enabled && defined?(Otto.logger)
-        Otto.logger.debug "[CSP] #{csp_policy}"
-      end
-
-      # Set the CSP header
-      headers['content-security-policy'] = csp_policy
+      apply_csp(
+        nonce,
+        mode: :override,
+        development_mode: opts[:development_mode] || false,
+        security_config: opts[:security_config]
+      )
     end
 
     # Set cache control headers to prevent caching
@@ -186,6 +201,22 @@ class Otto
       paths = paths.flatten.compact
       paths.unshift(request.env['SCRIPT_NAME']) if request&.env&.[]('SCRIPT_NAME')
       paths.join('/').gsub('//', '/')
+    end
+
+    private
+
+    # Emit the #send_csp_headers deprecation notice at most once per process
+    # (Response is per-request, so the guard lives on the class).
+    def warn_send_csp_headers_deprecated
+      return if self.class.send_csp_headers_deprecation_warned
+      return unless defined?(Otto.logger) && Otto.logger
+
+      self.class.send_csp_headers_deprecation_warned = true
+      Otto.logger.warn(
+        '[Otto::Response] #send_csp_headers is deprecated and will be removed in a ' \
+        'future release; use #apply_csp(nonce, mode: :override) (set Content-Type first), ' \
+        'or mount Otto::Security::CSP::EmitMiddleware via #enable_csp_emission!.'
+      )
     end
   end
 end

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -7,6 +7,7 @@ require 'digest'
 require 'openssl'
 require 'ipaddr'
 require_relative '../core/freezable'
+require_relative 'csp/policy'
 
 class Otto
   module Security
@@ -47,7 +48,9 @@ class Otto
       # Endpoint group name shared by the CSP `report-to` directive and the
       # `Reporting-Endpoints` response header (modern Reporting API). Browsers
       # match the directive's group to the header's key, so both must agree.
-      CSP_REPORTING_GROUP = 'otto-csp'
+      # Aliases {Otto::Security::CSP::Policy::REPORTING_GROUP} — the one source
+      # the policy builder uses — so the header and the directive cannot drift.
+      CSP_REPORTING_GROUP = Otto::Security::CSP::Policy::REPORTING_GROUP
 
       # Error raised when CSRF protection is enabled in production without an
       # explicitly configured secret. A randomly-generated per-process secret
@@ -67,7 +70,7 @@ class Otto
       attr_reader :csrf_protection,  :csrf_header_key,
                   :trusted_proxies, :require_secure_cookies,
                   :security_headers,
-                  :csp_nonce_enabled, :debug_csp, :mcp_auth,
+                  :csp_nonce_enabled, :debug_csp, :mcp_auth, :csp_nonce_key,
                   :ip_privacy_config, :trusted_proxy_depth, :trusted_proxy_header,
                   :csp_report_uri, :csp_report_to_url, :csp_violation_callback
 
@@ -92,6 +95,7 @@ class Otto
         @input_validation       = true
         @csp_nonce_enabled      = false
         @debug_csp              = false
+        @csp_nonce_key          = 'otto.nonce'
         @csp_policy             = nil
         @csp_report_uri         = nil
         @csp_report_to_url      = nil
@@ -393,6 +397,22 @@ class Otto
         @csp_nonce_enabled
       end
 
+      # Set the Rack env key the framework-owned lazy nonce is memoized under
+      # ({Otto::Security::CSP.nonce} / {Otto::Request#csp_nonce}). Defaults to
+      # `'otto.nonce'`; override it for an app with an existing convention (e.g.
+      # `'onetime.nonce'`) so the accessor adopts that app's env key without a
+      # rename. A blank value resets to the default.
+      #
+      # @param key [String] the env key
+      # @return [void]
+      # @raise [FrozenError] if configuration is frozen
+      def csp_nonce_key=(key)
+        ensure_not_frozen!
+
+        normalized     = key.to_s.strip
+        @csp_nonce_key = normalized.empty? ? 'otto.nonce' : normalized
+      end
+
       # Check if CSP debug logging is enabled
       #
       # @return [Boolean] true if CSP debug logging is enabled
@@ -506,16 +526,20 @@ class Otto
 
       # Generate a CSP policy string with the provided nonce
       #
+      # Thin facade over {Otto::Security::CSP::Policy.nonce_policy}; the directive
+      # sets and report-uri/report-to assembly live there now. Output is
+      # byte-identical to Otto's historical policy.
+      #
       # @param nonce [String] The nonce value to include in the CSP
       # @param development_mode [Boolean] Whether to use development-friendly directives
       # @return [String] Complete CSP policy string
       def generate_nonce_csp(nonce, development_mode: false)
-        directives = development_mode ? development_csp_directives(nonce) : production_csp_directives(nonce)
-        report_uri_directive = csp_report_directive
-        report_to_directive  = csp_report_to_directive
-        directives += ["#{report_uri_directive};"] if report_uri_directive
-        directives += ["#{report_to_directive};"] if report_to_directive
-        directives.join(' ')
+        Otto::Security::CSP::Policy.nonce_policy(
+          nonce,
+          development_mode: development_mode,
+          report_uri: @csp_report_uri,
+          report_to_url: @csp_report_to_url
+        )
       end
 
       # Enable X-Frame-Options header to prevent clickjacking
@@ -888,28 +912,6 @@ class Otto
         existing
       end
 
-      # The `report-uri` directive to append to emitted policies, or nil when no
-      # report URI is configured. No trailing semicolon (callers add their own
-      # separator to match each policy style).
-      #
-      # @return [String, nil]
-      def csp_report_directive
-        return nil if @csp_report_uri.nil? || @csp_report_uri.empty?
-
-        "report-uri #{@csp_report_uri}"
-      end
-
-      # The `report-to` directive (modern Reporting API) to append to emitted
-      # policies, or nil when no reporting endpoint URL is configured. Its group
-      # name matches the Reporting-Endpoints header. No trailing semicolon.
-      #
-      # @return [String, nil]
-      def csp_report_to_directive
-        return nil if @csp_report_to_url.nil? || @csp_report_to_url.empty?
-
-        "report-to #{CSP_REPORTING_GROUP}"
-      end
-
       # The `Reporting-Endpoints` response header value mapping the CSP reporting
       # group to the configured absolute endpoint URL, e.g.
       # `otto-csp="https://example.com/_/csp-report"`.
@@ -920,62 +922,18 @@ class Otto
       end
 
       # Build the stored static-CSP header value: the base policy plus the
-      # optional report-uri and report-to directives. Byte-identical to the bare
-      # policy when no reporting is configured, so existing static-CSP output is
-      # unchanged.
+      # optional report-uri and report-to directives. Thin facade over
+      # {Otto::Security::CSP::Policy.static_policy}; byte-identical to the bare
+      # policy when no reporting is configured.
       #
       # @param policy [String] the base policy passed to {#enable_csp!}
       # @return [String]
       def build_static_csp(policy)
-        [policy, csp_report_directive, csp_report_to_directive].compact.join('; ')
-      end
-
-      # Generate CSP directives for development environment
-      #
-      # Development mode allows inline scripts/styles and hot reloading connections
-      # for better developer experience with build tools like Vite.
-      #
-      # @param nonce [String] The nonce value to include in script-src
-      # @return [Array<String>] Array of CSP directive strings
-      def development_csp_directives(nonce)
-        [
-          "default-src 'none';",
-          "script-src 'nonce-#{nonce}' 'unsafe-inline';", # Allow inline scripts for development tools
-          "style-src 'self' 'unsafe-inline';",
-          "connect-src 'self' ws: wss: http: https:;", # Allow HTTP and all WebSocket connections for dev tools
-          "img-src 'self' data:;",
-          "font-src 'self';",
-          "object-src 'none';",
-          "base-uri 'self';",
-          "form-action 'self';",
-          "frame-ancestors 'none';",
-          "manifest-src 'self';",
-          "worker-src 'self' data:;",
-        ]
-      end
-
-      # Generate CSP directives for production environment
-      #
-      # Production mode is more restrictive, only allowing HTTPS connections
-      # and nonce-only scripts for enhanced XSS protection.
-      #
-      # @param nonce [String] The nonce value to include in script-src
-      # @return [Array<String>] Array of CSP directive strings
-      def production_csp_directives(nonce)
-        [
-          "default-src 'none';",                     # Restrict to same origin by default
-          "script-src 'nonce-#{nonce}';",            # Only allow scripts with valid nonce
-          "style-src 'self' 'unsafe-inline';",       # Allow inline styles and same-origin stylesheets
-          "connect-src 'self' wss: https:;",         # Only HTTPS and secure WebSockets
-          "img-src 'self' data:;",                   # Allow images from same origin and data URIs
-          "font-src 'self';",                        # Allow fonts from same origin only
-          "object-src 'none';",                      # Block <object>, <embed>, and <applet> elements
-          "base-uri 'self';",                        # Restrict <base> tag targets to same origin
-          "form-action 'self';",                     # Restrict form submissions to same origin
-          "frame-ancestors 'none';",                 # Prevent site from being embedded in frames
-          "manifest-src 'self';",                    # Allow web app manifests from same origin
-          "worker-src 'self' data:;",                # Allow Workers from same origin and data blobs
-        ]
+        Otto::Security::CSP::Policy.static_policy(
+          policy,
+          report_uri: @csp_report_uri,
+          report_to_url: @csp_report_to_url
+        )
       end
     end
 

--- a/lib/otto/security/configurator.rb
+++ b/lib/otto/security/configurator.rb
@@ -198,6 +198,20 @@ class Otto
         @security_config.enable_csp_with_nonce!(debug: debug)
       end
 
+      # Mount {Otto::Security::CSP::EmitMiddleware} (passive backstop that emits a
+      # nonce CSP for responses lacking one, never clobbering). Requires nonce-CSP
+      # enabled ({#enable_csp_with_nonce!}); inert otherwise. Emit-if-consumed by
+      # default — see {Otto::Security::Core#enable_csp_emission!}.
+      #
+      # @param eager [Boolean] mint-and-emit for every eligible HTML response
+      # @param development_mode [Boolean, #call, nil] development-directive toggle;
+      #   a callable is evaluated per request with the env
+      def enable_csp_emission!(eager: false, development_mode: nil)
+        return if middleware_enabled?(Otto::Security::CSP::EmitMiddleware)
+
+        @middleware_stack.add(Otto::Security::CSP::EmitMiddleware, eager: eager, development_mode: development_mode)
+      end
+
       # Enable turnkey CSP violation reporting: set the report URI (appends a
       # `report-uri` directive to emitted policies), register the callback, and
       # inject {Otto::Security::CSP::ReportMiddleware} pinned OUTERMOST so it

--- a/lib/otto/security/configurator.rb
+++ b/lib/otto/security/configurator.rb
@@ -199,9 +199,11 @@ class Otto
       end
 
       # Mount {Otto::Security::CSP::EmitMiddleware} (passive backstop that emits a
-      # nonce CSP for responses lacking one, never clobbering). Requires nonce-CSP
-      # enabled ({#enable_csp_with_nonce!}); inert otherwise. Emit-if-consumed by
-      # default — see {Otto::Security::Core#enable_csp_emission!}.
+      # nonce CSP for responses lacking one, never clobbering). Enable nonce-CSP
+      # ({#enable_csp_with_nonce!}) for it to emit anything; until then it is
+      # INERT (a transparent pass-through), not an error, and the two may be
+      # enabled in either order. Emit-if-consumed by default — see
+      # {Otto::Security::Core#enable_csp_emission!}.
       #
       # @param eager [Boolean] mint-and-emit for every eligible HTML response
       # @param development_mode [Boolean, #call, nil] development-directive toggle;

--- a/lib/otto/security/core.rb
+++ b/lib/otto/security/core.rb
@@ -135,6 +135,34 @@ class Otto
         @security_config.enable_csp_with_nonce!(debug: debug)
       end
 
+      # Mount {Otto::Security::CSP::EmitMiddleware} so nonce-based CSP headers are
+      # applied to responses by the framework instead of hand-rolled in each app.
+      #
+      # It is a passive backstop: it emits a nonce CSP only for responses that
+      # would otherwise ship without one, and never clobbers a policy a route
+      # already set. Requires nonce-CSP to be enabled (call
+      # {#enable_csp_with_nonce!} first); the middleware is inert otherwise.
+      #
+      # By DEFAULT it is emit-if-consumed — it emits only when the request
+      # actually consumed a nonce (a view called {Otto::Request#csp_nonce}). This
+      # is the only safe blanket default: a nonce-only policy on a page that never
+      # stamped the nonce blocks every script.
+      #
+      # @param eager [Boolean] mint-and-emit for every eligible HTML response
+      #   rather than only emit-if-consumed (see the middleware's caveats)
+      # @param development_mode [Boolean, #call, nil] whether to emit development
+      #   directives; a callable is evaluated per request with the env
+      # @return [void]
+      # @example
+      #   otto.enable_csp_with_nonce!
+      #   otto.enable_csp_emission!(development_mode: -> (env) { ENV['RACK_ENV'] == 'development' })
+      def enable_csp_emission!(eager: false, development_mode: nil)
+        ensure_not_frozen!
+        return if @middleware.includes?(Otto::Security::CSP::EmitMiddleware)
+
+        @middleware.add(Otto::Security::CSP::EmitMiddleware, eager: eager, development_mode: development_mode)
+      end
+
       # Enable turnkey Content Security Policy violation reporting.
       #
       # This is the receiving half of Otto's CSP support. It:

--- a/lib/otto/security/core.rb
+++ b/lib/otto/security/core.rb
@@ -140,8 +140,12 @@ class Otto
       #
       # It is a passive backstop: it emits a nonce CSP only for responses that
       # would otherwise ship without one, and never clobbers a policy a route
-      # already set. Requires nonce-CSP to be enabled (call
-      # {#enable_csp_with_nonce!} first); the middleware is inert otherwise.
+      # already set. Enable nonce-CSP via {#enable_csp_with_nonce!} for it to
+      # emit anything — until then the middleware is INERT (a transparent
+      # pass-through), NOT an error. The two may be enabled in either order:
+      # both read the same security config, so mounting the backstop first and
+      # enabling nonce-CSP later works. Enable-order independence is why this
+      # does not raise when nonce-CSP is off.
       #
       # By DEFAULT it is emit-if-consumed — it emits only when the request
       # actually consumed a nonce (a view called {Otto::Request#csp_nonce}). This

--- a/lib/otto/security/csp.rb
+++ b/lib/otto/security/csp.rb
@@ -3,17 +3,29 @@
 # frozen_string_literal: true
 
 #
-# Index file for Content-Security-Policy violation reporting components.
+# Index file for Content-Security-Policy components — both halves of Otto's CSP
+# support live under Otto::Security::CSP.
 #
-# Otto emits CSP headers via Otto::Security::Config (static #enable_csp! and
-# nonce-based #generate_nonce_csp / Otto::Response#send_csp_headers). This
-# module adds the receiving half: a turnkey violation-report endpoint plus a
-# callback API, so an application can collect CSP reports with a few lines of
-# config instead of hand-rolling a parser, size cap, and CSRF exemption.
+# EMISSION (delano/otto#180):
+# - Policy       — builds the policy string (directive sets, report-uri/report-to).
+# - Nonce        — the framework-owned lazy nonce (Otto::Security::CSP.nonce /
+#                  Otto::Request#csp_nonce), memoized in env['otto.nonce'].
+# - Writer       — the single structural apply core (in-place, key-scoped writes,
+#                  Result object, :override / :backstop modes) that every surface
+#                  routes through: Otto::Response#apply_csp, the EmitMiddleware,
+#                  and the deprecated Otto::Response#send_csp_headers shim.
+# - EmitMiddleware — passive backstop that emits a nonce CSP for responses whose
+#                  request consumed a nonce (emit-if-consumed). See
+#                  Otto::Security::Core#enable_csp_emission!.
 #
-# See Otto::Security::Core#enable_csp_reporting! for the primary entry point and
-# delano/otto#174 for the design.
+# RECEPTION (delano/otto#174):
+# - Report, Parser, ReportMiddleware — a turnkey violation-report endpoint plus a
+#   callback API. See Otto::Security::Core#enable_csp_reporting!.
 
+require_relative 'csp/policy'
+require_relative 'csp/nonce'
+require_relative 'csp/writer'
 require_relative 'csp/report'
 require_relative 'csp/parser'
 require_relative 'csp/report_middleware'
+require_relative 'csp/emit_middleware'

--- a/lib/otto/security/csp/emit_middleware.rb
+++ b/lib/otto/security/csp/emit_middleware.rb
@@ -1,0 +1,91 @@
+# lib/otto/security/csp/emit_middleware.rb
+#
+# frozen_string_literal: true
+
+require_relative 'writer'
+require_relative 'nonce'
+
+class Otto
+  module Security
+    module CSP
+      # Rack middleware that emits a nonce-based Content-Security-Policy on the
+      # way out — the EMITTING sibling of {Otto::Security::CSP::ReportMiddleware}.
+      #
+      # It is a passive BACKSTOP: it runs the CSP through {Otto::Security::CSP::Writer}
+      # in `:backstop` mode, so it fills the gap for responses that would
+      # otherwise ship without a CSP but NEVER clobbers one a route or another
+      # layer already set. All the emission invariants (enabled / HTML-only /
+      # nonce-present / don't-clobber / lowercase key) are the Writer's, so this
+      # middleware carries none of that guard logic itself.
+      #
+      # DEFAULT: emit-if-consumed. It emits only when the request actually
+      # consumed a nonce (a view called {Otto::Request#csp_nonce}, memoizing it
+      # into the env). This is the safe default: a nonce-only `script-src` on an
+      # HTML page whose templates never stamped that nonce would block EVERY
+      # script on the page. "CSP responses whose request consumed a nonce" is
+      # sound; "CSP all HTML responses" is not.
+      #
+      # EAGER (opt-in): with `eager: true` it MINTS a nonce for every otherwise
+      # eligible response, even one that never touched it. Only safe when the app
+      # either uses no nonce-gated inline scripts or stamps the nonce another way;
+      # otherwise it reintroduces the blocked-script hazard above.
+      #
+      # INERT unless {Otto::Security::Config#csp_nonce_enabled?}. When nonce-CSP
+      # is off it is a transparent pass-through (and never mints a nonce).
+      class EmitMiddleware
+        # @param app [#call] the inner Rack app
+        # @param config [Otto::Security::Config, nil] security config (the
+        #   middleware stack injects this); a nil config yields an inert instance
+        # @param eager [Boolean] mint-and-emit for every eligible response rather
+        #   than only emit-if-consumed
+        # @param development_mode [Boolean, #call, nil] whether to emit the
+        #   development directive set. A callable is invoked per request with the
+        #   env (e.g. `->(env) { OT.conf.dig('development', 'enabled') }`); a plain
+        #   value is used as-is; nil means production.
+        def initialize(app, config = nil, eager: false, development_mode: nil)
+          @app              = app
+          @config           = config || Otto::Security::Config.new
+          @eager            = eager
+          @development_mode = development_mode
+        end
+
+        def call(env)
+          status, headers, body = @app.call(env)
+          apply_backstop(env, headers) if @config.csp_nonce_enabled?
+          [status, headers, body]
+        end
+
+        private
+
+        # Resolve the nonce per the eager/consumed policy and, when present, let
+        # the Writer apply the backstop CSP. The Writer re-checks every guard, so
+        # a non-HTML or already-CSP'd response is left untouched.
+        def apply_backstop(env, headers)
+          nonce = resolve_nonce(env)
+          return if nonce.nil? || nonce.empty?
+
+          Otto::Security::CSP::Writer.apply(
+            headers, nonce,
+            config: @config, mode: :backstop, development_mode: development_mode?(env)
+          )
+        end
+
+        # Eager mode mints a nonce for this request; the default emits only a
+        # nonce the request already consumed (memoized in env by a view).
+        def resolve_nonce(env)
+          return Otto::Security::CSP.nonce(env) if @eager
+          return Otto::Security::CSP.nonce(env) if Otto::Security::CSP.nonce?(env)
+
+          nil
+        end
+
+        def development_mode?(env)
+          mode = @development_mode
+          return mode.call(env) if mode.respond_to?(:call)
+
+          !!mode
+        end
+      end
+    end
+  end
+end

--- a/lib/otto/security/csp/nonce.rb
+++ b/lib/otto/security/csp/nonce.rb
@@ -1,0 +1,78 @@
+# lib/otto/security/csp/nonce.rb
+#
+# frozen_string_literal: true
+
+require 'securerandom'
+
+class Otto
+  module Security
+    # Content-Security-Policy support. The framework-owned lazy nonce accessor
+    # lives directly on this module ({.nonce} / {.nonce?}), beside the {Policy}
+    # builder, the {Writer} apply core, the {Parser}, and the report/emit
+    # middlewares.
+    module CSP
+      # Default Rack env key the per-request nonce is memoized under. Registered
+      # as documentation in {Otto::EnvKeys::NONCE}; per that module's convention
+      # the string literal (not the constant) is what the codebase passes around,
+      # so this DEFAULT_NONCE_KEY exists for the CSP code's own use and the two
+      # are kept identical.
+      DEFAULT_NONCE_KEY = 'otto.nonce'
+
+      module_function
+
+      # Framework-owned, request-scoped, LAZY CSP nonce.
+      #
+      # Generates a fresh base64 nonce on first access and memoizes it into the
+      # request env under the resolved key, so every later reader observes ONE
+      # value: the views that stamp `nonce="…"` onto `<script>`/`<link>` tags and
+      # the {Otto::Security::CSP::EmitMiddleware} that writes the `script-src
+      # 'nonce-…'` header both read it here. The header's nonce matching the
+      # views' nonce is therefore a STRUCTURAL property, not a convention each app
+      # re-implements (Rails' `request.content_security_policy_nonce` model).
+      #
+      # An untouched request never generates a nonce and pays nothing — which is
+      # also why the emit-if-consumed middleware is safe: it only emits a
+      # nonce-only policy for a request whose views actually consumed the nonce.
+      #
+      # A value already present under the key (e.g. an app that still mints its
+      # own under the same convention) is honored, not overwritten.
+      #
+      # @param env [Hash] the Rack request env (mutated: the nonce is memoized in)
+      # @param key [String, nil] override the env key; nil resolves it from the
+      #   security config's {Otto::Security::Config#csp_nonce_key} (or the default)
+      # @return [String] the request's nonce
+      def nonce(env, key: nil)
+        resolved = key || nonce_key(env)
+        existing = env[resolved]
+        return existing if existing && !existing.empty?
+
+        env[resolved] = SecureRandom.base64(16)
+      end
+
+      # Whether a nonce was already minted for this request, WITHOUT minting one.
+      # This is the emit-if-consumed predicate.
+      #
+      # @param env [Hash]
+      # @param key [String, nil] see {.nonce}
+      # @return [Boolean]
+      def nonce?(env, key: nil)
+        value = env[key || nonce_key(env)]
+        !value.nil? && !value.empty?
+      end
+
+      # The env key the nonce lives under: the app's configured convention
+      # ({Otto::Security::Config#csp_nonce_key}) when a security config is present
+      # on the env, else the framework default. Lets an app with an existing
+      # convention (e.g. `onetime.nonce`) adopt the accessor without renaming its
+      # env key.
+      #
+      # @param env [Hash]
+      # @return [String]
+      def nonce_key(env)
+        config = env['otto.security_config']
+        configured = config.csp_nonce_key if config.respond_to?(:csp_nonce_key)
+        configured && !configured.empty? ? configured : DEFAULT_NONCE_KEY
+      end
+    end
+  end
+end

--- a/lib/otto/security/csp/policy.rb
+++ b/lib/otto/security/csp/policy.rb
@@ -1,0 +1,141 @@
+# lib/otto/security/csp/policy.rb
+#
+# frozen_string_literal: true
+
+class Otto
+  module Security
+    module CSP
+      # Assembles Content-Security-Policy strings from Otto's directive sets and
+      # the optional reporting directives.
+      #
+      # This is the policy-BUILDING half of Otto's CSP support, extracted from
+      # {Otto::Security::Config} so the domain (directive sets, report-uri /
+      # report-to assembly) lives beside the parser and the middlewares under
+      # {Otto::Security::CSP}. {Otto::Security::Config} keeps thin delegating
+      # facades ({Otto::Security::Config#generate_nonce_csp} and its static
+      # counterpart), so callers and output are unchanged — the assembly logic
+      # simply has a home of its own now.
+      #
+      # All methods are pure functions of their arguments (the report URI/URL are
+      # passed in, not read from global state), so the same policy string can be
+      # produced from any surface without a Config in hand.
+      module Policy
+        module_function
+
+        # Endpoint group name shared by the CSP `report-to` directive and the
+        # `Reporting-Endpoints` response header (modern Reporting API). Browsers
+        # match the directive's group to the header's key, so both must agree.
+        # {Otto::Security::Config::CSP_REPORTING_GROUP} aliases this so the two
+        # can never drift.
+        REPORTING_GROUP = 'otto-csp'
+
+        # Build the per-request nonce CSP policy string.
+        #
+        # Byte-identical to Otto's historical {Otto::Security::Config#generate_nonce_csp}
+        # output: the base directive set (development or production) followed by
+        # the optional `report-uri` and `report-to` directives, each terminated
+        # with `;` and joined by a single space.
+        #
+        # @param nonce [String] nonce value injected into `script-src`
+        # @param development_mode [Boolean] use the development directive set
+        # @param report_uri [String, nil] path for the `report-uri` directive
+        #   (omitted when nil/empty)
+        # @param report_to_url [String, nil] absolute URL configured for the
+        #   modern Reporting API; its presence (not its value) toggles the
+        #   `report-to <group>` directive (omitted when nil/empty)
+        # @return [String] complete CSP policy string
+        def nonce_policy(nonce, development_mode: false, report_uri: nil, report_to_url: nil)
+          directives = development_mode ? development_directives(nonce) : production_directives(nonce)
+          uri_directive = report_uri_directive(report_uri)
+          to_directive  = report_to_directive(report_to_url)
+          directives += ["#{uri_directive};"] if uri_directive
+          directives += ["#{to_directive};"] if to_directive
+          directives.join(' ')
+        end
+
+        # Build a static CSP header value: a base policy plus the optional
+        # reporting directives, joined `'; '`. Byte-identical to the bare policy
+        # when no reporting is configured.
+        #
+        # @param base [String] the base policy (e.g. from {Otto::Security::Config#enable_csp!})
+        # @param report_uri [String, nil] path for the `report-uri` directive
+        # @param report_to_url [String, nil] absolute URL toggling `report-to`
+        # @return [String]
+        def static_policy(base, report_uri: nil, report_to_url: nil)
+          [base, report_uri_directive(report_uri), report_to_directive(report_to_url)].compact.join('; ')
+        end
+
+        # The `report-uri` directive, or nil when no report URI is configured.
+        # No trailing semicolon (callers add their own separator).
+        #
+        # @param uri [String, nil]
+        # @return [String, nil]
+        def report_uri_directive(uri)
+          return nil if uri.nil? || uri.empty?
+
+          "report-uri #{uri}"
+        end
+
+        # The `report-to` directive (modern Reporting API), or nil when no
+        # reporting endpoint URL is configured. Its group name matches the
+        # Reporting-Endpoints header. No trailing semicolon.
+        #
+        # @param url [String, nil]
+        # @return [String, nil]
+        def report_to_directive(url)
+          return nil if url.nil? || url.empty?
+
+          "report-to #{REPORTING_GROUP}"
+        end
+
+        # CSP directives for the development environment.
+        #
+        # Development mode allows inline scripts/styles and hot reloading
+        # connections for better developer experience with build tools like Vite.
+        #
+        # @param nonce [String] nonce value injected into `script-src`
+        # @return [Array<String>] directive strings, each terminated with `;`
+        def development_directives(nonce)
+          [
+            "default-src 'none';",
+            "script-src 'nonce-#{nonce}' 'unsafe-inline';", # Allow inline scripts for development tools
+            "style-src 'self' 'unsafe-inline';",
+            "connect-src 'self' ws: wss: http: https:;", # Allow HTTP and all WebSocket connections for dev tools
+            "img-src 'self' data:;",
+            "font-src 'self';",
+            "object-src 'none';",
+            "base-uri 'self';",
+            "form-action 'self';",
+            "frame-ancestors 'none';",
+            "manifest-src 'self';",
+            "worker-src 'self' data:;",
+          ]
+        end
+
+        # CSP directives for the production environment.
+        #
+        # Production mode is more restrictive, only allowing HTTPS connections
+        # and nonce-only scripts for enhanced XSS protection.
+        #
+        # @param nonce [String] nonce value injected into `script-src`
+        # @return [Array<String>] directive strings, each terminated with `;`
+        def production_directives(nonce)
+          [
+            "default-src 'none';",                     # Restrict to same origin by default
+            "script-src 'nonce-#{nonce}';",            # Only allow scripts with valid nonce
+            "style-src 'self' 'unsafe-inline';",       # Allow inline styles and same-origin stylesheets
+            "connect-src 'self' wss: https:;",         # Only HTTPS and secure WebSockets
+            "img-src 'self' data:;",                   # Allow images from same origin and data URIs
+            "font-src 'self';",                        # Allow fonts from same origin only
+            "object-src 'none';",                      # Block <object>, <embed>, and <applet> elements
+            "base-uri 'self';",                        # Restrict <base> tag targets to same origin
+            "form-action 'self';",                     # Restrict form submissions to same origin
+            "frame-ancestors 'none';",                 # Prevent site from being embedded in frames
+            "manifest-src 'self';",                    # Allow web app manifests from same origin
+            "worker-src 'self' data:;",                # Allow Workers from same origin and data blobs
+          ]
+        end
+      end
+    end
+  end
+end

--- a/lib/otto/security/csp/writer.rb
+++ b/lib/otto/security/csp/writer.rb
@@ -1,0 +1,197 @@
+# lib/otto/security/csp/writer.rb
+#
+# frozen_string_literal: true
+
+class Otto
+  module Security
+    module CSP
+      # The single structural apply core for nonce-based Content-Security-Policy
+      # emission. Every in-framework surface that writes a nonce CSP onto a
+      # response — {Otto::Response#apply_csp}, {Otto::Security::CSP::EmitMiddleware},
+      # and the deprecated {Otto::Response#send_csp_headers} shim — routes through
+      # {.apply}, so the emission invariants are properties of ONE method rather
+      # than guard logic re-implemented (and re-reviewed) at each surface:
+      #
+      # - **Enabled only.** No header unless the security config has nonce-CSP on.
+      # - **Nonce present.** A nil/empty nonce never produces a broken
+      #   `script-src 'nonce-'` policy; it skips.
+      # - **HTML only.** Non-HTML responses (JSON, redirects, static assets) are
+      #   left untouched.
+      # - **Passive layers never clobber.** In `:backstop` mode an existing CSP is
+      #   deferred to; only an explicit `:override` replaces one.
+      #
+      # Writes are **in-place and key-scoped**: {.apply} finds any case-variant of
+      # the CSP key (Rack 3 mandates lowercase response-header keys, but a
+      # canonical-/mixed-cased key from a downstream layer is a spec violation this
+      # corrects in place), deletes it, and writes the lowercase key into the
+      # CALLER'S headers hash. There is no wrapping, no copy, and no
+      # "callers-must-use-the-return-value" contract — the `[status, headers,
+      # body]` tuple never needs reassignment. A frozen headers hash therefore
+      # fails loud (FrozenError) on write, surfacing the downstream SPEC violation
+      # rather than silently dropping the policy.
+      #
+      # The return is a {Result}, not the headers: `result.applied?`,
+      # `result.policy`, `result.skip_reason` give uniform observability across
+      # every surface (and drive the optional debug log) without any cleverness to
+      # detect "did anything happen".
+      class Writer
+        # Canonical (lowercase, per Rack 3 SPEC) response-header keys.
+        CSP_HEADER = 'content-security-policy'
+        CONTENT_TYPE_HEADER = 'content-type'
+
+        # Emission modes. `:override` is a deliberate per-request call that
+        # REPLACES any existing CSP (the caller owns this response's policy).
+        # `:backstop` is a passive layer that DEFERS to an existing CSP (it only
+        # fills the gap, never clobbers).
+        MODES = %i[override backstop].freeze
+
+        # Outcome of an {Writer.apply} call.
+        #
+        # `applied?` is the single source of truth for "did a header get
+        # written". `policy` is the emitted policy on success, or the pre-existing
+        # policy when a `:backstop` deferred to one. `skip_reason` is one of
+        # `:disabled`, `:blank_nonce`, `:non_html`, `:existing_csp` when skipped,
+        # else nil.
+        class Result
+          # Recognized skip reasons, in the order {Writer.apply} evaluates them.
+          SKIP_REASONS = %i[disabled blank_nonce non_html existing_csp].freeze
+
+          attr_reader :policy, :skip_reason, :mode
+
+          def initialize(applied:, mode:, policy: nil, skip_reason: nil)
+            @applied = applied
+            @mode = mode
+            @policy = policy
+            @skip_reason = skip_reason
+          end
+
+          # Build an "applied" result for a written policy.
+          def self.applied(policy, mode:)
+            new(applied: true, mode: mode, policy: policy)
+          end
+
+          # Build a "skipped" result. `policy` carries the pre-existing policy for
+          # the `:existing_csp` case (observability), nil otherwise.
+          def self.skipped(reason, mode:, policy: nil)
+            new(applied: false, mode: mode, skip_reason: reason, policy: policy)
+          end
+
+          # @return [Boolean] true when a CSP header was written
+          def applied?
+            @applied
+          end
+
+          # @return [Boolean] true when no header was written
+          def skipped?
+            !@applied
+          end
+        end
+
+        # Apply a nonce-based CSP to the caller's response headers, in place.
+        #
+        # @param headers [Hash] the Rack response headers hash, mutated in place.
+        #   MUST be mutable (Rack 3 SPEC); a frozen hash raises FrozenError.
+        # @param nonce [String, nil] the per-request nonce.
+        # @param config [Otto::Security::Config, nil] source of the enabled gate
+        #   and the policy string ({Otto::Security::Config#generate_nonce_csp}).
+        # @param mode [Symbol] one of {MODES}.
+        # @param development_mode [Boolean] use the development directive set.
+        # @return [Result]
+        # @raise [ArgumentError] if mode is not one of {MODES}
+        # @raise [FrozenError] if a write is attempted against a frozen headers hash
+        def self.apply(headers, nonce, config:, mode: :override, development_mode: false)
+          unless MODES.include?(mode)
+            raise ArgumentError, "mode must be one of #{MODES.join(', ')}, got #{mode.inspect}"
+          end
+
+          result = evaluate(headers, nonce, config, mode, development_mode)
+          log_debug(config, result)
+          result
+        end
+
+        # Guarded core: returns a Result and performs the in-place write when it
+        # applies. Guards are evaluated most-fundamental first so the reported
+        # skip_reason is stable and meaningful.
+        def self.evaluate(headers, nonce, config, mode, development_mode)
+          return Result.skipped(:disabled, mode: mode) unless enabled?(config)
+          return Result.skipped(:blank_nonce, mode: mode) if blank?(nonce)
+          return Result.skipped(:non_html, mode: mode) unless html_response?(headers)
+
+          existing = existing_csp(headers)
+          return Result.skipped(:existing_csp, mode: mode, policy: existing) if existing && mode == :backstop
+
+          policy = config.generate_nonce_csp(nonce, development_mode: development_mode)
+          write_csp(headers, policy)
+          Result.applied(policy, mode: mode)
+        end
+        private_class_method :evaluate
+
+        # In-place, key-scoped write. Delete any case-variant of the CSP key
+        # (correcting a downstream SPEC violation), then write the canonical
+        # lowercase key into the caller's hash. Variant keys are collected before
+        # deleting so we never mutate the hash while iterating it.
+        def self.write_csp(headers, policy)
+          variant_keys = headers.keys.select { |key| key != CSP_HEADER && key.to_s.casecmp?(CSP_HEADER) }
+          variant_keys.each { |key| headers.delete(key) }
+          headers[CSP_HEADER] = policy
+        end
+        private_class_method :write_csp
+
+        # Whether the config has nonce-CSP enabled (nil/foreign configs are "off").
+        def self.enabled?(config)
+          config.respond_to?(:csp_nonce_enabled?) && config.csp_nonce_enabled?
+        end
+        private_class_method :enabled?
+
+        # Whether the response is HTML, by the leading media type of its
+        # Content-Type (case-insensitive; charset and other parameters ignored).
+        # The media type must be exactly `text/html` — matched on the token
+        # before any `;`, so `text/html; charset=utf-8` is HTML but `text/html5`
+        # or `text/html-foo` is not. Absent Content-Type is treated as non-HTML:
+        # a nonce-only CSP on a response the templates never stamped would block
+        # every script.
+        def self.html_response?(headers)
+          content_type = lookup(headers, CONTENT_TYPE_HEADER)
+          return false if content_type.nil?
+
+          media_type = content_type.to_s.split(';', 2).first.to_s.strip.downcase
+          media_type == 'text/html'
+        end
+        private_class_method :html_response?
+
+        # The existing CSP value (any case-variant key), or nil.
+        def self.existing_csp(headers)
+          lookup(headers, CSP_HEADER)
+        end
+        private_class_method :existing_csp
+
+        # Case-insensitive header read: fast path for the canonical lowercase key,
+        # else a scan for a case-variant.
+        def self.lookup(headers, name)
+          return headers[name] if headers.key?(name)
+
+          headers.each { |key, value| return value if key.to_s.casecmp?(name) }
+          nil
+        end
+        private_class_method :lookup
+
+        def self.blank?(value)
+          value.nil? || value.to_s.empty?
+        end
+        private_class_method :blank?
+
+        # Uniform debug observability: when the config opts into CSP debugging,
+        # log the outcome — applied policy OR skip reason — so "why didn't my page
+        # get a CSP?" no longer needs a debugger.
+        def self.log_debug(config, result)
+          return unless config.respond_to?(:debug_csp?) && config.debug_csp?
+          return unless defined?(Otto.logger) && Otto.logger
+
+          detail = result.applied? ? "applied (#{result.mode}) #{result.policy}" : "skipped (#{result.skip_reason})"
+          Otto.logger.debug("[CSP] #{detail}")
+        end
+        private_class_method :log_debug
+      end
+    end
+  end
+end

--- a/lib/otto/version.rb
+++ b/lib/otto/version.rb
@@ -3,5 +3,5 @@
 # frozen_string_literal: true
 
 class Otto
-  VERSION = '2.4.0'
+  VERSION = '2.5.0'
 end

--- a/spec/otto/response_csp_spec.rb
+++ b/spec/otto/response_csp_spec.rb
@@ -4,70 +4,141 @@
 
 require 'spec_helper'
 
-# Unit coverage for Otto::Response#send_csp_headers — the public, nonce-based
-# CSP EMITTING half. It had zero direct coverage; this pins its branch logic:
-# the csp_nonce_enabled? gate, security_config resolution (opts -> request env
-# -> nil), the override-with-warning behavior, and development vs production
-# directives.
-RSpec.describe Otto::Response, '#send_csp_headers' do
-  let(:response) { described_class.new }
-
-  def nonce_config(debug: false)
+# Coverage for the Otto::Response nonce-CSP EMITTING surface: the #apply_csp
+# helper (routed through the single apply core) and the deprecated
+# #send_csp_headers shim whose historical quirks are now fixed by that core.
+RSpec.describe Otto::Response do
+  def build_config(enabled: true, debug: false)
     config = Otto::Security::Config.new
-    config.enable_csp_with_nonce!(debug: debug)
+    config.enable_csp_with_nonce!(debug: debug) if enabled
     config
   end
 
-  it 'emits a nonce-based CSP policy when nonce support is enabled' do
-    response.send_csp_headers('text/html', 'abc123', security_config: nonce_config)
+  # Reset the one-time deprecation guard so each example observes it freshly.
+  before { described_class.send_csp_headers_deprecation_warned = false }
 
-    csp = response.headers['content-security-policy']
-    expect(csp).to include("script-src 'nonce-abc123'")
-    expect(response.headers['content-type']).to eq('text/html')
+  describe '#apply_csp' do
+    # Contract helper (see spec/support/nonce_csp_emission_examples.rb).
+    def emit_csp(headers:, nonce:, mode: :override, enabled: true, development_mode: false)
+      response = described_class.new
+      headers.each { |k, v| response.headers[k] = v }
+      response.apply_csp(nonce, mode: mode, development_mode: development_mode,
+                                security_config: build_config(enabled: enabled))
+      response.headers
+    end
+
+    include_examples 'a nonce-CSP emission surface'
+    include_examples 'a CSP override surface'
+    include_examples 'a CSP backstop surface'
+
+    it 'returns the Writer::Result' do
+      response = described_class.new
+      response.headers['content-type'] = 'text/html'
+      result = response.apply_csp('N', security_config: build_config)
+
+      expect(result).to be_a(Otto::Security::CSP::Writer::Result)
+      expect(result).to be_applied
+      expect(result.policy).to include("'nonce-N'")
+    end
+
+    it 'resolves the security config from the request env when not passed' do
+      env = mock_rack_env(method: 'GET', path: '/')
+      env['otto.security_config'] = build_config
+      response = described_class.new
+      response.headers['content-type'] = 'text/html'
+      response.request = Otto::Request.new(env)
+
+      response.apply_csp('zzz')
+      expect(response.headers['content-security-policy']).to include("'nonce-zzz'")
+    end
+
+    it 'does not set the Content-Type (caller owns it)' do
+      response = described_class.new
+      result = response.apply_csp('N', security_config: build_config)
+
+      expect(response.headers).not_to have_key('content-security-policy')
+      expect(result.skip_reason).to eq(:non_html)
+    end
   end
 
-  it 'does nothing (no CSP header) when nonce support is disabled' do
-    disabled = Otto::Security::Config.new # nonce not enabled
+  describe '#send_csp_headers (deprecated shim)' do
+    let(:response) { described_class.new }
 
-    response.send_csp_headers('text/html', 'abc123', security_config: disabled)
+    it 'emits a nonce-based CSP policy when nonce support is enabled' do
+      response.send_csp_headers('text/html', 'abc123', security_config: build_config)
 
-    expect(response.headers).not_to have_key('content-security-policy')
-    # content-type is still set before the early return
-    expect(response.headers['content-type']).to eq('text/html')
-  end
+      expect(response.headers['content-security-policy']).to include("script-src 'nonce-abc123'")
+      expect(response.headers['content-type']).to eq('text/html')
+    end
 
-  it 'does nothing when no security config can be resolved' do
-    response.send_csp_headers('text/html', 'abc123')
+    it 'sets Content-Type only when not already set' do
+      response.headers['content-type'] = 'text/html; charset=utf-8'
+      response.send_csp_headers('text/plain', 'abc123', security_config: build_config)
 
-    expect(response.headers).not_to have_key('content-security-policy')
-  end
+      expect(response.headers['content-type']).to eq('text/html; charset=utf-8')
+    end
 
-  it 'resolves the security config from the request env when not passed in opts' do
-    env = mock_rack_env(method: 'GET', path: '/')
-    env['otto.security_config'] = nonce_config
-    response.request = Otto::Request.new(env)
+    it 'does nothing (no CSP) when nonce support is disabled' do
+      response.send_csp_headers('text/html', 'abc123', security_config: build_config(enabled: false))
 
-    response.send_csp_headers('text/html', 'zzz')
+      expect(response.headers).not_to have_key('content-security-policy')
+      expect(response.headers['content-type']).to eq('text/html') # set before the skip
+    end
 
-    expect(response.headers['content-security-policy']).to include("'nonce-zzz'")
-  end
+    it 'does nothing when no security config can be resolved' do
+      response.send_csp_headers('text/html', 'abc123')
+      expect(response.headers).not_to have_key('content-security-policy')
+    end
 
-  it 'overrides an existing CSP header and warns' do
-    response.headers['content-security-policy'] = "default-src 'self'"
+    it 'resolves the security config from the request env' do
+      env = mock_rack_env(method: 'GET', path: '/')
+      env['otto.security_config'] = build_config
+      response.request = Otto::Request.new(env)
 
-    expect do
-      response.send_csp_headers('text/html', 'abc123', security_config: nonce_config)
-    end.to output(/CSP header already set/).to_stderr
+      response.send_csp_headers('text/html', 'zzz')
+      expect(response.headers['content-security-policy']).to include("'nonce-zzz'")
+    end
 
-    expect(response.headers['content-security-policy']).to include("'nonce-abc123'")
-  end
+    it 'uses development directives when development_mode is set' do
+      response.send_csp_headers('text/html', 'devnonce',
+                                security_config: build_config, development_mode: true)
 
-  it 'uses development directives when development_mode is set' do
-    response.send_csp_headers('text/html', 'devnonce',
-      security_config: nonce_config, development_mode: true)
+      expect(response.headers['content-security-policy']).to include("script-src 'nonce-devnonce' 'unsafe-inline'")
+    end
 
-    csp = response.headers['content-security-policy']
-    # Development allows inline scripts alongside the nonce; production does not.
-    expect(csp).to include("script-src 'nonce-devnonce' 'unsafe-inline'")
+    context 'quirks now fixed by the apply core' do
+      it 'skips a blank/nil nonce instead of emitting a broken nonce- policy' do
+        response.send_csp_headers('text/html', '', security_config: build_config)
+        expect(response.headers).not_to have_key('content-security-policy')
+
+        response.send_csp_headers('text/html', nil, security_config: build_config)
+        expect(response.headers).not_to have_key('content-security-policy')
+      end
+
+      it 'does not emit a CSP for a non-HTML (JSON) response' do
+        response.send_csp_headers('application/json', 'abc123', security_config: build_config)
+        expect(response.headers).not_to have_key('content-security-policy')
+      end
+
+      it 'overrides an existing CSP WITHOUT writing to stderr (override is deliberate now)' do
+        response.headers['content-security-policy'] = "default-src 'self'"
+
+        expect do
+          response.send_csp_headers('text/html', 'abc123', security_config: build_config)
+        end.not_to output.to_stderr
+
+        expect(response.headers['content-security-policy']).to include("'nonce-abc123'")
+      end
+    end
+
+    context 'deprecation notice' do
+      it 'warns once via Otto.logger (not stderr)' do
+        expect(Otto.logger).to receive(:warn).with(/#send_csp_headers is deprecated/).once
+
+        response.send_csp_headers('text/html', 'abc123', security_config: build_config)
+        # A second call in the same process does not warn again.
+        described_class.new.send_csp_headers('text/html', 'abc123', security_config: build_config)
+      end
+    end
   end
 end

--- a/spec/otto/security/csp/emit_middleware_spec.rb
+++ b/spec/otto/security/csp/emit_middleware_spec.rb
@@ -1,0 +1,137 @@
+# spec/otto/security/csp/emit_middleware_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Otto::Security::CSP::EmitMiddleware do
+  def build_config(enabled: true, debug: false)
+    config = Otto::Security::Config.new
+    config.enable_csp_with_nonce!(debug: debug) if enabled
+    config
+  end
+
+  # Contract helper (see spec/support/nonce_csp_emission_examples.rb). The
+  # middleware is always a backstop; a provided nonce is simulated as one the
+  # request CONSUMED (memoized in env), matching emit-if-consumed. `mode:` is
+  # accepted for signature symmetry but the middleware is inherently :backstop.
+  def emit_csp(headers:, nonce:, mode: :backstop, enabled: true, development_mode: false)
+    config = build_config(enabled: enabled)
+    env = { 'otto.security_config' => config }
+    env['otto.nonce'] = nonce if nonce && !nonce.to_s.empty?
+    app = ->(_e) { [200, headers, []] }
+    _status, out_headers, = described_class.new(app, config, development_mode: development_mode).call(env)
+    out_headers
+  end
+
+  include_examples 'a nonce-CSP emission surface'
+  include_examples 'a CSP backstop surface'
+
+  let(:enabled_config) { build_config }
+  let(:html_headers) { { 'content-type' => 'text/html; charset=utf-8' } }
+
+  def call_with(env:, headers:, config: enabled_config, **opts)
+    app = ->(_e) { [200, headers, ['body']] }
+    described_class.new(app, config, **opts).call(env)
+  end
+
+  describe 'inertness' do
+    it 'is a transparent pass-through when nonce-CSP is disabled' do
+      env = { 'otto.security_config' => build_config(enabled: false), 'otto.nonce' => 'N' }
+      status, headers, body = call_with(env: env, headers: html_headers.dup, config: build_config(enabled: false))
+
+      expect(status).to eq(200)
+      expect(body).to eq(['body'])
+      expect(headers).not_to have_key('content-security-policy')
+    end
+
+    it 'never mints a nonce when disabled, even in eager mode' do
+      env = { 'otto.security_config' => build_config(enabled: false) }
+      call_with(env: env, headers: html_headers.dup, config: build_config(enabled: false), eager: true)
+      expect(env).not_to have_key('otto.nonce')
+    end
+  end
+
+  describe 'emit-if-consumed (default)' do
+    it 'does NOT emit when the request never consumed a nonce' do
+      env = { 'otto.security_config' => enabled_config }
+      _status, headers, = call_with(env: env, headers: html_headers.dup)
+
+      expect(headers).not_to have_key('content-security-policy')
+      expect(env).not_to have_key('otto.nonce') # and it did not mint one
+    end
+
+    it 'emits when a view consumed the nonce (memoized in env)' do
+      env = { 'otto.security_config' => enabled_config, 'otto.nonce' => 'view-nonce' }
+      _status, headers, = call_with(env: env, headers: html_headers.dup)
+
+      expect(headers['content-security-policy']).to include("'nonce-view-nonce'")
+    end
+
+    it 'agrees with the env nonce (structural view/header agreement)' do
+      env = mock_rack_env(method: 'GET', path: '/')
+      env['otto.security_config'] = enabled_config
+      request = Otto::Request.new(env)
+      consumed = request.csp_nonce # a "view" consumes the nonce
+
+      _status, headers, = call_with(env: env, headers: html_headers.dup)
+      expect(headers['content-security-policy']).to include("'nonce-#{consumed}'")
+    end
+  end
+
+  describe 'eager mode' do
+    it 'mints a nonce and emits even without consumption' do
+      env = { 'otto.security_config' => enabled_config }
+      headers = html_headers.dup
+      call_with(env: env, headers: headers, eager: true)
+
+      minted = env['otto.nonce']
+      expect(minted).not_to be_nil
+      expect(headers['content-security-policy']).to include("'nonce-#{minted}'")
+    end
+
+    it 'still defers to an existing CSP (backstop, never clobbers)' do
+      env = { 'otto.security_config' => enabled_config }
+      headers = html_headers.merge('content-security-policy' => 'PRESET')
+      call_with(env: env, headers: headers, eager: true)
+
+      expect(headers['content-security-policy']).to eq('PRESET')
+    end
+  end
+
+  describe 'per-request development_mode callable' do
+    it 'invokes the callable with the env to decide the directive set' do
+      env = { 'otto.security_config' => enabled_config, 'otto.nonce' => 'N', 'dev' => true }
+      dev = ->(e) { e['dev'] == true }
+      _status, headers, = call_with(env: env, headers: html_headers.dup, development_mode: dev)
+
+      expect(headers['content-security-policy']).to include("'nonce-N' 'unsafe-inline'")
+    end
+
+    it 'uses production directives when the callable returns false' do
+      env = { 'otto.security_config' => enabled_config, 'otto.nonce' => 'N', 'dev' => false }
+      dev = ->(e) { e['dev'] == true }
+      _status, headers, = call_with(env: env, headers: html_headers.dup, development_mode: dev)
+
+      expect(headers['content-security-policy']).to include("script-src 'nonce-N';")
+      expect(headers['content-security-policy']).not_to include('unsafe-inline;')
+    end
+  end
+
+  describe 'response passthrough' do
+    it 'returns the same status and body the inner app produced' do
+      env = { 'otto.security_config' => enabled_config, 'otto.nonce' => 'N' }
+      status, _headers, body = call_with(env: env, headers: html_headers.dup)
+
+      expect(status).to eq(200)
+      expect(body).to eq(['body'])
+    end
+  end
+
+  describe 'wiring' do
+    it 'is registered as config-consuming middleware' do
+      stack = Otto::Core::MiddlewareStack.new
+      expect(stack.send(:middleware_needs_config?, described_class)).to be true
+    end
+  end
+end

--- a/spec/otto/security/csp/nonce_spec.rb
+++ b/spec/otto/security/csp/nonce_spec.rb
@@ -1,0 +1,130 @@
+# spec/otto/security/csp/nonce_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Otto::Security::CSP, '.nonce (framework-owned lazy nonce)' do
+  describe '.nonce' do
+    it 'generates a nonce on first access' do
+      env = {}
+      expect(described_class.nonce(env)).to be_a(String)
+      expect(described_class.nonce(env)).not_to be_empty
+    end
+
+    it 'memoizes: the same value on repeated access within a request' do
+      env = {}
+      first = described_class.nonce(env)
+      expect(described_class.nonce(env)).to eq(first)
+      expect(env['otto.nonce']).to eq(first)
+    end
+
+    it 'stores the nonce under the default env key' do
+      env = {}
+      nonce = described_class.nonce(env)
+      expect(env['otto.nonce']).to eq(nonce)
+    end
+
+    it 'honors a value already present under the key (app-minted convention)' do
+      env = { 'otto.nonce' => 'preset' }
+      expect(described_class.nonce(env)).to eq('preset')
+    end
+
+    it 'regenerates over a blank pre-set value' do
+      env = { 'otto.nonce' => '' }
+      expect(described_class.nonce(env)).not_to be_empty
+    end
+
+    it 'respects an explicit key override' do
+      env = {}
+      nonce = described_class.nonce(env, key: 'custom.nonce')
+      expect(env['custom.nonce']).to eq(nonce)
+      expect(env).not_to have_key('otto.nonce')
+    end
+
+    it 'resolves the key from the security config convention' do
+      config = Otto::Security::Config.new
+      config.csp_nonce_key = 'onetime.nonce'
+      env = { 'otto.security_config' => config }
+
+      nonce = described_class.nonce(env)
+      expect(env['onetime.nonce']).to eq(nonce)
+      expect(env).not_to have_key('otto.nonce')
+    end
+  end
+
+  describe '.nonce? (emit-if-consumed predicate)' do
+    it 'is false for an untouched request and does NOT mint a nonce' do
+      env = {}
+      expect(described_class.nonce?(env)).to be false
+      expect(env).not_to have_key('otto.nonce')
+    end
+
+    it 'is true once a nonce has been consumed' do
+      env = {}
+      described_class.nonce(env)
+      expect(described_class.nonce?(env)).to be true
+    end
+
+    it 'is false for a blank value under the key' do
+      expect(described_class.nonce?({ 'otto.nonce' => '' })).to be false
+    end
+
+    it 'honors the configured key' do
+      config = Otto::Security::Config.new
+      config.csp_nonce_key = 'onetime.nonce'
+      env = { 'otto.security_config' => config, 'onetime.nonce' => 'N' }
+      expect(described_class.nonce?(env)).to be true
+    end
+  end
+
+  describe 'Otto::Request#csp_nonce' do
+    it 'generates and memoizes into the request env' do
+      req = Otto::Request.new(mock_rack_env(method: 'GET', path: '/'))
+      nonce = req.csp_nonce
+      expect(nonce).to be_a(String)
+      expect(nonce).not_to be_empty
+      expect(req.csp_nonce).to eq(nonce)
+      expect(req.env['otto.nonce']).to eq(nonce)
+    end
+
+    it 'uses the configured nonce key' do
+      config = Otto::Security::Config.new
+      config.csp_nonce_key = 'onetime.nonce'
+      env = mock_rack_env(method: 'GET', path: '/')
+      env['otto.security_config'] = config
+
+      req = Otto::Request.new(env)
+      nonce = req.csp_nonce
+      expect(env['onetime.nonce']).to eq(nonce)
+    end
+  end
+
+  describe 'Otto::Security::Config#csp_nonce_key' do
+    subject(:config) { Otto::Security::Config.new }
+
+    it 'defaults to otto.nonce' do
+      expect(config.csp_nonce_key).to eq('otto.nonce')
+    end
+
+    it 'is settable to an app convention' do
+      config.csp_nonce_key = 'onetime.nonce'
+      expect(config.csp_nonce_key).to eq('onetime.nonce')
+    end
+
+    it 'strips surrounding whitespace' do
+      config.csp_nonce_key = '  app.nonce  '
+      expect(config.csp_nonce_key).to eq('app.nonce')
+    end
+
+    it 'resets a blank value to the default' do
+      config.csp_nonce_key = '   '
+      expect(config.csp_nonce_key).to eq('otto.nonce')
+    end
+
+    it 'raises when the configuration is frozen' do
+      config.deep_freeze!
+      expect { config.csp_nonce_key = 'x' }.to raise_error(FrozenError)
+    end
+  end
+end

--- a/spec/otto/security/csp/policy_spec.rb
+++ b/spec/otto/security/csp/policy_spec.rb
@@ -1,0 +1,105 @@
+# spec/otto/security/csp/policy_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Direct coverage for Otto::Security::CSP::Policy. Its output is also exercised
+# transitively (Config#generate_nonce_csp / #build_static_csp delegate here), but
+# pinning the exact directive format in isolation guards the byte-identical
+# contract against a regression in the delegation or the directive sets.
+RSpec.describe Otto::Security::CSP::Policy do
+  let(:production) do
+    "default-src 'none'; script-src 'nonce-N'; style-src 'self' 'unsafe-inline'; " \
+      "connect-src 'self' wss: https:; img-src 'self' data:; font-src 'self'; " \
+      "object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; " \
+      "manifest-src 'self'; worker-src 'self' data:;"
+  end
+
+  describe '.nonce_policy' do
+    it 'produces the production directive set by default' do
+      expect(described_class.nonce_policy('N')).to eq(production)
+    end
+
+    it 'produces the development directive set when requested' do
+      csp = described_class.nonce_policy('N', development_mode: true)
+      expect(csp).to include("script-src 'nonce-N' 'unsafe-inline';")
+      expect(csp).to include("connect-src 'self' ws: wss: http: https:;")
+    end
+
+    it 'appends report-uri (terminated with a semicolon) when configured' do
+      expect(described_class.nonce_policy('N', report_uri: '/_/csp-report'))
+        .to eq("#{production} report-uri /_/csp-report;")
+    end
+
+    it 'appends report-to (using the shared group) when a reporting URL is configured' do
+      expect(described_class.nonce_policy('N', report_to_url: 'https://e/x'))
+        .to eq("#{production} report-to otto-csp;")
+    end
+
+    it 'appends report-uri before report-to when both are configured' do
+      expect(described_class.nonce_policy('N', report_uri: '/r', report_to_url: 'https://e/x'))
+        .to eq("#{production} report-uri /r; report-to otto-csp;")
+    end
+
+    it 'omits reporting directives for nil/blank values' do
+      expect(described_class.nonce_policy('N', report_uri: '', report_to_url: nil)).to eq(production)
+    end
+  end
+
+  describe '.static_policy' do
+    it 'is byte-identical to the base policy when no reporting is configured' do
+      expect(described_class.static_policy("default-src 'self'")).to eq("default-src 'self'")
+    end
+
+    it 'appends report-uri joined with a semicolon' do
+      expect(described_class.static_policy("default-src 'self'", report_uri: '/r'))
+        .to eq("default-src 'self'; report-uri /r")
+    end
+
+    it 'appends report-to using the shared group' do
+      expect(described_class.static_policy("default-src 'self'", report_to_url: 'https://e/x'))
+        .to eq("default-src 'self'; report-to otto-csp")
+    end
+
+    it 'appends both, report-uri before report-to' do
+      expect(described_class.static_policy("default-src 'self'", report_uri: '/r', report_to_url: 'https://e/x'))
+        .to eq("default-src 'self'; report-uri /r; report-to otto-csp")
+    end
+  end
+
+  describe 'reporting directive helpers' do
+    it 'returns nil for a nil/blank report URI' do
+      expect(described_class.report_uri_directive(nil)).to be_nil
+      expect(described_class.report_uri_directive('')).to be_nil
+    end
+
+    it 'returns nil for a nil/blank report-to URL' do
+      expect(described_class.report_to_directive(nil)).to be_nil
+      expect(described_class.report_to_directive('')).to be_nil
+    end
+  end
+
+  describe 'REPORTING_GROUP' do
+    it 'is the shared group name' do
+      expect(described_class::REPORTING_GROUP).to eq('otto-csp')
+    end
+
+    it 'is the single source Config::CSP_REPORTING_GROUP aliases' do
+      expect(Otto::Security::Config::CSP_REPORTING_GROUP).to eq(described_class::REPORTING_GROUP)
+    end
+  end
+
+  describe 'byte-identical delegation from Config' do
+    it 'matches Config#generate_nonce_csp exactly (production + reporting)' do
+      config = Otto::Security::Config.new
+      config.enable_csp_with_nonce!
+      config.csp_report_uri = '/_/csp-report'
+      config.csp_report_to_url = 'https://example.com/_/csp-report'
+
+      expect(config.generate_nonce_csp('N')).to eq(
+        described_class.nonce_policy('N', report_uri: '/_/csp-report', report_to_url: 'https://example.com/_/csp-report')
+      )
+    end
+  end
+end

--- a/spec/otto/security/csp/writer_spec.rb
+++ b/spec/otto/security/csp/writer_spec.rb
@@ -1,0 +1,125 @@
+# spec/otto/security/csp/writer_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Otto::Security::CSP::Writer do
+  def build_config(enabled: true, debug: false)
+    config = Otto::Security::Config.new
+    config.enable_csp_with_nonce!(debug: debug) if enabled
+    config
+  end
+
+  # Contract helper (see spec/support/nonce_csp_emission_examples.rb): drive the
+  # Writer and return the caller's headers as it left them.
+  def emit_csp(headers:, nonce:, mode: :override, enabled: true, development_mode: false)
+    described_class.apply(headers, nonce, config: build_config(enabled: enabled), mode: mode,
+                                          development_mode: development_mode)
+    headers
+  end
+
+  include_examples 'a nonce-CSP emission surface'
+  include_examples 'a CSP override surface'
+  include_examples 'a CSP backstop surface'
+
+  describe '.apply return value (Result)' do
+    let(:config) { build_config }
+
+    it 'returns an applied Result carrying the written policy and mode' do
+      headers = { 'content-type' => 'text/html' }
+      result = described_class.apply(headers, 'N', config: config, mode: :override)
+
+      expect(result).to be_applied
+      expect(result).not_to be_skipped
+      expect(result.policy).to eq(headers['content-security-policy'])
+      expect(result.policy).to include("'nonce-N'")
+      expect(result.mode).to eq(:override)
+      expect(result.skip_reason).to be_nil
+    end
+
+    it 'reports :disabled when nonce-CSP is off' do
+      result = described_class.apply({ 'content-type' => 'text/html' }, 'N', config: build_config(enabled: false))
+      expect(result.skip_reason).to eq(:disabled)
+      expect(result.policy).to be_nil
+    end
+
+    it 'reports :disabled when config is nil' do
+      result = described_class.apply({ 'content-type' => 'text/html' }, 'N', config: nil)
+      expect(result).to be_skipped
+      expect(result.skip_reason).to eq(:disabled)
+    end
+
+    it 'reports :blank_nonce for a nil/empty nonce' do
+      expect(described_class.apply({ 'content-type' => 'text/html' }, nil, config: config).skip_reason).to eq(:blank_nonce)
+      expect(described_class.apply({ 'content-type' => 'text/html' }, '', config: config).skip_reason).to eq(:blank_nonce)
+    end
+
+    it 'reports :non_html for a non-HTML response' do
+      expect(described_class.apply({ 'content-type' => 'application/json' }, 'N', config: config).skip_reason).to eq(:non_html)
+      expect(described_class.apply({}, 'N', config: config).skip_reason).to eq(:non_html)
+    end
+
+    it 'reports :existing_csp and returns the pre-existing policy in backstop mode' do
+      headers = { 'content-type' => 'text/html', 'content-security-policy' => 'PRESET' }
+      result = described_class.apply(headers, 'N', config: config, mode: :backstop)
+
+      expect(result).to be_skipped
+      expect(result.skip_reason).to eq(:existing_csp)
+      expect(result.policy).to eq('PRESET')
+      expect(headers['content-security-policy']).to eq('PRESET')
+    end
+  end
+
+  describe 'in-place, key-scoped writes' do
+    it 'mutates the caller hash in place (same object identity)' do
+      headers = { 'content-type' => 'text/html' }
+      described_class.apply(headers, 'N', config: build_config)
+      expect(headers).to have_key('content-security-policy')
+    end
+
+    it 'leaves unrelated headers untouched' do
+      headers = { 'content-type' => 'text/html', 'x-frame-options' => 'DENY' }
+      described_class.apply(headers, 'N', config: build_config)
+      expect(headers['x-frame-options']).to eq('DENY')
+    end
+
+    it 'does not touch the hash at all when it skips' do
+      headers = { 'content-type' => 'application/json' }.freeze
+      expect { described_class.apply(headers, 'N', config: build_config) }.not_to raise_error
+    end
+  end
+
+  describe 'frozen headers (downstream Rack SPEC violation) fails loud' do
+    it 'raises FrozenError when a write is attempted against a frozen hash' do
+      headers = { 'content-type' => 'text/html' }.freeze
+      expect { described_class.apply(headers, 'N', config: build_config) }.to raise_error(FrozenError)
+    end
+  end
+
+  describe 'mode validation' do
+    it 'raises ArgumentError for an unknown mode' do
+      expect { described_class.apply({ 'content-type' => 'text/html' }, 'N', config: build_config, mode: :clobber) }
+        .to raise_error(ArgumentError, /mode must be one of/)
+    end
+  end
+
+  describe 'debug observability' do
+    it 'logs the applied policy when debug_csp? is on' do
+      config = build_config(debug: true)
+      expect(Otto.logger).to receive(:debug).with(/\[CSP\] applied \(override\).*nonce-N/)
+      described_class.apply({ 'content-type' => 'text/html' }, 'N', config: config)
+    end
+
+    it 'logs the skip reason when debug_csp? is on (skips are observable)' do
+      config = build_config(debug: true)
+      expect(Otto.logger).to receive(:debug).with('[CSP] skipped (non_html)')
+      described_class.apply({ 'content-type' => 'application/json' }, 'N', config: config)
+    end
+
+    it 'does not log when debug_csp? is off' do
+      expect(Otto.logger).not_to receive(:debug)
+      described_class.apply({ 'content-type' => 'text/html' }, 'N', config: build_config(debug: false))
+    end
+  end
+end

--- a/spec/otto/security/csp_emission_integration_spec.rb
+++ b/spec/otto/security/csp_emission_integration_spec.rb
@@ -1,0 +1,108 @@
+# spec/otto/security/csp_emission_integration_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tempfile'
+
+# End-to-end coverage of Otto#enable_csp_emission!: a full Otto instance with a
+# routes file, exercised through Rack::Test, proving the EmitMiddleware backstop
+# applies a nonce CSP for HTML responses whose request consumed a nonce, stays
+# silent for those that did not (emit-if-consumed), and never clobbers a policy
+# a route already set.
+RSpec.describe 'Otto CSP emission (integration)' do
+  include Rack::Test::Methods
+
+  # Controller instantiated as new(req, res); the action runs with no arguments.
+  class CspEmitApp
+    def initialize(req, res)
+      @req = req
+      @res = res
+    end
+
+    # A "view" that stamps the framework-owned nonce onto an inline script.
+    def with_nonce
+      @res['content-type'] = 'text/html; charset=utf-8'
+      @res.write(%(<script nonce="#{@req.csp_nonce}">1</script>))
+    end
+
+    # An HTML response that never touches the nonce.
+    def without_nonce
+      @res['content-type'] = 'text/html; charset=utf-8'
+      @res.write('<p>no nonce</p>')
+    end
+
+    # A JSON response (non-HTML).
+    def json
+      @res['content-type'] = 'application/json'
+      @res.write('{"ok":true}')
+    end
+
+    # A route that sets its own CSP; the backstop must defer to it.
+    def preset_csp
+      @res['content-type'] = 'text/html; charset=utf-8'
+      @res['content-security-policy'] = "default-src 'self'"
+      @res.write('preset')
+    end
+  end
+
+  let(:routes_file) do
+    file = Tempfile.new(['csp_emit_routes', '.txt'])
+    file.write(<<~ROUTES)
+      GET /with CspEmitApp#with_nonce
+      GET /without CspEmitApp#without_nonce
+      GET /json CspEmitApp#json
+      GET /preset CspEmitApp#preset_csp
+    ROUTES
+    file.flush
+    file
+  end
+
+  let(:otto) do
+    instance = Otto.new(routes_file.path)
+    instance.enable_csp_with_nonce!
+    instance.enable_csp_emission!
+    instance
+  end
+
+  def app
+    otto
+  end
+
+  after { routes_file.close! }
+
+  it 'registers the emit middleware in the stack' do
+    expect(otto.middleware_stack.map(&:name)).to include('Otto::Security::CSP::EmitMiddleware')
+  end
+
+  it 'emits a nonce CSP whose nonce matches the one the view stamped' do
+    get '/with'
+    csp = last_response.headers['content-security-policy']
+    body_nonce = last_response.body[/nonce="([^"]+)"/, 1]
+
+    expect(csp).to include("script-src 'nonce-#{body_nonce}'")
+  end
+
+  it 'stays silent for an HTML response that never consumed a nonce' do
+    get '/without'
+    expect(last_response.headers).not_to have_key('content-security-policy')
+  end
+
+  it 'stays silent for a non-HTML (JSON) response' do
+    get '/json'
+    expect(last_response.headers).not_to have_key('content-security-policy')
+  end
+
+  it 'defers to a CSP the route already set (never clobbers)' do
+    get '/preset'
+    expect(last_response.headers['content-security-policy']).to eq("default-src 'self'")
+  end
+
+  it 'is inert when emission is enabled but nonce-CSP is not' do
+    instance = Otto.new(routes_file.path)
+    instance.enable_csp_emission! # no enable_csp_with_nonce!
+    get_env = Rack::MockRequest.env_for('/with')
+    _status, headers, = instance.call(get_env)
+    expect(headers).not_to have_key('content-security-policy')
+  end
+end

--- a/spec/support/nonce_csp_emission_examples.rb
+++ b/spec/support/nonce_csp_emission_examples.rb
@@ -1,0 +1,189 @@
+# spec/support/nonce_csp_emission_examples.rb
+#
+# frozen_string_literal: true
+
+# Contract-spec suites shared by the in-framework nonce-CSP emission surfaces
+# that opt in: the Writer core, the EmitMiddleware, and Otto::Response#apply_csp.
+# (The deprecated Otto::Response#send_csp_headers inherits the same contract by
+# delegating to #apply_csp, so it is exercised transitively rather than via these
+# suites.) Running the same guards, casing, and no-duplicate assertions against
+# each surface is what keeps the emission invariants from drifting apart again —
+# the whole point of routing every surface through one apply core.
+#
+# A host example group opts in by:
+#   include_examples 'a nonce-CSP emission surface'
+# and defining an `emit_csp` helper with this contract:
+#
+#   emit_csp(headers:, nonce:, mode: <surface default>, enabled: true,
+#            development_mode: false) -> Hash  # the resulting response headers
+#
+# The helper drives the surface under test and returns the response headers as
+# the surface left them, so the shared examples can assert on observable state.
+# `headers` may be pre-populated (e.g. with a case-variant CSP key) to exercise
+# the casing/clobber matrix.
+
+RSpec.shared_examples 'a nonce-CSP emission surface' do
+  # A distinctive nonce so "the header carries THIS request's nonce" is
+  # unambiguous (env-nonce / header agreement).
+  let(:test_nonce) { 'contract-nonce-Xyz09+/' }
+
+  def csp_keys(headers)
+    headers.keys.select { |k| k.to_s.casecmp?('content-security-policy') }
+  end
+
+  def csp_value(headers)
+    key = csp_keys(headers).first
+    key && headers[key]
+  end
+
+  context 'on the happy path (enabled, HTML, nonce present, no existing CSP)' do
+    let(:result_headers) do
+      emit_csp(headers: { 'content-type' => 'text/html; charset=utf-8' }, nonce: test_nonce)
+    end
+
+    it 'writes exactly one CSP header (no duplicate case-variant keys)' do
+      expect(csp_keys(result_headers).length).to eq(1)
+    end
+
+    it 'writes the canonical lowercase key' do
+      expect(csp_keys(result_headers)).to eq(['content-security-policy'])
+    end
+
+    it "carries this request's nonce (view/header agreement)" do
+      expect(csp_value(result_headers)).to include("'nonce-#{test_nonce}'")
+    end
+  end
+
+  context 'guards' do
+    it 'skips when nonce-CSP is disabled' do
+      headers = emit_csp(headers: { 'content-type' => 'text/html' }, nonce: test_nonce, enabled: false)
+      expect(csp_keys(headers)).to be_empty
+    end
+
+    it 'skips when the nonce is blank' do
+      headers = emit_csp(headers: { 'content-type' => 'text/html' }, nonce: '')
+      expect(csp_keys(headers)).to be_empty
+    end
+
+    it 'skips when the nonce is nil' do
+      headers = emit_csp(headers: { 'content-type' => 'text/html' }, nonce: nil)
+      expect(csp_keys(headers)).to be_empty
+    end
+
+    it 'skips a non-HTML (JSON) response' do
+      headers = emit_csp(headers: { 'content-type' => 'application/json' }, nonce: test_nonce)
+      expect(csp_keys(headers)).to be_empty
+    end
+
+    it 'skips a response with no Content-Type' do
+      headers = emit_csp(headers: {}, nonce: test_nonce)
+      expect(csp_keys(headers)).to be_empty
+    end
+
+    it 'emits for text/html with charset and other parameters' do
+      headers = emit_csp(headers: { 'content-type' => 'text/html; charset=utf-8' }, nonce: test_nonce)
+      expect(csp_keys(headers)).not_to be_empty
+    end
+
+    it 'emits for an uppercase TEXT/HTML media type (case-insensitive)' do
+      headers = emit_csp(headers: { 'content-type' => 'TEXT/HTML' }, nonce: test_nonce)
+      expect(csp_keys(headers)).not_to be_empty
+    end
+
+    it 'skips a media type that merely starts with text/html (e.g. text/html5)' do
+      headers = emit_csp(headers: { 'content-type' => 'text/html5' }, nonce: test_nonce)
+      expect(csp_keys(headers)).to be_empty
+    end
+  end
+
+  context 'development mode' do
+    it 'uses the development directive set when requested' do
+      headers = emit_csp(headers: { 'content-type' => 'text/html' }, nonce: test_nonce, development_mode: true)
+      expect(csp_value(headers)).to include("script-src 'nonce-#{test_nonce}' 'unsafe-inline'")
+    end
+  end
+end
+
+# Override-mode surfaces (a deliberate per-request call). These REPLACE an
+# existing CSP and normalize the key to canonical lowercase.
+RSpec.shared_examples 'a CSP override surface' do
+  let(:test_nonce) { 'override-nonce-42' }
+
+  def override_csp_keys(headers)
+    headers.keys.select { |k| k.to_s.casecmp?('content-security-policy') }
+  end
+
+  it 'replaces an existing lowercase CSP' do
+    headers = emit_csp(
+      headers: { 'content-type' => 'text/html', 'content-security-policy' => "default-src 'self'" },
+      nonce: test_nonce, mode: :override
+    )
+    expect(override_csp_keys(headers).length).to eq(1)
+    expect(headers['content-security-policy']).to include("'nonce-#{test_nonce}'")
+  end
+
+  it 'normalizes a mixed-case CSP key to a single lowercase key' do
+    headers = emit_csp(
+      headers: { 'content-type' => 'text/html', 'Content-Security-Policy' => "default-src 'self'" },
+      nonce: test_nonce, mode: :override
+    )
+    expect(override_csp_keys(headers)).to eq(['content-security-policy'])
+    expect(headers['content-security-policy']).to include("'nonce-#{test_nonce}'")
+  end
+
+  it 'collapses duplicate case-variant keys into one lowercase key' do
+    headers = emit_csp(
+      headers: {
+        'content-type' => 'text/html',
+        'Content-Security-Policy' => 'OLD-A',
+        'content-security-policy' => 'OLD-B',
+      },
+      nonce: test_nonce, mode: :override
+    )
+    expect(override_csp_keys(headers)).to eq(['content-security-policy'])
+    expect(headers['content-security-policy']).to include("'nonce-#{test_nonce}'")
+  end
+end
+
+# Backstop-mode surfaces (a passive layer). These DEFER to any existing CSP,
+# regardless of the key's casing — the case-insensitive detection is what fixes
+# the reviewer-flagged case-sensitive lookups against canonical-cased headers.
+RSpec.shared_examples 'a CSP backstop surface' do
+  let(:test_nonce) { 'backstop-nonce-7' }
+
+  def csp_entries(headers)
+    headers.select { |k, _| k.to_s.casecmp?('content-security-policy') }
+  end
+
+  # Assert on VALUE preservation + single entry rather than the exact key
+  # string, so the suite is surface-independent: raw-tuple surfaces (Writer,
+  # middleware) preserve the caller's key casing, while Rack::Headers-backed
+  # surfaces (Response) auto-lowercase on insertion. Either way, a case-SENSITIVE
+  # bug would fail to detect the existing CSP and leave a second entry (or a
+  # changed value) — which these assertions catch.
+  it 'defers to an existing lowercase CSP (leaves it untouched)' do
+    headers = emit_csp(
+      headers: { 'content-type' => 'text/html', 'content-security-policy' => 'PRESET' },
+      nonce: test_nonce, mode: :backstop
+    )
+    expect(csp_entries(headers).values).to eq(['PRESET'])
+  end
+
+  it 'defers to an existing MIXED-CASE CSP (case-insensitive; leaves it untouched)' do
+    headers = emit_csp(
+      headers: { 'content-type' => 'text/html', 'Content-Security-Policy' => 'PRESET' },
+      nonce: test_nonce, mode: :backstop
+    )
+    entries = csp_entries(headers)
+    expect(entries.values).to eq(['PRESET'])
+    expect(entries.size).to eq(1)
+  end
+
+  it 'fills the gap when no CSP is present' do
+    headers = emit_csp(
+      headers: { 'content-type' => 'text/html' },
+      nonce: test_nonce, mode: :backstop
+    )
+    expect(headers['content-security-policy']).to include("'nonce-#{test_nonce}'")
+  end
+end


### PR DESCRIPTION
## Summary

This PR extracts Otto's nonce-based Content-Security-Policy emission logic into a unified architecture with a single apply core (`Writer`), a dedicated policy builder (`Policy`), and a passive backstop middleware (`EmitMiddleware`). All in-framework CSP emission surfaces now route through one code path, eliminating guard-logic duplication and ensuring invariants hold uniformly.

## Key Changes

- **`Otto::Security::CSP::Writer`** — Single structural apply core for nonce-CSP emission
  - `Writer.apply(headers, nonce, config:, mode:, development_mode:)` writes CSP in-place and key-scoped
  - Handles case-variant header key normalization (Rack 3 compliance)
  - Returns a `Result` with `applied?`, `policy`, and `skip_reason` (`:disabled`, `:blank_nonce`, `:non_html`, `:existing_csp`)
  - Named modes: `:override` (deliberate, replaces) and `:backstop` (passive, defers to existing)
  - Frozen headers hash fails loud (FrozenError) rather than silently dropping the policy

- **`Otto::Security::CSP::Policy`** — Policy string building extracted from `Config`
  - `Policy.nonce_policy(nonce, development_mode:, report_uri:, report_to_url:)` assembles the directive set
  - `Policy.static_policy(base, report_uri:, report_to_url:)` for static CSP headers
  - `Config` delegates to this module with byte-identical output; `CSP_REPORTING_GROUP` now aliases `Policy::REPORTING_GROUP`

- **`Otto::Security::CSP::EmitMiddleware`** — Passive backstop that emits nonce CSP on the way out
  - Emit-if-consumed (default): only emits when request consumed a nonce (view called `req.csp_nonce`)
  - Optional `eager: true` mode to mint-and-emit for every eligible response
  - Per-request `development_mode:` callable support
  - Inert when nonce-CSP is disabled; never clobbers existing policies

- **Framework-owned lazy nonce** — `Otto::Request#csp_nonce` / `Otto::Security::CSP.nonce(env)`
  - Generates on first access, memoizes into `env['otto.nonce']` (registered as `Otto::EnvKeys::NONCE`)
  - Views and header read the same value (structural agreement)
  - Configurable env key via `Otto::Security::Config#csp_nonce_key` for apps with existing conventions

- **`Otto::Response#apply_csp(nonce, mode: :override)`** — The one emission helper
  - Routes through `Writer.apply` core
  - Resolves security config from request env when not passed
  - Returns `Writer::Result` for uniform observability

- **`Otto::Response#send_csp_headers` (deprecated shim)**
  - Now delegates to `#apply_csp` for backward compatibility
  - One-time deprecation warning per process
  - Historical quirks (nil/empty nonce, missing Content-Type) fixed by the apply core

- **`Otto#enable_csp_emission!`** — Mounts the EmitMiddleware
  - Passive backstop; requires `enable_csp_with_nonce!` first
  - Supports `eager:` and per-request `development_mode:` options

## Notable Implementation Details

- All emission surfaces (`Writer`, `EmitMiddleware`, `Response#apply_csp`, deprecated `send_csp_headers`) route through one `Writer.apply` call, so invariants are properties of ONE method rather than re-implemented at each surface
- Shared example suites (`spec/support/nonce_csp_emission_examples.rb`) exercise the same guards, casing, and no-duplicate assertions against each surface, preventing drift
- In-place, key-scoped writes: `Writer.apply` finds any case-variant CSP key, deletes it, and writes the lowercase key

https://claude.ai/code/session_01XUKDE3MSxGqUaZfhqkT683