### PR TITLE
Add lambda/inline route handlers (issue #41)

### DIFF
--- a/examples/advanced_routes/README.md
+++ b/examples/advanced_routes/README.md
@@ -58,6 +58,55 @@ Add arbitrary key-value pairs for flexible routing:
 GET  /admin            AdminPanel#dashboard     role=admin
 ```
 
+### Lambda / Inline Route Handlers (Issue #41)
+Route to a proc that you **pre-register** by name, using the `&` prefix:
+```
+GET  /ping             &health_check            response=json
+POST /webhook          &receive_webhook         response=json csrf=exempt
+GET  /go               &to_dashboard            response=redirect
+```
+
+The `&name` token is a plain string key looked up (O(1)) in a registry you
+supply at construction — the entire token after `&` is the key (dots, `#`, and
+`::` are inert). Register the procs when you build Otto:
+```ruby
+otto = Otto.new('routes', lambda_handlers: {
+  'health_check'   => ->(req, res, extra_params) {
+    { status: 'ok', at: Time.now.to_i }        # response=json serializes this Hash
+  },
+  'receive_webhook' => ->(req, res, extra_params) {
+    { received: true }
+  },
+  'to_dashboard'   => ->(req, res, extra_params) {
+    '/dashboard'                                 # response=redirect uses this path
+  },
+})
+```
+
+The handler contract:
+
+- Each proc is called with **`(req, res, extra_params)`** — `extra_params` is the
+  hash of path captures (e.g. `:id` from `/users/:id`).
+- The proc must accept 3 arguments (fixed arity `3`, or a splat/optional form).
+  An invalid arity raises `ArgumentError` at construction.
+- **All response types work** exactly as for controller routes:
+  `response=json` (serializes a returned Hash), `response=view` (`to_s` as HTML),
+  `response=redirect` (returned String is the `Location`), `response=auto`
+  (content negotiation). With the default response type the proc must write to
+  `res` directly, just like the other handler kinds.
+- **Route options apply**: `csrf=exempt` (parse/expose parity with controllers),
+  `auth=`, `role=`, and custom path params all flow through unchanged.
+
+Security guarantee (the point of this feature): route files never carry code.
+`&name` is only ever a name; there is **no `eval` and no dynamic constant
+loading**. A route naming an unregistered handler fails with a clear
+`ArgumentError` ("Lambda handler '...' is not registered or not callable")
+instead of executing anything. The registered procs are, of course, trusted
+code that you wrote.
+
+Note: `csrf=exempt` is parse-and-expose parity with controller routes — the CSRF
+middleware does not enforce it for any handler kind.
+
 ## How to Run
 
 ### Using rackup (recommended)

--- a/examples/advanced_routes/config.rb
+++ b/examples/advanced_routes/config.rb
@@ -4,8 +4,21 @@ require 'rack'
 require_relative '../../lib/otto'
 require_relative 'app'
 
-# Simple Otto configuration demonstrating advanced routes syntax
-otto = Otto.new('routes')
+# Simple Otto configuration demonstrating advanced routes syntax.
+#
+# Lambda / inline route handlers (issue #41): procs are pre-registered by name
+# and referenced from the routes file with the '&name' prefix. Lookup is O(1)
+# by exact string — no eval, no dynamic code from the route file.
+otto = Otto.new('routes', lambda_handlers: {
+  # GET /ping &health_check response=json
+  'health_check'    => ->(_req, _res, _extra_params) { { status: 'ok', at: Time.now.to_i } },
+
+  # POST /hooks/receive &receive_webhook response=json csrf=exempt
+  'receive_webhook' => ->(req, _res, _extra_params) { { received: true, method: req.request_method } },
+
+  # GET /go/dashboard &to_dashboard response=redirect (returned String is the Location)
+  'to_dashboard'    => ->(_req, _res, _extra_params) { '/dashboard' },
+})
 
 # Enable basic security features to demonstrate CSRF functionality
 otto.enable_csrf_protection!

--- a/examples/advanced_routes/routes
+++ b/examples/advanced_routes/routes
@@ -94,6 +94,18 @@ POST  /logic/complex/handler    Complex::Business::Handler response=json
 PUT   /logic/system/config      System::Config::Manager response=json csrf=exempt
 
 # ========================================
+# LAMBDA / INLINE ROUTE HANDLERS (Issue #41)
+# ========================================
+
+# The '&name' prefix references a proc pre-registered via
+#   Otto.new('routes', lambda_handlers: { 'name' => ->(req,res,extra){ ... } })
+# Lookup is O(1) by exact string name — no eval, no dynamic constants.
+# An unregistered name fails with a clear error, never executes code.
+GET   /ping                     &health_check response=json
+POST  /hooks/receive            &receive_webhook response=json csrf=exempt
+GET   /go/dashboard             &to_dashboard response=redirect
+
+# ========================================
 # NAMESPACED CLASS ROUTES
 # ========================================
 

--- a/examples/lambda_handlers/README.md
+++ b/examples/lambda_handlers/README.md
@@ -1,0 +1,126 @@
+# Otto - Lambda / Inline Route Handlers
+
+This example demonstrates Otto's fourth route-handler kind (issue #41):
+**lambda handlers**. A lambda handler is a plain proc, pre-registered by name,
+that a route can target with an `&` prefix.
+
+## What You'll Learn
+
+- Registering lambda handlers at `Otto.new` construction time
+- The `&handler_name` route syntax
+- Returning strings, Hashes (JSON), and mutating the response directly
+- Applying route options (`response=json`, `csrf=exempt`) to lambdas
+- Why this is safe: no `eval`, no dynamic code from route files
+
+## The Four Handler Kinds
+
+| Route target    | Kind        | Resolves to             |
+|-----------------|-------------|-------------------------|
+| `App.index`     | `:class`    | class method            |
+| `App#index`     | `:instance` | instance method         |
+| `BareClass`     | `:logic`    | Logic object            |
+| `&health_check` | `:lambda`   | pre-registered proc     |
+
+## Registration
+
+Lambdas are supplied to Otto as a `name => callable` Hash. Otto validates each
+entry (must respond to `#call`, must accept 3 arguments) and freezes the
+registry:
+
+```ruby
+require_relative '../../lib/otto'
+require_relative 'handlers'
+
+app = Otto.new('routes', {
+  lambda_handlers: LambdaHandlers::REGISTRY,
+})
+```
+
+Each handler receives `(req, res, extra_params)`:
+
+```ruby
+HEALTH_CHECK = lambda do |req, res, extra_params|
+  res.headers['content-type'] = 'text/plain; charset=utf-8'
+  res.body = 'OK'
+end
+```
+
+## Route Syntax
+
+Prefix the target with `&` and give the registered name. Everything after the
+`&` is the exact registry key. The target comes first; route options follow it:
+
+```
+GET   /ping           &health_check
+GET   /status         &status    response=json
+GET   /greet/:name    &greet     response=json
+POST  /webhook        &webhook   csrf=exempt response=json
+```
+
+## Response Types
+
+Lambdas participate in Otto's normal response-type dispatch, the same way a
+class/instance/logic handler does:
+
+- **Default** (no `response=`): the handler mutates `res` directly — set
+  `res.status` / `res.headers` / `res.body`. The return value is ignored, so
+  writing `res.body` is what produces output.
+- **`response=json`**: the returned Hash is serialized as JSON and the JSON
+  content-type is set for you.
+
+## Route Options
+
+Route options apply to lambdas just like any other handler:
+
+- `response=json` — serialize the returned Hash as JSON.
+- `csrf=exempt` — skip CSRF verification (used here for the webhook, which
+  external callers reach without a browser token).
+- `auth=` / `role=` — authentication and authorization (when `auth_config`
+  is configured on the Otto instance).
+
+## Security
+
+The `&` syntax performs an O(1) lookup of a **pre-registered** proc by name.
+Route files never contain Ruby code and are never `eval`'d. A route naming a
+handler that was not registered raises a clear error instead of executing
+anything.
+
+## How to Run
+
+```sh
+cd examples/lambda_handlers
+rackup config.ru -p 10780
+```
+
+Then, from another terminal:
+
+```sh
+curl localhost:10780/ping
+# OK
+
+curl localhost:10780/status
+# {"service":"otto-lambda-demo","status":"healthy","time":"..."}
+
+curl localhost:10780/greet/otto
+# {"greeting":"Hello, otto!"}
+
+curl -X POST --data 'hello' localhost:10780/webhook
+# {"received":true,"bytes":5}
+```
+
+## File Structure
+
+- `README.md`: This file.
+- `handlers.rb`: Defines the lambda procs and the `REGISTRY` Hash.
+- `routes`: Maps URLs to lambdas using the `&` syntax.
+- `config.ru`: Rack config that registers the lambdas with `Otto.new`.
+
+## Next Steps
+
+- Explore [Advanced Routes](../advanced_routes/) for class/instance/logic
+  handlers and response-type negotiation.
+- See [Security Features](../security_features/) for CSRF and input validation.
+
+## Further Reading
+
+- [docs/ADVANCED_ROUTES.txt](../../docs/ADVANCED_ROUTES.txt)

--- a/examples/lambda_handlers/README.md
+++ b/examples/lambda_handlers/README.md
@@ -73,8 +73,10 @@ class/instance/logic handler does:
 Route options apply to lambdas just like any other handler:
 
 - `response=json` — serialize the returned Hash as JSON.
-- `csrf=exempt` — skip CSRF verification (used here for the webhook, which
-  external callers reach without a browser token).
+- `csrf=exempt` — parsed and exposed on the route definition (intended to mark
+  the webhook, which external callers reach without a browser token). Note:
+  `CSRFMiddleware` does not yet consult per-route options, so this option is
+  currently recorded but not enforced — see issue #186.
 - `auth=` / `role=` — authentication and authorization (when `auth_config`
   is configured on the Otto instance).
 

--- a/examples/lambda_handlers/config.ru
+++ b/examples/lambda_handlers/config.ru
@@ -1,0 +1,26 @@
+# examples/lambda_handlers/config.ru
+#
+# Usage:
+#
+#     $ rackup config.ru -p 10780
+#
+# then, in another terminal:
+#
+#     $ curl localhost:10780/ping
+#     $ curl localhost:10780/status
+#     $ curl localhost:10780/greet/otto
+#     $ curl -X POST --data 'hello' localhost:10780/webhook
+
+require_relative '../../lib/otto'
+require_relative 'handlers'
+
+# Register the lambda handlers at construction time. Only names present in
+# this Hash can be referenced from the routes file's '&' syntax. Otto
+# validates every entry here (must respond to #call, arity of 3) and freezes
+# the registry — a route naming an unknown handler fails loudly rather than
+# executing anything.
+app = Otto.new('routes', {
+  lambda_handlers: LambdaHandlers::REGISTRY,
+})
+
+run app

--- a/examples/lambda_handlers/handlers.rb
+++ b/examples/lambda_handlers/handlers.rb
@@ -1,0 +1,73 @@
+# examples/lambda_handlers/handlers.rb
+#
+# frozen_string_literal: true
+
+# Pre-registered lambda route handlers (Otto issue #41).
+#
+# A lambda handler is any object responding to #call that accepts exactly
+# three arguments: (req, res, extra_params).
+#
+#   * req          - the Rack::Request for this request
+#   * res          - the Rack::Response to populate
+#   * extra_params - a Hash of route/path params merged by Otto
+#
+# These procs are handed to Otto at construction time via the
+# `lambda_handlers:` option (see config.ru). Each is looked up O(1) by name
+# from the route file's `&handler_name` syntax. Nothing in the route file is
+# ever eval'd — only names present in this registry can be invoked, and an
+# unknown name fails loudly instead of executing arbitrary code.
+#
+# How the response is produced depends on the route's `response=` option,
+# exactly like the class/instance/logic handler kinds:
+#
+#   * default (no `response=`) -> the handler mutates `res` directly
+#     (status/headers/body); the return value is ignored.
+#   * `response=json`          -> the returned Hash is serialized to JSON.
+module LambdaHandlers
+  # A minimal string responder. With no `response=` option the default response
+  # handler leaves the body alone, so (like a class handler) we write it here.
+  HEALTH_CHECK = lambda do |_req, res, _extra|
+    res.headers['content-type'] = 'text/plain; charset=utf-8'
+    res.body = 'OK'
+  end
+
+  # A Hash responder. Pair it with `response=json` on the route and Otto's
+  # JSON response handler serializes the Hash and sets the JSON content-type.
+  STATUS = lambda do |_req, _res, _extra|
+    {
+      service: 'otto-lambda-demo',
+      status: 'healthy',
+      time: Time.now.utc.iso8601,
+    }
+  end
+
+  # A handler that reads merged params. Path/query params arrive in
+  # `extra_params`; request params are available through `req`.
+  GREET = lambda do |req, _res, extra|
+    name = extra['name'] || req.params['name'] || 'world'
+    { greeting: "Hello, #{name}!" }
+  end
+
+  # A webhook-style POST handler. The matching route declares `csrf=exempt`
+  # so external callers (which cannot present a CSRF token) are not rejected.
+  # Security note: exempt CSRF only for endpoints authenticated another way
+  # (signature header, shared secret, etc.).
+  WEBHOOK = lambda do |req, _res, _extra|
+    # Rewind first: upstream middleware may already have read the input stream.
+    req.body.rewind if req.body.respond_to?(:rewind)
+    payload = req.body.read.to_s
+    # NOTE: this route uses `response=json`, so Otto's JSON response handler
+    # owns the status (200) and content-type. Setting them here would be
+    # overridden, so we only return the Hash to be serialized.
+    { received: true, bytes: payload.bytesize }
+  end
+
+  # The registry passed to Otto.new(lambda_handlers: ...). Keys are the names
+  # referenced after '&' in the routes file.
+  REGISTRY = {
+    'health_check' => HEALTH_CHECK,
+    'status'       => STATUS,
+    'greet'        => GREET,
+    'webhook'      => WEBHOOK,
+  }.freeze
+end

--- a/examples/lambda_handlers/handlers.rb
+++ b/examples/lambda_handlers/handlers.rb
@@ -48,10 +48,12 @@ module LambdaHandlers
     { greeting: "Hello, #{name}!" }
   end
 
-  # A webhook-style POST handler. The matching route declares `csrf=exempt`
-  # so external callers (which cannot present a CSRF token) are not rejected.
-  # Security note: exempt CSRF only for endpoints authenticated another way
-  # (signature header, shared secret, etc.).
+  # A webhook-style POST handler. The matching route declares `csrf=exempt`,
+  # intended to let external callers (which cannot present a CSRF token) reach
+  # it. Note: CSRFMiddleware does not yet honor per-route csrf=exempt (issue
+  # #186), so the option is currently advisory. When enforcement lands, exempt
+  # CSRF only for endpoints authenticated another way (signature header, shared
+  # secret, etc.).
   WEBHOOK = lambda do |req, _res, _extra|
     # Rewind first: upstream middleware may already have read the input stream.
     req.body.rewind if req.body.respond_to?(:rewind)

--- a/examples/lambda_handlers/routes
+++ b/examples/lambda_handlers/routes
@@ -1,0 +1,27 @@
+# examples/lambda_handlers/routes
+
+# OTTO - LAMBDA / INLINE ROUTE HANDLERS (issue #41)
+#
+# A route target prefixed with '&' names a pre-registered lambda handler
+# instead of a class/method. The name after '&' is looked up O(1) from the
+# lambda_handlers registry supplied to Otto.new -- never eval'd.
+#
+# The target comes first; route options follow it.
+#
+# Compare the four handler kinds:
+#   App.index      -> :class    (class method)
+#   App#index      -> :instance (instance method)
+#   BareClass      -> :logic    (Logic object)
+#   &health_check  -> :lambda   (pre-registered proc)   <-- this file
+
+# Plain-text string responder (default response handler).
+GET   /ping           &health_check
+
+# Hash responder serialized as JSON.
+GET   /status         &status    response=json
+
+# Reads a path param, returned as JSON.
+GET   /greet/:name    &greet     response=json
+
+# Webhook receiver: CSRF-exempt so external POSTs are accepted.
+POST  /webhook        &webhook   csrf=exempt response=json

--- a/examples/lambda_handlers/routes
+++ b/examples/lambda_handlers/routes
@@ -23,5 +23,6 @@ GET   /status         &status    response=json
 # Reads a path param, returned as JSON.
 GET   /greet/:name    &greet     response=json
 
-# Webhook receiver: CSRF-exempt so external POSTs are accepted.
+# Webhook receiver: marked csrf=exempt (option is parsed/exposed but not yet
+# enforced by CSRFMiddleware -- see issue #186).
 POST  /webhook        &webhook   csrf=exempt response=json

--- a/lib/otto.rb
+++ b/lib/otto.rb
@@ -107,6 +107,10 @@ class Otto
   end
   alias options option
 
+  # Read-only view of assembled instance options. LambdaHandler resolves its
+  # registry via otto_instance.config[:lambda_handlers].
+  alias config option
+
   # Main Rack application interface
   def call(env)
     # Freeze configuration on first request (thread-safe).
@@ -234,6 +238,10 @@ class Otto
 
     # Initialize MCP server
     configure_mcp(opts)
+
+    # Validate and freeze the lambda handler registry (issue #41).
+    # Runs last so misconfiguration fails fast at construction.
+    configure_lambda_handlers(opts)
   end
 
   class << self

--- a/lib/otto/core/configuration.rb
+++ b/lib/otto/core/configuration.rb
@@ -100,6 +100,75 @@ class Otto
         @mcp_server.enable!(mcp_options)
       end
 
+      # Validate and freeze the lambda handler registry supplied at construction
+      # (issue #41, AC#3). Security: only pre-registered callables are accepted;
+      # nothing from route files reaches here, so no eval / dynamic code (AC#8).
+      def configure_lambda_handlers(opts)
+        @option[:lambda_handlers] = validate_lambda_handlers!(opts[:lambda_handlers])
+      end
+
+      # @raise [ArgumentError] naming the offending handler on any invalid entry
+      # @return [Hash] frozen registry ({}.freeze when none supplied)
+      def validate_lambda_handlers!(handlers)
+        return {}.freeze if handlers.nil?
+
+        unless handlers.is_a?(Hash)
+          raise ArgumentError,
+                "Otto :lambda_handlers must be a Hash of name => callable, got #{handlers.class}"
+        end
+
+        handlers.each do |name, handler|
+          unless handler.respond_to?(:call)
+            raise ArgumentError,
+                  "Lambda handler '#{name}' is not callable (expected an object " \
+                  "responding to #call, got #{handler.class})"
+          end
+
+          next if lambda_handler_accepts_three?(handler)
+
+          raise ArgumentError,
+                "Lambda handler '#{name}' has invalid arity " \
+                '(must accept 3 arguments: req, res, extra_params)'
+        end
+
+        handlers.freeze
+      end
+
+      # True if +handler+ can be invoked with exactly three positional arguments.
+      #
+      # Reflects on the callable's #parameters rather than #arity so that:
+      #   * non-Proc/Method callables (a plain object with #call) are supported
+      #     without ever calling #arity, which they need not define (BUG A); and
+      #   * optional-arg forms that cannot actually take 3 positional args are
+      #     rejected instead of blanket-accepted by a negative arity (BUG B) --
+      #     e.g. ->(a=1){} (accepts 0..1) and ->(a,b=1){} (accepts 1..2).
+      #
+      # Accepts req/opt/rest combinations that admit 3 positionals; rejects
+      # anything requiring more than 3 or unable to reach 3.
+      #
+      # @api private
+      # @return [Boolean]
+      def lambda_handler_accepts_three?(handler)
+        callable =
+          if handler.is_a?(Proc) || handler.is_a?(Method)
+            handler
+          else
+            handler.method(:call)
+          end
+        params   = callable.parameters
+        required = params.count { |(type, _)| type == :req }
+        optional = params.count { |(type, _)| type == :opt }
+        has_rest = params.any?  { |(type, _)| type == :rest }
+
+        return false if required > 3
+
+        has_rest || (required + optional) >= 3
+      rescue NameError, NoMethodError
+        # A pathological callable whose #method(:call) reflection blows up still
+        # yields a clean, handler-named ArgumentError from the caller.
+        false
+      end
+
       # Configure locale settings for the application
       #
       # @param available_locales [Hash] Hash of available locales (e.g., { 'en' => 'English', 'es' => 'Spanish' })

--- a/lib/otto/core/configuration.rb
+++ b/lib/otto/core/configuration.rb
@@ -109,6 +109,12 @@ class Otto
 
       # @raise [ArgumentError] naming the offending handler on any invalid entry
       # @return [Hash] frozen registry ({}.freeze when none supplied)
+      #
+      # Keys are normalized to Strings so lookups from +&name+ routes (whose
+      # target is always a String parsed from the route file) resolve regardless
+      # of whether the caller registered handlers under Symbol or String keys.
+      # A fresh Hash is built and frozen so the caller's input object is never
+      # mutated in place.
       def validate_lambda_handlers!(handlers)
         return {}.freeze if handlers.nil?
 
@@ -117,21 +123,38 @@ class Otto
                 "Otto :lambda_handlers must be a Hash of name => callable, got #{handlers.class}"
         end
 
+        registry = {}
+
         handlers.each do |name, handler|
+          key = name.to_s
+          if key.strip.empty?
+            raise ArgumentError,
+                  "Lambda handler name #{name.inspect} is blank " \
+                  '(expected a non-empty name matching the &handler_name route target)'
+          end
+
+          if registry.key?(key)
+            raise ArgumentError,
+                  "Lambda handler name #{key.inspect} is registered more than once " \
+                  '(String and Symbol keys collide once normalized to a String)'
+          end
+
           unless handler.respond_to?(:call)
             raise ArgumentError,
-                  "Lambda handler '#{name}' is not callable (expected an object " \
+                  "Lambda handler '#{key}' is not callable (expected an object " \
                   "responding to #call, got #{handler.class})"
           end
 
-          next if lambda_handler_accepts_three?(handler)
+          unless lambda_handler_accepts_three?(handler)
+            raise ArgumentError,
+                  "Lambda handler '#{key}' has invalid arity " \
+                  '(must accept 3 arguments: req, res, extra_params)'
+          end
 
-          raise ArgumentError,
-                "Lambda handler '#{name}' has invalid arity " \
-                '(must accept 3 arguments: req, res, extra_params)'
+          registry[key] = handler
         end
 
-        handlers.freeze
+        registry.freeze
       end
 
       # True if +handler+ can be invoked with exactly three positional arguments.

--- a/lib/otto/route.rb
+++ b/lib/otto/route.rb
@@ -52,8 +52,15 @@ class Otto
       # Create immutable route definition
       @route_definition = Otto::RouteDefinition.new(verb, path, definition, pattern: pattern, keys: keys)
 
-      # Resolve the class
-      @klass = Otto::Security::ConstantResolver.safe_const_get(@route_definition.klass_name)
+      # Resolve the class.
+      # Lambda routes carry a registry KEY in klass_name, not a Ruby constant.
+      # Skip constant resolution (it would raise on a lowercase/unregistered key
+      # and the loader would silently drop the route).
+      @klass = if @route_definition.kind == :lambda
+                 nil
+               else
+                 Otto::Security::ConstantResolver.safe_const_get(@route_definition.klass_name)
+               end
     end
 
     # Delegate common methods to route_definition for backward compatibility
@@ -124,8 +131,11 @@ class Otto
         end
       end
 
-      klass.extend Otto::Route::ClassMethods
-      klass.otto = otto
+      # No target class for lambda routes (klass is nil); skip class extension.
+      if klass
+        klass.extend Otto::Route::ClassMethods
+        klass.otto = otto
+      end
 
       # Add security helpers if CSRF is enabled
       if otto.respond_to?(:security_config) && otto.security_config&.csrf_enabled?

--- a/lib/otto/route_definition.rb
+++ b/lib/otto/route_definition.rb
@@ -191,6 +191,19 @@ class Otto
     # @return [Hash] Hash with :klass_name, :method_name, and :kind
     def parse_target(target)
       case target
+      when /^&/
+        # Lambda handler: '&name' references a proc pre-registered in the
+        # lambda_handlers registry. The entire remainder after '&' is the exact
+        # O(1) Hash lookup key (may contain '.', '#', '::' — all inert here;
+        # resolution is string equality, never eval/const_get). Issue #41 security.
+        name = target[1..].to_s
+        if name.strip.empty?
+          raise ArgumentError,
+                "Invalid lambda handler target #{target.inspect}: handler name " \
+                "after '&' cannot be empty (expected '&handler_name')"
+        end
+        { klass_name: name, method_name: nil, kind: :lambda }
+
       when /^(.+)\.(.+)$/
         # Class.method - call class method directly
         { klass_name: ::Regexp.last_match(1), method_name: ::Regexp.last_match(2), kind: :class }

--- a/lib/otto/route_handlers/base.rb
+++ b/lib/otto/route_handlers/base.rb
@@ -125,6 +125,10 @@ class Otto
       # @param env [Hash] Rack environment
       # @param extra_params [Hash] Additional parameters
       def setup_request_response(req, res, env, extra_params)
+        # Expose the raw path-capture hash to invoke_target (LambdaHandler
+        # passes it as the proc's 3rd arg). Inert for other subclasses.
+        @extra_params = extra_params
+
         # Set request reference (helpers are already included in class)
         res.request = req
 

--- a/lib/otto/route_handlers/factory.rb
+++ b/lib/otto/route_handlers/factory.rb
@@ -19,6 +19,7 @@ class Otto
                         when :logic then LogicClassHandler
                         when :instance then InstanceMethodHandler
                         when :class then ClassMethodHandler
+                        when :lambda then LambdaHandler
                         else
                           raise ArgumentError, "Unknown handler kind: #{route_definition.kind}"
                         end

--- a/lib/otto/route_handlers/lambda.rb
+++ b/lib/otto/route_handlers/lambda.rb
@@ -1,46 +1,61 @@
 # lib/otto/route_handlers/lambda.rb
 #
 # frozen_string_literal: true
-require 'securerandom'
 
 require_relative 'base'
 
 class Otto
   module RouteHandlers
-    # Custom handler for lambda/proc definitions (future extension)
+    # Handler for pre-registered lambda/proc route targets (issue #41).
+    #
+    # Route syntax `GET /ping &health_check` parses to kind :lambda with
+    # klass_name = "health_check" (the registry KEY, not a Ruby constant) and
+    # method_name = nil. The proc is looked up O(1) by name from the Otto
+    # instance's pre-registered lambda_handlers — no eval, no dynamic constants.
+    #
+    # Reuses BaseHandler#call: implements #invoke_target and guards the base's
+    # constant-resolution steps (#target_class / #handler_name).
     class LambdaHandler < BaseHandler
-      def call(env, extra_params = {})
-        start_time = Otto::Utils.now_in_μs
-        req = otto_instance ? otto_instance.request_class.new(env) : Otto::Request.new(env)
-        res = otto_instance ? otto_instance.response_class.new : Otto::Response.new
+      protected
 
-        begin
-          # Security: Lambda handlers require pre-configured procs from Otto instance
-          # This prevents code injection via eval and maintains security
-          handler_name    = route_definition.klass_name
-          lambda_registry = otto_instance&.config&.dig(:lambda_handlers) || {}
+      # No Ruby constant backs a lambda route. Returning nil (a) prevents
+      # ConstantResolver.safe_const_get from raising on a registry key and
+      # (b) makes BaseHandler#setup_request_response skip its target_class
+      # extension block.
+      def target_class
+        nil
+      end
 
-          lambda_proc = lambda_registry[handler_name]
-          unless lambda_proc.respond_to?(:call)
-            raise ArgumentError, "Lambda handler '#{handler_name}' not found in registry or not callable"
-          end
+      # Derive the log/handler name from the route, not target_class.name
+      # (which would be nil.name -> NoMethodError inside handle_execution_error).
+      def handler_name
+        "Lambda[#{route_definition.klass_name}]"
+      end
 
-          result = lambda_proc.call(req, res, extra_params)
+      # Look up the pre-registered proc and invoke it with (req, res, extra_params).
+      # @return [Array] [result, context] consumed by BaseHandler#handle_response
+      def invoke_target(req, res)
+        handler_key = route_definition.klass_name
+        lambda_proc = lambda_registry[handler_key]
 
-          handle_response(result, res, {
-                            lambda: lambda_proc,
-            request: req,
-                          })
-        rescue StandardError => e
-          # Store handler context in env for centralized error handler
-          handler_name = "Lambda[#{route_definition.klass_name}]"
-          env['otto.handler'] = handler_name
-          env['otto.handler_duration'] = Otto::Utils.now_in_μs - start_time
-
-          raise e # Re-raise to let Otto's centralized error handler manage the response
+        unless lambda_proc.respond_to?(:call)
+          raise ArgumentError,
+                "Lambda handler '#{handler_key}' is not registered or not callable"
         end
 
-        res.finish
+        result = lambda_proc.call(req, res, @extra_params || {})
+        [result, { request: req }]
+      end
+
+      private
+
+      # O(1) read of the frozen registry from Otto config. Tolerates the
+      # direct-testing context (no otto_instance / no :config) by returning {},
+      # so invoke_target raises the clear "not registered" ArgumentError.
+      def lambda_registry
+        return {} unless otto_instance.respond_to?(:config)
+
+        (otto_instance.config && otto_instance.config[:lambda_handlers]) || {}
       end
     end
   end

--- a/spec/otto/lambda_handler_config_spec.rb
+++ b/spec/otto/lambda_handler_config_spec.rb
@@ -200,6 +200,48 @@ RSpec.describe 'Otto lambda_handlers configuration (issue #41 AC#3/AC#8)' do
     end
   end
 
+  describe 'key normalization (Symbol keys resolve like String keys)' do
+    # Route targets are always Strings parsed from the route file, so a handler
+    # registered under a Symbol key must be reachable by its String name.
+    it 'normalizes Symbol keys to Strings in the stored registry' do
+      handler = ->(_a, _b, _c) {}
+      otto = build(health_check: handler)
+      expect(otto.config[:lambda_handlers]['health_check']).to be(handler)
+    end
+
+    it 'preserves String keys as-is' do
+      handler = ->(_a, _b, _c) {}
+      otto = build('health_check' => handler)
+      expect(otto.config[:lambda_handlers]['health_check']).to be(handler)
+    end
+
+    it 'rejects a blank handler name' do
+      expect { build('' => ->(_a, _b, _c) {}) }
+        .to raise_error(ArgumentError, /blank/)
+    end
+
+    it 'rejects a whitespace-only handler name' do
+      expect { build('   ' => ->(_a, _b, _c) {}) }
+        .to raise_error(ArgumentError, /blank/)
+    end
+
+    it 'raises when a Symbol and String key collide after normalization' do
+      expect { build(health_check: ->(_a, _b, _c) {}, 'health_check' => ->(_a, _b, _c) {}) }
+        .to raise_error(ArgumentError, /more than once/)
+    end
+  end
+
+  describe "does not mutate the caller's Hash" do
+    it 'leaves the input Hash unfrozen and independent of the stored registry' do
+      input = { 'health_check' => ->(_a, _b, _c) {} }
+      otto = build(input)
+      expect(input).not_to be_frozen
+      expect(input).not_to be(otto.config[:lambda_handlers])
+      # Caller can still mutate their own object without a FrozenError.
+      expect { input['other'] = ->(_a, _b, _c) {} }.not_to raise_error
+    end
+  end
+
   describe 'empty / absent registry' do
     it 'defaults to a frozen empty Hash when no :lambda_handlers option is given' do
       otto = Otto.new(routes_file)

--- a/spec/otto/lambda_handler_config_spec.rb
+++ b/spec/otto/lambda_handler_config_spec.rb
@@ -1,0 +1,215 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Acceptance coverage for issue #41, AC#3 & AC#8:
+# Otto validates the :lambda_handlers registry synchronously during
+# construction, accepting only pre-registered callables with a compatible
+# arity, raising a clear ArgumentError (naming the offending handler) for
+# anything else, and storing the result frozen at otto.config[:lambda_handlers].
+#
+# NOTE (per test plan): never stub otto.config / otto.option. Always drive a
+# real Otto built with `lambda_handlers:` so verify_partial_doubles and the
+# real frozen registry are exercised.
+RSpec.describe 'Otto lambda_handlers configuration (issue #41 AC#3/AC#8)' do
+  # A minimal, lambda-free route file. The registry is validated by the
+  # constructor independently of the routes, so a plain controller route keeps
+  # these examples focused on registry validation only.
+  let(:routes_file) { create_test_routes_file('test_routes_lambda_cfg.txt', ['GET /health TestApp.index']) }
+
+  # Build a real Otto with the given handler registry.
+  def build(handlers)
+    Otto.new(routes_file, lambda_handlers: handlers)
+  end
+
+  describe 'accepted callables (valid arities)' do
+    it 'accepts a 3-arity lambda ->(req, res, extra) {}' do
+      expect { build('ok' => ->(_a, _b, _c) {}) }.not_to raise_error
+    end
+
+    it 'accepts a splat lambda ->(*a) {} (arity -1)' do
+      handler = ->(*_a) {}
+      expect(handler.arity).to eq(-1)
+      expect { build('ok' => handler) }.not_to raise_error
+    end
+
+    it 'accepts a one-required-plus-splat lambda ->(a, *b) {} (arity -2)' do
+      handler = ->(_a, *_b) {}
+      expect(handler.arity).to eq(-2)
+      expect { build('ok' => handler) }.not_to raise_error
+    end
+
+    it 'accepts an optional-tail lambda ->(a, b, c = 1) {} (arity -3)' do
+      handler = ->(_a, _b, _c = 1) {}
+      expect(handler.arity).to eq(-3)
+      expect { build('ok' => handler) }.not_to raise_error
+    end
+
+    it 'accepts a non-lambda proc of arity 3 (proc {|a, b, c| })' do
+      handler = proc { |_a, _b, _c| }
+      expect(handler.arity).to eq(3)
+      expect(handler.lambda?).to be(false)
+      expect { build('ok' => handler) }.not_to raise_error
+    end
+
+    it 'accepts a registry of several valid handlers together' do
+      expect do
+        build(
+          'a' => ->(_req, _res, _extra) {},
+          'b' => ->(*_args) {},
+          'c' => proc { |_req, _res, _extra| }
+        )
+      end.not_to raise_error
+    end
+  end
+
+  describe 'rejected optional-arg lambdas that cannot take 3 positionals (BUG B)' do
+    # These forms have a negative arity but cannot actually accept 3 positional
+    # args, so they must fail fast at Otto.new instead of raising "wrong number
+    # of arguments" at request time.
+    it 'rejects ->(a = 1) {} (arity -1, accepts 0..1) naming the handler' do
+      handler = ->(_a = 1) {}
+      expect(handler.arity).to eq(-1)
+      expect { build('bad' => handler) }.to raise_error(ArgumentError, /bad/)
+    end
+
+    it 'rejects ->(a, b = 1) {} (arity -2, accepts 1..2) naming the handler' do
+      handler = ->(_a, _b = 1) {}
+      expect(handler.arity).to eq(-2)
+      expect { build('bad' => handler) }.to raise_error(ArgumentError, /bad/)
+    end
+  end
+
+  describe 'non-Proc callable objects (BUG A: no #arity required)' do
+    # An object with `def call(req, res, extra)` responds to #call but not
+    # #arity. It must be accepted without a NoMethodError, and rejected with a
+    # clear named ArgumentError when its #call takes the wrong number of args.
+    let(:valid_callable_class) do
+      Class.new do
+        def call(_req, _res, _extra); end
+      end
+    end
+
+    let(:wrong_arity_callable_class) do
+      Class.new do
+        def call(_only_one); end
+      end
+    end
+
+    it 'accepts a callable object whose #call takes (req, res, extra)' do
+      handler = valid_callable_class.new
+      expect(handler).not_to respond_to(:arity)
+      expect { build('ok' => handler) }.not_to raise_error
+    end
+
+    it 'rejects a callable object whose #call takes the wrong number of args' do
+      handler = wrong_arity_callable_class.new
+      expect(handler).not_to respond_to(:arity)
+      expect { build('bad' => handler) }.to raise_error(ArgumentError, /bad/)
+    end
+  end
+
+  describe 'rejected fixed arities (clear ArgumentError naming the handler)' do
+    it 'rejects a zero-arity lambda ->{} (arity 0)' do
+      expect { build('bad' => -> {}) }.to raise_error(ArgumentError, /bad/)
+    end
+
+    it 'rejects a 1-arity lambda ->(a) {} (arity 1)' do
+      expect { build('bad' => ->(_a) {}) }.to raise_error(ArgumentError, /bad/)
+    end
+
+    it 'rejects a 2-arity lambda ->(a, b) {} (arity 2)' do
+      expect { build('bad' => ->(_a, _b) {}) }.to raise_error(ArgumentError, /bad/)
+    end
+
+    it 'rejects a 4-arity lambda ->(a, b, c, d) {} (arity 4)' do
+      expect { build('bad' => ->(_a, _b, _c, _d) {}) }.to raise_error(ArgumentError, /bad/)
+    end
+
+    it 'names the offending handler key and cites arity in the message' do
+      error = nil
+      begin
+        build('bad' => ->(_a) {})
+      rescue ArgumentError => e
+        error = e
+      end
+      expect(error).to be_a(ArgumentError)
+      expect(error.message).to match(/bad/)
+      expect(error.message).to match(/arity/)
+    end
+  end
+
+  describe 'rejected non-callable values (message mentions callable)' do
+    def capture_build_error(handlers)
+      build(handlers)
+      nil
+    rescue ArgumentError => e
+      e
+    end
+
+    it 'rejects a String value naming the handler and mentioning callable' do
+      error = capture_build_error('bad' => 'a string')
+      expect(error).to be_a(ArgumentError)
+      expect(error.message).to match(/bad/)
+      expect(error.message).to match(/callable/)
+    end
+
+    it 'rejects an Integer value naming the handler and mentioning callable' do
+      error = capture_build_error('bad' => 42)
+      expect(error).to be_a(ArgumentError)
+      expect(error.message).to match(/bad/)
+      expect(error.message).to match(/callable/)
+    end
+
+    it 'rejects a plain Object value naming the handler and mentioning callable' do
+      error = capture_build_error('bad' => Object.new)
+      expect(error).to be_a(ArgumentError)
+      expect(error.message).to match(/bad/)
+      expect(error.message).to match(/callable/)
+    end
+  end
+
+  describe 'validation happens during Otto.new, before any request is served' do
+    it 'raises synchronously from the constructor (no otto.call needed)' do
+      expect { build('bad' => -> {}) }.to raise_error(ArgumentError)
+    end
+
+    it 'does not partially construct — a valid handler alongside a bad one still raises' do
+      expect do
+        build('good' => ->(_a, _b, _c) {}, 'bad' => ->(_a) {})
+      end.to raise_error(ArgumentError, /bad/)
+    end
+  end
+
+  describe 'stored registry is exposed and frozen (AC#8)' do
+    it 'exposes the registry at otto.config[:lambda_handlers]' do
+      handler = ->(_a, _b, _c) {}
+      otto = build('health_check' => handler)
+      expect(otto.config[:lambda_handlers]).to be_a(Hash)
+      expect(otto.config[:lambda_handlers]['health_check']).to be(handler)
+    end
+
+    it 'freezes the stored registry' do
+      otto = build('health_check' => ->(_a, _b, _c) {})
+      expect(otto.config[:lambda_handlers]).to be_frozen
+    end
+
+    it 'raises FrozenError on attempted mutation of the registry' do
+      otto = build('health_check' => ->(_a, _b, _c) {})
+      expect { otto.config[:lambda_handlers]['x'] = -> {} }.to raise_error(FrozenError)
+    end
+  end
+
+  describe 'empty / absent registry' do
+    it 'defaults to a frozen empty Hash when no :lambda_handlers option is given' do
+      otto = Otto.new(routes_file)
+      expect(otto.config[:lambda_handlers]).to eq({})
+      expect(otto.config[:lambda_handlers]).to be_frozen
+    end
+
+    it 'accepts an explicit empty Hash without error' do
+      expect { build({}) }.not_to raise_error
+      expect(build({}).config[:lambda_handlers]).to eq({})
+    end
+  end
+end

--- a/spec/otto/lambda_routes_integration_spec.rb
+++ b/spec/otto/lambda_routes_integration_spec.rb
@@ -1,0 +1,327 @@
+# spec/otto/lambda_routes_integration_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# End-to-end acceptance coverage for issue #41 (Lambda / Inline Route Handlers).
+#
+# Every example here drives a *real* request through a *real* Otto instance via
+# otto.call(mock_rack_env(...)) — the full middleware + router + factory +
+# LambdaHandler + response/auth pipeline. This is the executable acceptance
+# spec for the feature as a whole: dispatch, response types, route options
+# (csrf / auth / role / custom params), and — the point of the feature —
+# security: an unregistered handler yields a clear error and executes NO code,
+# and a handler name that looks like Ruby source is treated as a plain (absent)
+# registry key, never resolved as a constant and never eval'd.
+#
+# House style follows spec/otto/response_integration_spec.rb: build an Otto,
+# call it with a mock env, and assert on the [status, headers, body] triple.
+# Per the test plan we NEVER stub otto.config / otto.option — always a real
+# Otto built with `lambda_handlers:` so the frozen registry is exercised.
+RSpec.describe 'Otto lambda routes end-to-end (issue #41)' do
+  # Build a real Otto from one or more route lines plus a lambda registry.
+  # @param routes [Array<String>] route-file lines
+  # @param handlers [Hash] the lambda_handlers registry
+  # @param opts [Hash] extra Otto options (csrf_protection, auth_strategies, ...)
+  def build_otto(routes, handlers, **opts)
+    routes_file = create_test_routes_file('test_routes_lambda_e2e.txt', routes)
+    Otto.new(routes_file, { lambda_handlers: handlers }.merge(opts))
+  end
+
+  describe 'D1: request dispatch (GET and POST)' do
+    it 'dispatches a GET lambda route and renders its Hash return as JSON' do
+      otto = build_otto(
+        ['GET /ping &health_check response=json'],
+        { 'health_check' => ->(_req, _res, _extra) { { status: 'ok' } } }
+      )
+
+      status, headers, body = otto.call(mock_rack_env(method: 'GET', path: '/ping'))
+
+      expect(status).to eq(200)
+      expect(headers['Content-Type']).to eq('application/json')
+      expect(JSON.parse(body.join)).to eq('status' => 'ok')
+    end
+
+    it 'dispatches a POST lambda route and can read request params' do
+      otto = build_otto(
+        ['POST /submit &submit response=json'],
+        { 'submit' => ->(req, _res, _extra) { { name: req.params['name'] } } }
+      )
+
+      env = mock_rack_env(method: 'POST', path: '/submit', params: { 'name' => 'x' })
+      status, _headers, body = otto.call(env)
+
+      expect(status).to eq(200)
+      expect(JSON.parse(body.join)).to eq('name' => 'x')
+    end
+  end
+
+  describe 'D2: response types (AC#5), one route each, driven through otto.call' do
+    it 'json: a Hash return becomes a JSON body with capitalized Content-Type' do
+      otto = build_otto(
+        ['GET /j &jh response=json'],
+        { 'jh' => ->(_req, _res, _extra) { { ok: true } } }
+      )
+
+      status, headers, body = otto.call(mock_rack_env(path: '/j'))
+
+      expect(status).to eq(200)
+      expect(headers['Content-Type']).to eq('application/json')
+      expect(JSON.parse(body.join)).to eq('ok' => true)
+    end
+
+    it 'view: a String return becomes an HTML body (text/html)' do
+      otto = build_otto(
+        ['GET /v &vh response=view'],
+        { 'vh' => ->(_req, _res, _extra) { '<h1>Hi</h1>' } }
+      )
+
+      status, headers, body = otto.call(mock_rack_env(path: '/v'))
+
+      expect(status).to eq(200)
+      expect(headers['Content-Type']).to eq('text/html')
+      expect(body.join).to eq('<h1>Hi</h1>')
+    end
+
+    it 'redirect: a String return becomes a 302 with a Location header' do
+      otto = build_otto(
+        ['GET /r &rh response=redirect'],
+        { 'rh' => ->(_req, _res, _extra) { '/next' } }
+      )
+
+      status, headers, _body = otto.call(mock_rack_env(path: '/r'))
+
+      expect(status).to eq(302)
+      expect(headers['Location']).to eq('/next')
+    end
+
+    it 'auto: a Hash return is auto-detected as JSON' do
+      otto = build_otto(
+        ['GET /a &ah response=auto'],
+        { 'ah' => ->(_req, _res, _extra) { { ok: true } } }
+      )
+
+      status, headers, body = otto.call(mock_rack_env(path: '/a'))
+
+      expect(status).to eq(200)
+      expect(headers['Content-Type']).to eq('application/json')
+      expect(JSON.parse(body.join)).to eq('ok' => true)
+    end
+
+    it 'default: the written body is served and the return value is ignored' do
+      otto = build_otto(
+        ['GET /d &dh'],
+        # Writes to res AND returns a Hash: under the default response type the
+        # return value must be ignored and only what was written is served.
+        { 'dh' => ->(_req, res, _extra) { res.write('written'); { ignored: true } } }
+      )
+
+      status, _headers, body = otto.call(mock_rack_env(path: '/d'))
+
+      expect(status).to eq(200)
+      expect(body.join).to eq('written')
+    end
+  end
+
+  describe 'D3: route options — custom params and csrf=exempt (AC#6)' do
+    it 'delivers a captured path param to the lambda (req.params and extra_params)' do
+      seen_extra = nil
+      otto = build_otto(
+        ['GET /users/:id &show_user response=json'],
+        { 'show_user' => lambda { |req, _res, extra|
+          seen_extra = extra
+          { from_params: req.params['id'], from_extra: extra['id'] }
+        } }
+      )
+
+      status, _headers, body = otto.call(mock_rack_env(path: '/users/42'))
+
+      expect(status).to eq(200)
+      # AC#4/AC#6: the capture reaches the lambda both via req.params and as the
+      # 3rd (extra_params) argument.
+      expect(JSON.parse(body.join)).to eq('from_params' => '42', 'from_extra' => '42')
+      expect(seen_extra).to include('id' => '42')
+    end
+
+    context 'csrf=exempt on a POST lambda route (parse + expose only)' do
+      # The route file parses csrf=exempt into the route definition and exposes
+      # it, but CSRFMiddleware does not enforce per-route exemption for ANY
+      # handler kind (it ignores route options). So we assert two honest things:
+      #   1. the option is parsed and exposed on the route definition, and
+      #   2. the exempt lambda route behaves IDENTICALLY to an equivalent
+      #      controller route under the same csrf configuration.
+      # We deliberately do NOT assert that the exemption bypasses CSRF, because
+      # the middleware does not honor it (see issue notes).
+      it 'parses and exposes csrf=exempt on the route definition' do
+        rd = Otto::RouteDefinition.new('POST', '/webhook', '&hook csrf=exempt response=json')
+        expect(rd.kind).to eq(:lambda)
+        expect(rd.option(:csrf)).to eq('exempt')
+        expect(rd.csrf_exempt?).to be(true)
+      end
+
+      it 'behaves identically to a controller route under csrf_protection' do
+        lambda_otto = build_otto(
+          ['POST /webhook &hook csrf=exempt response=json'],
+          { 'hook' => ->(_req, _res, _extra) { { ok: true } } },
+          csrf_protection: true
+        )
+
+        controller_routes = create_test_routes_file(
+          'test_routes_lambda_ctrl.txt',
+          ['POST /webhook TestApp.create csrf=exempt response=json']
+        )
+        controller_otto = Otto.new(controller_routes, csrf_protection: true)
+
+        lambda_status, = lambda_otto.call(mock_rack_env(method: 'POST', path: '/webhook'))
+        controller_status, = controller_otto.call(mock_rack_env(method: 'POST', path: '/webhook'))
+
+        # Parity: whatever CSRFMiddleware does to a tokenless POST, it does the
+        # same to the lambda route and the controller route.
+        expect(lambda_status).to eq(controller_status)
+      end
+    end
+  end
+
+  describe 'D4: auth / role protected lambda routes (AC#6)' do
+    # A minimal role-aware session strategy, mirroring the pattern used in
+    # spec/otto/security/route_auth_wrapper_spec.rb.
+    let(:role_strategy) do
+      Class.new do
+        def authenticate(env, _requirement)
+          session = env['rack.session']
+          unless session && session['user_id']
+            return Otto::Security::Authentication::AuthFailure.new(
+              failure_reason: 'No session',
+              auth_method: 'session'
+            )
+          end
+
+          Otto::Security::Authentication::StrategyResult.new(
+            user: { id: session['user_id'], roles: session['user_roles'] || [] },
+            session: session,
+            auth_method: 'session',
+            metadata: {},
+            strategy_name: 'session'
+          )
+        end
+      end.new
+    end
+
+    def build_auth_otto(route_line, handler_key)
+      build_otto(
+        [route_line],
+        { handler_key => ->(_req, _res, _extra) { { admin: true } } },
+        # Register the same role-aware strategy under both requirement names so
+        # `auth=authenticated` and `auth=session` routes both resolve.
+        auth_strategies: { 'authenticated' => role_strategy, 'session' => role_strategy },
+        default_auth_strategy: 'session'
+      )
+    end
+
+    def json_env(path, session: nil)
+      env = mock_rack_env(method: 'GET', path: path, headers: { 'Accept' => 'application/json' })
+      env['rack.session'] = session if session
+      env
+    end
+
+    context 'auth=authenticated' do
+      let(:otto) { build_auth_otto('GET /admin &admin_panel auth=authenticated response=json', 'admin_panel') }
+
+      it 'runs the lambda and returns 200 for an authenticated session' do
+        status, _headers, body = otto.call(json_env('/admin', session: { 'user_id' => 1 }))
+
+        expect(status).to eq(200)
+        expect(JSON.parse(body.join)).to eq('admin' => true)
+      end
+
+      it 'returns 401 and does NOT run the lambda for an empty session' do
+        status, headers, body = otto.call(json_env('/admin', session: {}))
+
+        expect(status).to eq(401)
+        expect(headers['content-type']).to eq('application/json')
+        # The body is the auth error, not the lambda's {admin: true} payload.
+        parsed = JSON.parse(body.join)
+        expect(parsed).not_to include('admin' => true)
+        expect(parsed['error']).to match(/Authentication Required/i)
+      end
+    end
+
+    context 'auth=session role=admin' do
+      let(:otto) { build_auth_otto('GET /admin &admin_panel auth=session role=admin response=json', 'admin_panel') }
+
+      it 'returns 403 for the wrong role and does NOT run the lambda' do
+        status, headers, body = otto.call(
+          json_env('/admin', session: { 'user_id' => 2, 'user_roles' => ['user'] })
+        )
+
+        expect(status).to eq(403)
+        expect(headers['content-type']).to eq('application/json')
+        parsed = JSON.parse(body.join)
+        expect(parsed).not_to include('admin' => true)
+        expect(parsed['error']).to match(/Forbidden/i)
+      end
+
+      it 'runs the lambda and returns 200 for the correct role' do
+        status, _headers, body = otto.call(
+          json_env('/admin', session: { 'user_id' => 3, 'user_roles' => ['admin'] })
+        )
+
+        expect(status).to eq(200)
+        expect(JSON.parse(body.join)).to eq('admin' => true)
+      end
+    end
+  end
+
+  describe 'D5: security — no eval, no dynamic code execution (AC#7, AC#8)' do
+    it 'an UNregistered handler yields a generic 500 JSON error (details only logged)' do
+      otto = build_otto(['GET /danger &danger_handler response=json'], {})
+
+      status, headers, body = otto.call(
+        mock_rack_env(method: 'GET', path: '/danger', headers: { 'Accept' => 'application/json' })
+      )
+
+      expect(status).to eq(500)
+      expect(headers['content-type']).to eq('application/json')
+      parsed = JSON.parse(body.join)
+      # Generic message — the specific "not registered" detail is logged, not leaked.
+      expect(parsed['error']).to eq('Internal Server Error')
+    end
+
+    it 'a source-looking handler name is treated as an absent key and executes nothing' do
+      executed = [] # closure-local canary (order.random-safe; no globals)
+      otto = build_otto(
+        ["GET /x &system('boom') response=json"],
+        # The ONLY registered proc; its key is unrelated to the route's token.
+        { 'safe' => ->(_req, _res, _extra) { executed << :ran; { ok: true } } }
+      )
+
+      # Nothing should ever shell out: the token is a registry key, never eval'd.
+      expect(Kernel).not_to receive(:system)
+
+      status, = otto.call(
+        mock_rack_env(method: 'GET', path: '/x', headers: { 'Accept' => 'application/json' })
+      )
+
+      expect(status).to eq(500)
+      expect(executed).to be_empty
+    end
+
+    it 'a dotted handler name is the whole (absent) key — never sent to constant resolution' do
+      executed = []
+      otto = build_otto(
+        ['GET /y &Kernel.system response=json'],
+        { 'safe' => ->(_req, _res, _extra) { executed << :ran; { ok: true } } }
+      )
+
+      status, = otto.call(
+        mock_rack_env(method: 'GET', path: '/y', headers: { 'Accept' => 'application/json' })
+      )
+
+      # "Kernel.system" is the (missing) registry key in full; it is not split,
+      # not resolved as a constant, and no code runs.
+      expect(status).to eq(500)
+      expect(executed).to be_empty
+    end
+  end
+end

--- a/spec/otto/route_definition_spec.rb
+++ b/spec/otto/route_definition_spec.rb
@@ -207,6 +207,83 @@ RSpec.describe Otto::RouteDefinition do
     end
   end
 
+  describe 'lambda routes (& prefix)' do
+    it 'parses "&handler" to kind :lambda with klass_name and nil method_name' do
+      route = described_class.new('GET', '/ping', '&health_check')
+
+      expect(route.kind).to eq(:lambda)
+      expect(route.klass_name).to eq('health_check')
+      expect(route.method_name).to be_nil
+    end
+
+    it 'parses the target and options together for "&handler csrf=exempt response=json"' do
+      route = described_class.new('GET', '/ping', '&health_check csrf=exempt response=json')
+
+      expect(route.kind).to eq(:lambda)
+      expect(route.klass_name).to eq('health_check')
+      expect(route.method_name).to be_nil
+      expect(route.option(:csrf)).to eq('exempt')
+      expect(route.response_type).to eq('json')
+      expect(route.csrf_exempt?).to be true
+    end
+
+    it 'exposes lambda target details through to_h' do
+      route = described_class.new('GET', '/ping', '&health_check')
+
+      hash = route.to_h
+
+      expect(hash[:kind]).to eq(:lambda)
+      expect(hash[:klass_name]).to eq('health_check')
+      expect(hash[:method_name]).to be_nil
+    end
+
+    it 'is not a logic route' do
+      route = described_class.new('GET', '/ping', '&health_check')
+
+      expect(route.logic_route?).to be false
+    end
+
+    it 'treats a dotted handler name as a single lambda key (ordering lock)' do
+      route = described_class.new('GET', '/metrics', '&metrics.collect')
+
+      expect(route.kind).to eq(:lambda)
+      expect(route.klass_name).to eq('metrics.collect')
+      expect(route.method_name).to be_nil
+    end
+
+    it 'treats a hashed handler name as a single lambda key (ordering lock)' do
+      route = described_class.new('GET', '/key', '&ns#key')
+
+      expect(route.kind).to eq(:lambda)
+      expect(route.klass_name).to eq('ns#key')
+      expect(route.method_name).to be_nil
+    end
+
+    it 'preserves the "&" target on a with_options round-trip' do
+      route   = described_class.new('GET', '/ping', '&health_check')
+      updated = route.with_options(response: 'json')
+
+      expect(updated.kind).to eq(:lambda)
+      expect(updated.klass_name).to eq('health_check')
+      expect(updated.method_name).to be_nil
+      expect(updated.response_type).to eq('json')
+    end
+
+    it 'parses auth and role options for a lambda route' do
+      route = described_class.new('GET', '/admin', '&admin_panel auth=session role=admin')
+
+      expect(route.kind).to eq(:lambda)
+      expect(route.auth_requirements).to eq(['session'])
+      expect(route.role_requirements).to eq(['admin'])
+    end
+
+    it 'raises ArgumentError when the handler name after "&" is empty' do
+      expect do
+        described_class.new('GET', '/x', '&')
+      end.to raise_error(ArgumentError)
+    end
+  end
+
   describe 'immutability' do
     it 'freezes the route definition instance' do
       route = described_class.new('GET', '/test', 'TestApp.test')

--- a/spec/otto/route_handlers/lambda_handler_spec.rb
+++ b/spec/otto/route_handlers/lambda_handler_spec.rb
@@ -1,0 +1,250 @@
+# spec/otto/route_handlers/lambda_handler_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+
+# Acceptance spec for the Lambda/Inline route handler (issue #41).
+#
+# LambdaHandler resolves a pre-registered proc O(1) by name from
+# otto.config[:lambda_handlers] (no eval, no dynamic constants) and reuses the
+# BaseHandler#call pipeline (setup_request_response, response-type dispatch,
+# centralized error handling). These tests drive the handler directly and prove:
+#   - HandlerFactory dispatches :lambda RouteDefinitions to LambdaHandler (AC#2)
+#   - the proc is invoked with (req, res, extra_params) (AC#4)
+#   - every response type is honored (AC#5)
+#   - a missing/uncallable handler fails with a clear, named error and never
+#     executes arbitrary code (AC#7, AC#8)
+#
+# NOTE ON CONTEXTS: the lambda registry lives ON the Otto instance
+# (otto.config[:lambda_handlers]); a handler built WITHOUT an otto_instance has
+# an empty registry by design, so happy-path resolution is exercised in the
+# integrated (otto present) context. The direct (no-otto) context is exercised
+# for its supported behavior: the base's constant-resolution guards hold and the
+# failure surfaces as a clean local 500 rather than a constant/nil crash.
+RSpec.describe Otto::RouteHandlers::LambdaHandler do
+  let(:route_definition) do
+    Otto::RouteDefinition.new('GET', '/ping', '&health_check')
+  end
+
+  # Build a real Otto with a real, frozen lambda registry (never stub
+  # otto.config -- verify_partial_doubles + the real registry is the point).
+  def build_otto(handlers)
+    routes_file = create_test_routes_file('lambda_handler.txt', ['GET /ping &health_check'])
+    Otto.new(routes_file, lambda_handlers: handlers)
+  end
+
+  # Construct a LambdaHandler for `target_def`, backed by an otto whose registry
+  # maps 'health_check' => proc_obj, and drive #call. Returns the Rack triple.
+  def run_lambda(target_def, proc_obj, path: '/ping', headers: {}, extra: {})
+    otto = build_otto('health_check' => proc_obj)
+    rd = Otto::RouteDefinition.new('GET', path, target_def)
+    handler = described_class.new(rd, otto)
+    env = mock_rack_env(method: 'GET', path: path, headers: headers)
+    handler.call(env, extra)
+  end
+
+  describe 'factory dispatch (AC#2)' do
+    it 'routes a :lambda RouteDefinition to a LambdaHandler in the direct context' do
+      handler = Otto::RouteHandlers::HandlerFactory.create_handler(route_definition)
+
+      expect(handler).to be_a(described_class)
+    end
+
+    it 'wraps the LambdaHandler in a RouteAuthWrapper in the integrated context' do
+      otto = build_otto('health_check' => ->(_req, _res, _extra) {})
+
+      handler = Otto::RouteHandlers::HandlerFactory.create_handler(route_definition, otto)
+
+      expect(handler).to be_a(Otto::Security::Authentication::RouteAuthWrapper)
+      expect(handler.wrapped_handler).to be_a(described_class)
+    end
+  end
+
+  describe 'invocation contract (AC#4)' do
+    it 'invokes the registered proc with (req, res, extra_params)' do
+      seen = []
+      proc_obj = lambda do |req, res, extra|
+        seen = [req, res, extra]
+        res.write('ok')
+        nil
+      end
+      otto = build_otto('health_check' => proc_obj)
+      handler = described_class.new(route_definition, otto)
+
+      handler.call(mock_rack_env(path: '/ping'), { id: '7' })
+
+      expect(seen[0]).to respond_to(:params)   # a request object
+      expect(seen[1]).to respond_to(:write)    # a response object
+      expect(seen[2]).to include(id: '7')      # extra_params reached the 3rd arg
+    end
+
+    it 'reuses the BaseHandler pipeline: setup exposes route metadata on env' do
+      otto = build_otto('health_check' => ->(_req, _res, _extra) {})
+      handler = described_class.new(route_definition, otto)
+      env = mock_rack_env(path: '/ping')
+
+      handler.call(env)
+
+      # A standalone #call would leave these unset; their presence proves
+      # setup_request_response ran (pipeline reuse, not a bypass).
+      expect(env['otto.route_definition']).to eq(route_definition)
+      expect(env['otto.route_options']).to eq(route_definition.options)
+    end
+  end
+
+  describe 'response types (AC#5)' do
+    it 'json: serializes a Hash return value' do
+      status, headers, body = run_lambda('&health_check response=json',
+                                         ->(_req, _res, _extra) { { ok: true } })
+
+      expect(status).to eq(200)
+      expect(headers['Content-Type']).to eq('application/json')
+      expect(JSON.parse(body.first)).to eq('ok' => true)
+    end
+
+    it 'json: wraps a String return value under data' do
+      _status, _headers, body = run_lambda('&health_check response=json',
+                                           ->(_req, _res, _extra) { 'hello' })
+
+      expect(JSON.parse(body.first)).to eq('success' => true, 'data' => 'hello')
+    end
+
+    it 'json: treats a nil return value as success' do
+      _status, _headers, body = run_lambda('&health_check response=json',
+                                           ->(_req, _res, _extra) { nil })
+
+      expect(JSON.parse(body.first)).to eq('success' => true)
+    end
+
+    it 'redirect: a returned String path becomes a 302 Location' do
+      status, headers, = run_lambda('&health_check response=redirect',
+                                    ->(_req, _res, _extra) { '/next' })
+
+      expect(status).to eq(302)
+      expect(headers['Location']).to eq('/next')
+    end
+
+    it 'view: a returned String becomes an HTML body' do
+      _status, headers, body = run_lambda('&health_check response=view',
+                                          ->(_req, _res, _extra) { '<h1>Hi</h1>' })
+
+      expect(headers['Content-Type']).to eq('text/html')
+      expect(body.first).to eq('<h1>Hi</h1>')
+    end
+
+    it 'auto: a Hash is auto-detected as JSON' do
+      _status, headers, = run_lambda('&health_check response=auto',
+                                     ->(_req, _res, _extra) { { ok: true } })
+
+      expect(headers['Content-Type']).to eq('application/json')
+    end
+
+    it 'auto: a path-like String is auto-detected as a redirect' do
+      status, headers, = run_lambda('&health_check response=auto',
+                                    ->(_req, _res, _extra) { '/go' })
+
+      expect(status).to eq(302)
+      expect(headers['Location']).to eq('/go')
+    end
+
+    it 'default: honors what the proc writes and ignores the return value' do
+      status, _headers, body = run_lambda('&health_check',
+                                          lambda do |_req, res, _extra|
+                                            res.write('written')
+                                            { ignored: true } # return value ignored under default
+                                          end)
+
+      expect(status).to eq(200)
+      expect(body.first).to eq('written')
+    end
+  end
+
+  describe 'missing / invalid handlers (AC#7, AC#8)' do
+    it 'raises a clear, named ArgumentError when the handler is absent from the registry' do
+      otto = build_otto({}) # empty registry; route names &health_check
+      handler = described_class.new(route_definition, otto)
+
+      expect do
+        handler.call(mock_rack_env(path: '/ping'))
+      end.to raise_error(ArgumentError) do |err|
+        expect(err.message).to match(/health_check/)              # names the handler
+        expect(err.message).to match(/not registered|not callable/) # states the reason
+      end
+    end
+
+    it 'annotates env with a Lambda handler name and duration on failure (handler_name guard)' do
+      otto = build_otto({})
+      handler = described_class.new(route_definition, otto)
+      env = mock_rack_env(path: '/ping')
+
+      begin
+        handler.call(env)
+      rescue ArgumentError
+        # expected -- integrated context re-raises for the centralized handler
+      end
+
+      # Proves #handler_name is derived from the route, not target_class.name
+      # (which would be nil.name -> NoMethodError). No crash-on-nil occurred.
+      expect(env['otto.handler']).to match(/Lambda/)
+      expect(env['otto.handler_duration']).to be_a(Integer)
+    end
+
+    it 'rejects a non-callable registry value at construction (fail fast)' do
+      routes_file = create_test_routes_file('lambda_handler.txt', ['GET /ping &health_check'])
+
+      # The registry is validated during Otto.new, so an uncallable value never
+      # survives to be dispatched -- the clear error surfaces synchronously.
+      expect do
+        Otto.new(routes_file, lambda_handlers: { 'health_check' => 'nope' })
+      end.to raise_error(ArgumentError, /not callable/)
+    end
+
+    it 'does not execute arbitrary code: a source-looking key is an inert, absent lookup (AC#8)' do
+      executed = []
+      # Registry knows only 'safe'; the route names a key that LOOKS like code.
+      routes_file = create_test_routes_file('lambda_handler.txt', ["GET /x &system('boom') response=json"])
+      otto = Otto.new(routes_file, lambda_handlers: { 'safe' => ->(_r, _s, _e) { executed << :ran } })
+      rd = Otto::RouteDefinition.new('GET', '/x', "&system('boom') response=json")
+      handler = described_class.new(rd, otto)
+
+      expect(Kernel).not_to receive(:system)
+      expect do
+        handler.call(mock_rack_env(path: '/x'))
+      end.to raise_error(ArgumentError, %r{system\('boom'\)})
+      # The key was never eval'd, never const-resolved, never dispatched.
+      expect(executed).to be_empty
+    end
+  end
+
+  describe 'direct vs integrated context symmetry' do
+    it 'direct (no otto_instance): guards hold and an unresolved handler yields a clean local 500' do
+      # No otto -> empty registry by design. The base constant-resolution guards
+      # (target_class -> nil, handler_name override) must hold so this fails as a
+      # clean local 500, NOT an "Invalid class name format" or nil.name crash.
+      rd = Otto::RouteDefinition.new('GET', '/ping', '&health_check response=json')
+      handler = described_class.new(rd) # no otto_instance
+      env = mock_rack_env(path: '/ping', headers: { 'Accept' => 'application/json' })
+
+      status, headers, body = handler.call(env)
+
+      expect(status).to eq(500)
+      expect(headers['content-type']).to eq('application/json')
+      # Generic error body -- details are logged, never leaked (AC#8).
+      expect(JSON.parse(body.first)['error']).to eq('Internal Server Error')
+    end
+
+    it 'integrated: an exception raised inside the proc propagates with the handler annotated' do
+      otto = build_otto('health_check' => ->(*) { raise StandardError, 'boom' })
+      handler = described_class.new(route_definition, otto)
+      env = mock_rack_env(path: '/ping')
+
+      expect do
+        handler.call(env)
+      end.to raise_error(StandardError, 'boom')
+
+      # The centralized error handler receives a named handler, not target_class.name.
+      expect(env['otto.handler']).to match(/Lambda/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements Otto's fourth route-handler kind: **lambda handlers** — pre-registered procs that routes can target with an `&` prefix syntax. This feature enables inline request handlers without requiring controller classes, while maintaining security through O(1) registry lookup (no eval, no dynamic code execution).

## Key Changes

- **Route syntax**: Routes can now target pre-registered lambdas using `&handler_name` prefix (e.g., `GET /ping &health_check response=json`)
- **LambdaHandler class**: New handler type that resolves procs from a frozen registry by exact string key, reusing the BaseHandler pipeline for response-type dispatch and error handling
- **Registry validation**: Otto validates the `lambda_handlers:` option at construction time, ensuring all entries are callable with correct arity (3 arguments: req, res, extra_params), raising clear ArgumentError on invalid entries
- **RouteDefinition parsing**: Extended to recognize `&` prefix and parse lambda targets, storing the registry key in `klass_name` with `kind: :lambda`
- **Route class updates**: Skip constant resolution for lambda routes (the key is not a Ruby constant)
- **HandlerFactory dispatch**: Routes with `kind: :lambda` are dispatched to LambdaHandler
- **Configuration**: Added `configure_lambda_handlers` to validate and freeze the registry; exposed via `otto.config[:lambda_handlers]`
- **Security guards**: Handler name derivation bypasses `target_class.name` (which would be nil); unregistered handlers raise ArgumentError with handler name; source-code-looking keys are treated as plain registry keys, never resolved as constants
- **Response types**: Lambda handlers support all response types (json, view, redirect, auto, default) identically to class/instance/logic handlers
- **Route options**: Lambda routes support auth, role, csrf, and custom params just like other handler kinds

## Implementation Details

- **Arity validation**: Uses `#parameters` reflection to handle both Proc/Method callables and plain objects with `#call`, rejecting optional-arg forms that cannot accept 3 positional arguments (e.g., `->(a=1) {}`)
- **Registry freezing**: The lambda_handlers Hash is frozen after validation to prevent runtime mutation
- **Error handling**: Missing handlers surface as ArgumentError during request dispatch, with handler name and duration annotated in env for centralized error handling
- **No eval**: Route files contain only plain string keys; nothing is ever evaluated or dynamically resolved as a constant
- **Example**: Added `examples/lambda_handlers/` demonstrating registration, route syntax, response types, and webhook handling with CSRF exemption

## Testing

- Comprehensive integration tests covering dispatch, response types, route options, auth/role protection, and security (no eval, no dynamic code)
- Unit tests for LambdaHandler invocation contract, response-type dispatch, and error cases
- Configuration validation tests covering accepted callables, rejected arities, non-Proc objects, and frozen registry
- RouteDefinition parsing tests for lambda syntax with options

https://claude.ai/code/session_013Bf2gjjfqfyvs246oDvMJ3