### PR TITLE
Add stable-keyed IP correlation hash for long-horizon tracking

### DIFF
--- a/changelog.d/20260709_055658_ops_correlation_hash.rst
+++ b/changelog.d/20260709_055658_ops_correlation_hash.rst
@@ -1,0 +1,11 @@
+Added
+-----
+
+- IP privacy: stable-keyed correlation hash of the full client IP, computed
+  pre-masking and exposed as ``req.ip_correlation_hash`` /
+  ``env['otto.privacy.correlation_hash']``. Unlike the daily-rotating
+  ``hashed_ip``, it is keyed with a caller-configured stable secret
+  (``configure_ip_privacy(correlation_secret:)``), so the same host correlates
+  across days for long-lived records — without the raw IP ever reaching the
+  app. Returns ``nil`` when privacy is disabled or no secret is configured.
+  (#192)

--- a/lib/otto/env_keys.rb
+++ b/lib/otto/env_keys.rb
@@ -153,13 +153,13 @@ class Otto
       # Used by: Session correlation without storing IPs
       HASHED_IP = 'otto.privacy.hashed_ip'
 
-      # Stable-keyed IP correlation hash for long-horizon correlation
+      # Stable IP correlation hash: identifies the same visitor across days/months
       # Type: String (hexadecimal), or nil when no correlation secret configured
       # Set by: IPPrivacyMiddleware (computed over the FULL client IP,
       #   pre-masking, keyed with the caller-configured stable
       #   correlation_secret — NOT the daily rotation_key behind HASHED_IP)
-      # Used by: Correlating the same host across days/months (e.g. audit
-      #   trails) without ever storing or exposing the raw IP
+      # Used by: Correlating the same visitor across days/months (e.g. audit
+      #   trails) without ever storing or exposing the real IP
       # Read via: Otto::Request#ip_correlation_hash
       # Contrast: HASHED_IP rotates daily (session-scoped); this is stable.
       CORRELATION_HASH = 'otto.privacy.correlation_hash'

--- a/lib/otto/env_keys.rb
+++ b/lib/otto/env_keys.rb
@@ -153,6 +153,17 @@ class Otto
       # Used by: Session correlation without storing IPs
       HASHED_IP = 'otto.privacy.hashed_ip'
 
+      # Stable-keyed IP correlation hash for long-horizon correlation
+      # Type: String (hexadecimal), or nil when no correlation secret configured
+      # Set by: IPPrivacyMiddleware (computed over the FULL client IP,
+      #   pre-masking, keyed with the caller-configured stable
+      #   correlation_secret — NOT the daily rotation_key behind HASHED_IP)
+      # Used by: Correlating the same host across days/months (e.g. audit
+      #   trails) without ever storing or exposing the raw IP
+      # Read via: Otto::Request#ip_correlation_hash
+      # Contrast: HASHED_IP rotates daily (session-scoped); this is stable.
+      CORRELATION_HASH = 'otto.privacy.correlation_hash'
+
       # Privacy fingerprint object
       # Type: Otto::Privacy::RedactedFingerprint
       # Set by: IPPrivacyMiddleware

--- a/lib/otto/privacy/config.rb
+++ b/lib/otto/privacy/config.rb
@@ -27,7 +27,8 @@ class Otto
     class Config
       include Otto::Core::Freezable
 
-      attr_accessor :octet_precision, :hash_rotation_period, :geo_enabled, :mask_private_ips
+      attr_accessor :octet_precision, :hash_rotation_period, :geo_enabled, :mask_private_ips,
+                    :correlation_secret
       attr_reader :disabled
 
       # Class-level rotation key storage (mutable, not frozen with instances)
@@ -51,6 +52,11 @@ class Otto
       # @option options [Boolean] :geo_enabled Enable geo-location resolution (default: true)
       # @option options [Boolean] :disabled Disable privacy entirely (default: false)
       # @option options [Boolean] :mask_private_ips Mask private/localhost IPs (default: false)
+      # @option options [String] :correlation_secret Stable secret for the long-horizon
+      #   IP correlation hash (default: nil). Distinct from the daily-rotating
+      #   rotation_key used by hashed_ip: this key is caller-owned and does NOT
+      #   rotate, so the same IP hashes identically across days. When nil/empty
+      #   no correlation hash is produced (never hash under a weak/empty key).
       # @option options [Redis] :redis Optional Redis connection for multi-server environments
       def initialize(options = {})
         @octet_precision = options.fetch(:octet_precision, 1)
@@ -58,6 +64,7 @@ class Otto
         @geo_enabled = options.fetch(:geo_enabled, true)
         @disabled = options.fetch(:disabled, false) # Enabled by default (privacy-by-default)
         @mask_private_ips = options.fetch(:mask_private_ips, false) # Don't mask private/localhost by default
+        @correlation_secret = options.fetch(:correlation_secret, nil) # Stable long-horizon correlation key
         @redis = options[:redis] # Optional Redis connection for multi-server environments
       end
 

--- a/lib/otto/privacy/config.rb
+++ b/lib/otto/privacy/config.rb
@@ -51,11 +51,18 @@ class Otto
       # @option options [Boolean] :geo_enabled Enable geo-location resolution (default: true)
       # @option options [Boolean] :disabled Disable privacy entirely (default: false)
       # @option options [Boolean] :mask_private_ips Mask private/localhost IPs (default: false)
-      # @option options [String] :correlation_secret Stable secret for the long-horizon
-      #   IP correlation hash (default: nil). Distinct from the daily-rotating
-      #   rotation_key used by hashed_ip: this key is caller-owned and does NOT
-      #   rotate, so the same IP hashes identically across days. When nil/empty
-      #   no correlation hash is produced (never hash under a weak/empty key).
+      # @option options [String] :correlation_secret Enables the long-horizon IP
+      #   correlation hash, exposed as req.ip_correlation_hash (default: nil = off).
+      #   What it's for: let long-lived records answer "did these two events come
+      #   from the same host, months apart?" WITHOUT the app ever handling the raw
+      #   IP. The middleware masks the IP before the app sees it, leaving only a
+      #   /24 — too coarse to identify a host. This instead hashes the FULL IP at
+      #   the edge, pre-masking, keyed with this stable, caller-owned secret. And
+      #   unlike hashed_ip's key, which rotates daily (session correlation, useless
+      #   across days), this one never rotates, so the same IP hashes identically
+      #   over time — the piece long-horizon correlation needs. nil/empty leaves
+      #   the feature off; an empty key is refused, because the secret is the only
+      #   thing stopping anyone from recomputing the hash and de-anonymizing the IP.
       # @option options [Redis] :redis Optional Redis connection for multi-server environments
       def initialize(options = {})
         @octet_precision = options.fetch(:octet_precision, 1)

--- a/lib/otto/privacy/config.rb
+++ b/lib/otto/privacy/config.rb
@@ -27,9 +27,8 @@ class Otto
     class Config
       include Otto::Core::Freezable
 
-      attr_accessor :octet_precision, :hash_rotation_period, :geo_enabled, :mask_private_ips,
-                    :correlation_secret
-      attr_reader :disabled
+      attr_accessor :octet_precision, :hash_rotation_period, :geo_enabled, :mask_private_ips
+      attr_reader :disabled, :correlation_secret
 
       # Class-level rotation key storage (mutable, not frozen with instances)
       # This is stored at the class level so it persists across frozen config instances
@@ -64,8 +63,27 @@ class Otto
         @geo_enabled = options.fetch(:geo_enabled, true)
         @disabled = options.fetch(:disabled, false) # Enabled by default (privacy-by-default)
         @mask_private_ips = options.fetch(:mask_private_ips, false) # Don't mask private/localhost by default
-        @correlation_secret = options.fetch(:correlation_secret, nil) # Stable long-horizon correlation key
+        self.correlation_secret = options.fetch(:correlation_secret, nil) # Stable long-horizon correlation key
         @redis = options[:redis] # Optional Redis connection for multi-server environments
+      end
+
+      # Set the stable correlation secret, validating its type up front.
+      #
+      # nil or an empty string mean "correlation hash disabled" (see
+      # IPPrivacyMiddleware#correlation_hash — an empty key is never used to
+      # hash). Any other non-String is a configuration error: without this
+      # guard it would surface far from its cause, as a NoMethodError on
+      # `#empty?` deep inside per-request middleware. Fail fast here instead,
+      # at the point of misconfiguration, with a message that names the type.
+      #
+      # @param value [String, nil] stable secret, or nil/"" to disable
+      # @raise [ArgumentError] if value is neither a String nor nil
+      def correlation_secret=(value)
+        unless value.nil? || value.is_a?(String)
+          raise ArgumentError, "correlation_secret must be a String or nil, got: #{value.class}"
+        end
+
+        @correlation_secret = value
       end
 
       # Check if privacy is enabled

--- a/lib/otto/privacy/config.rb
+++ b/lib/otto/privacy/config.rb
@@ -51,18 +51,22 @@ class Otto
       # @option options [Boolean] :geo_enabled Enable geo-location resolution (default: true)
       # @option options [Boolean] :disabled Disable privacy entirely (default: false)
       # @option options [Boolean] :mask_private_ips Mask private/localhost IPs (default: false)
-      # @option options [String] :correlation_secret Enables the long-horizon IP
-      #   correlation hash, exposed as req.ip_correlation_hash (default: nil = off).
-      #   What it's for: let long-lived records answer "did these two events come
-      #   from the same host, months apart?" WITHOUT the app ever handling the raw
-      #   IP. The middleware masks the IP before the app sees it, leaving only a
-      #   /24 — too coarse to identify a host. This instead hashes the FULL IP at
-      #   the edge, pre-masking, keyed with this stable, caller-owned secret. And
-      #   unlike hashed_ip's key, which rotates daily (session correlation, useless
-      #   across days), this one never rotates, so the same IP hashes identically
-      #   over time — the piece long-horizon correlation needs. nil/empty leaves
-      #   the feature off; an empty key is refused, because the secret is the only
-      #   thing stopping anyone from recomputing the hash and de-anonymizing the IP.
+      # @option options [String] :correlation_secret A secret string that turns
+      #   on IP correlation. Default nil, meaning off.
+      #
+      #   It answers one question: "are these two requests, maybe months apart,
+      #   from the same visitor?" — without your app ever seeing the real IP.
+      #
+      #   Otto masks each IP before your app runs (203.0.113.42 becomes
+      #   203.0.113.0), which is too coarse to tell visitors apart. When a secret
+      #   is set, Otto also fingerprints the full IP, before masking, and hands
+      #   your app just the fingerprint as req.ip_correlation_hash. The same IP
+      #   always produces the same fingerprint, and it can't be turned back into
+      #   an IP without the secret.
+      #
+      #   Keep the secret stable — changing it changes every fingerprint. An empty
+      #   string is rejected, because an empty secret would let anyone reverse the
+      #   fingerprint back to an IP.
       # @option options [Redis] :redis Optional Redis connection for multi-server environments
       def initialize(options = {})
         @octet_precision = options.fetch(:octet_precision, 1)
@@ -70,7 +74,7 @@ class Otto
         @geo_enabled = options.fetch(:geo_enabled, true)
         @disabled = options.fetch(:disabled, false) # Enabled by default (privacy-by-default)
         @mask_private_ips = options.fetch(:mask_private_ips, false) # Don't mask private/localhost by default
-        self.correlation_secret = options.fetch(:correlation_secret, nil) # Stable long-horizon correlation key
+        self.correlation_secret = options.fetch(:correlation_secret, nil) # Opt-in stable IP-correlation secret
         @redis = options[:redis] # Optional Redis connection for multi-server environments
       end
 

--- a/lib/otto/privacy/core.rb
+++ b/lib/otto/privacy/core.rb
@@ -52,15 +52,13 @@ class Otto
       # @param hash_rotation [Integer] Seconds between key rotation (default: 86400)
       # @param geo [Boolean] Enable geo-location resolution (default: true)
       # @param redis [Redis] Redis connection for multi-server atomic key generation
-      # @param correlation_secret [String] Stable secret that enables the
-      #   long-horizon IP correlation hash (req.ip_correlation_hash). What it's
-      #   for: let long-lived records tell whether two events came from the same
-      #   host across days/months, without the app ever handling the raw IP — the
-      #   per-host granularity the masked-IP-only view can't give you (that's just
-      #   a /24). It hashes the full pre-masking IP with a key that, unlike
-      #   hashed_ip's daily-rotating one, never rotates. Omit (nil) to leave any
-      #   existing secret unchanged, consistent with the other kwargs here; pass
-      #   an empty string to explicitly disable a previously configured secret.
+      # @param correlation_secret [String] A secret string that turns on IP
+      #   correlation: it lets you tell whether two requests, even months apart,
+      #   came from the same visitor — without your app ever seeing the real IP.
+      #   (Otto masks the IP before your app runs; with a secret set it also
+      #   fingerprints the full IP into req.ip_correlation_hash, which can't be
+      #   reversed to an IP without the secret.) Omit it to leave any existing
+      #   secret unchanged; pass an empty string to turn the feature back off.
       #
       # @example Mask 2 octets instead of 1
       #   otto.configure_ip_privacy(octet_precision: 2)
@@ -71,7 +69,7 @@ class Otto
       # @example Custom hash rotation
       #   otto.configure_ip_privacy(hash_rotation: 24.hours)
       #
-      # @example Enable long-horizon IP correlation
+      # @example Enable stable IP correlation (same visitor across days)
       #   otto.configure_ip_privacy(correlation_secret: ENV['IP_CORRELATION_SECRET'])
       #
       # @example Multi-server with Redis

--- a/lib/otto/privacy/core.rb
+++ b/lib/otto/privacy/core.rb
@@ -52,6 +52,10 @@ class Otto
       # @param hash_rotation [Integer] Seconds between key rotation (default: 86400)
       # @param geo [Boolean] Enable geo-location resolution (default: true)
       # @param redis [Redis] Redis connection for multi-server atomic key generation
+      # @param correlation_secret [String] Stable secret for the long-horizon IP
+      #   correlation hash (req.ip_correlation_hash). Distinct from the daily-
+      #   rotating hashed_ip key: this one does NOT rotate, so the same IP
+      #   correlates across days. Leave unset to disable the correlation hash.
       #
       # @example Mask 2 octets instead of 1
       #   otto.configure_ip_privacy(octet_precision: 2)
@@ -62,16 +66,21 @@ class Otto
       # @example Custom hash rotation
       #   otto.configure_ip_privacy(hash_rotation: 24.hours)
       #
+      # @example Enable long-horizon IP correlation
+      #   otto.configure_ip_privacy(correlation_secret: ENV['IP_CORRELATION_SECRET'])
+      #
       # @example Multi-server with Redis
       #   redis = Redis.new(url: ENV['REDIS_URL'])
       #   otto.configure_ip_privacy(redis: redis)
-      def configure_ip_privacy(octet_precision: nil, hash_rotation: nil, geo: nil, redis: nil)
+      def configure_ip_privacy(octet_precision: nil, hash_rotation: nil, geo: nil, redis: nil,
+                               correlation_secret: nil)
         ensure_not_frozen!
         config = @security_config.ip_privacy_config
 
         config.octet_precision = octet_precision if octet_precision
         config.hash_rotation_period = hash_rotation if hash_rotation
         config.geo_enabled = geo unless geo.nil?
+        config.correlation_secret = correlation_secret if correlation_secret
         config.instance_variable_set(:@redis, redis) if redis
 
         # Validate configuration

--- a/lib/otto/privacy/core.rb
+++ b/lib/otto/privacy/core.rb
@@ -52,12 +52,15 @@ class Otto
       # @param hash_rotation [Integer] Seconds between key rotation (default: 86400)
       # @param geo [Boolean] Enable geo-location resolution (default: true)
       # @param redis [Redis] Redis connection for multi-server atomic key generation
-      # @param correlation_secret [String] Stable secret for the long-horizon IP
-      #   correlation hash (req.ip_correlation_hash). Distinct from the daily-
-      #   rotating hashed_ip key: this one does NOT rotate, so the same IP
-      #   correlates across days. Omit (nil) to leave any existing secret
-      #   unchanged, consistent with the other kwargs here; pass an empty
-      #   string to explicitly disable a previously configured secret.
+      # @param correlation_secret [String] Stable secret that enables the
+      #   long-horizon IP correlation hash (req.ip_correlation_hash). What it's
+      #   for: let long-lived records tell whether two events came from the same
+      #   host across days/months, without the app ever handling the raw IP — the
+      #   per-host granularity the masked-IP-only view can't give you (that's just
+      #   a /24). It hashes the full pre-masking IP with a key that, unlike
+      #   hashed_ip's daily-rotating one, never rotates. Omit (nil) to leave any
+      #   existing secret unchanged, consistent with the other kwargs here; pass
+      #   an empty string to explicitly disable a previously configured secret.
       #
       # @example Mask 2 octets instead of 1
       #   otto.configure_ip_privacy(octet_precision: 2)

--- a/lib/otto/privacy/core.rb
+++ b/lib/otto/privacy/core.rb
@@ -55,7 +55,9 @@ class Otto
       # @param correlation_secret [String] Stable secret for the long-horizon IP
       #   correlation hash (req.ip_correlation_hash). Distinct from the daily-
       #   rotating hashed_ip key: this one does NOT rotate, so the same IP
-      #   correlates across days. Leave unset to disable the correlation hash.
+      #   correlates across days. Omit (nil) to leave any existing secret
+      #   unchanged, consistent with the other kwargs here; pass an empty
+      #   string to explicitly disable a previously configured secret.
       #
       # @example Mask 2 octets instead of 1
       #   otto.configure_ip_privacy(octet_precision: 2)
@@ -80,7 +82,12 @@ class Otto
         config.octet_precision = octet_precision if octet_precision
         config.hash_rotation_period = hash_rotation if hash_rotation
         config.geo_enabled = geo unless geo.nil?
-        config.correlation_secret = correlation_secret if correlation_secret
+        # Mirror geo's `unless nil?` guard: nil means "leave unchanged", while an
+        # explicit "" is a real value that disables the correlation hash. (A
+        # plain `if correlation_secret` would also assign "" since "" is truthy
+        # in Ruby, but stating the nil intent explicitly keeps this consistent
+        # with the other nilable kwargs.)
+        config.correlation_secret = correlation_secret unless correlation_secret.nil?
         config.instance_variable_set(:@redis, redis) if redis
 
         # Validate configuration

--- a/lib/otto/request.rb
+++ b/lib/otto/request.rb
@@ -133,6 +133,29 @@ class Otto
       redacted_fingerprint&.hashed_ip || env['otto.privacy.hashed_ip']
     end
 
+    # Get the stable-keyed correlation hash of the client IP.
+    #
+    # Contrast with #hashed_ip: that value is keyed with a daily-rotating
+    # secret (great for correlating requests within a session, useless across
+    # days). This value is HMAC-SHA256 over the SAME full, pre-masking client
+    # IP but keyed with a caller-configured STABLE secret, so the same IP
+    # produces the same hash indefinitely — the granularity long-lived audit
+    # records need without ever handling the raw IP.
+    #
+    # Both are computed before masking, so both reflect the per-host address
+    # (not the /24 the app is otherwise left with); the raw IP itself never
+    # reaches the application — only the hash does.
+    #
+    # Returns nil when IP privacy is disabled or no correlation secret is
+    # configured (see Otto#configure_ip_privacy(correlation_secret:)).
+    #
+    # @return [String, nil] Hexadecimal HMAC-SHA256 hash string or nil
+    # @example
+    #   req.ip_correlation_hash  # => 'b7e2...'  (stable across days)
+    def ip_correlation_hash
+      env['otto.privacy.correlation_hash']
+    end
+
     def client_ipaddress
       # Prefer the canonical client IP resolved once by IPPrivacyMiddleware
       # ("resolve once, read everywhere"). Falls back to the shared resolver

--- a/lib/otto/request.rb
+++ b/lib/otto/request.rb
@@ -146,8 +146,12 @@ class Otto
     # (not the /24 the app is otherwise left with); the raw IP itself never
     # reaches the application — only the hash does.
     #
-    # Returns nil when IP privacy is disabled or no correlation secret is
-    # configured (see Otto#configure_ip_privacy(correlation_secret:)).
+    # Returns nil when IP privacy is disabled, no correlation secret is
+    # configured (see Otto#configure_ip_privacy(correlation_secret:)), or the
+    # client IP is exempt from masking. By default private/localhost IPs are
+    # exempt (mask_private_ips is false), so this is nil for RFC-1918 and
+    # loopback addresses — including the common local dev path — just like
+    # #masked_ip and #hashed_ip. It targets public audit-trail traffic.
     #
     # @return [String, nil] Hexadecimal HMAC-SHA256 hash string or nil
     # @example

--- a/lib/otto/security/middleware/ip_privacy_middleware.rb
+++ b/lib/otto/security/middleware/ip_privacy_middleware.rb
@@ -72,12 +72,6 @@ class Otto
         # Apply privacy settings to environment
         #
         # @param env [Hash] Rack environment
-        # Apply privacy settings to environment
-        #
-        # @param env [Hash] Rack environment
-        # Apply privacy settings to environment
-        #
-        # @param env [Hash] Rack environment
         def apply_privacy(env)
           # Resolve the actual client IP once (handling proxies). This is the
           # canonical resolution step; masking below operates on this value.
@@ -116,6 +110,15 @@ class Otto
               # Canonical client IP downstream reads (exempt: not masked)
               env['otto.client_ip'] = client_ip
               # Don't mask forwarded headers for private IPs
+              #
+              # This early return also means NONE of the privacy fingerprint
+              # values are produced for exempt IPs — no otto.privacy.fingerprint,
+              # masked_ip, hashed_ip, geo_country, or correlation_hash. That is
+              # intentional and consistent: the correlation hash targets public
+              # audit-trail traffic, so req.ip_correlation_hash is nil for
+              # localhost / RFC-1918 addresses (the default dev path) even when a
+              # correlation_secret is configured. Set mask_private_ips to treat
+              # private IPs as public and run them through the full path below.
               Otto.logger.debug "[IPPrivacyMiddleware] Private/localhost IP exempted: #{client_ip}" if Otto.debug
               return
             end

--- a/lib/otto/security/middleware/ip_privacy_middleware.rb
+++ b/lib/otto/security/middleware/ip_privacy_middleware.rb
@@ -137,15 +137,12 @@ class Otto
           env['otto.privacy.hashed_ip'] = fingerprint.hashed_ip
           env['otto.privacy.geo_country'] = fingerprint.country
 
-          # Stable-keyed correlation hash over the FULL, still-unmasked client
-          # IP. Computed here — while client_ip is the resolved raw address and
-          # before REMOTE_ADDR is overwritten with the masked value below — so
-          # it captures per-host granularity, not the /24 the app would be left
-          # with. Unlike hashed_ip (daily-rotating key, for short-lived session
-          # correlation), this uses a caller-configured STABLE secret, so the
-          # same IP hashes identically across days for long-horizon records.
-          # nil when no correlation secret is configured. The raw IP itself is
-          # never written to env; only this hash escapes the middleware.
+          # Fingerprint the FULL client IP here — while client_ip is still the
+          # real address, before REMOTE_ADDR is masked below — so it identifies
+          # the visitor, not just their /24. Uses the caller's stable secret
+          # (unlike hashed_ip's daily key), so the same IP matches across days.
+          # nil when no secret is set. The real IP is never written to env; only
+          # this hash leaves the middleware.
           env['otto.privacy.correlation_hash'] = correlation_hash(client_ip)
 
           # CRITICAL: Replace REMOTE_ADDR and forwarded headers with masked values
@@ -172,18 +169,14 @@ class Otto
           # or env['otto.original_referer']. This prevents accidental leakage of the real values.
         end
 
-        # Compute the stable-keyed correlation hash over the full client IP.
+        # Fingerprint of the full client IP, keyed with the caller's stable
+        # correlation secret (not hashed_ip's daily-rotating key). The same IP
+        # and secret always produce the same value, so it can match a visitor
+        # across days — which the daily hash can't.
         #
-        # HMAC-SHA256 keyed with the caller-configured, non-rotating
-        # correlation secret (distinct from the daily rotation_key behind
-        # hashed_ip). Same IP + same secret => same hash, indefinitely — the
-        # long-horizon correlation the daily hash cannot provide.
-        #
-        # Returns nil when no correlation secret is configured. We never hash
-        # under a nil/empty key (that would be trivially guessable and defeat
-        # the privacy guarantee) — mirroring IPPrivacy.hash_ip's own empty-key
-        # guard, but degrading to nil here rather than raising, since a missing
-        # secret is a valid "feature not enabled" state, not a caller error.
+        # Returns nil when no secret is configured. An empty key is never used
+        # to hash (that would let anyone reverse it); we return nil rather than
+        # raise, since "no secret" just means the feature is off.
         #
         # @param client_ip [String] Resolved full client IP (pre-masking)
         # @return [String, nil] Hex HMAC-SHA256 digest, or nil when unconfigured

--- a/lib/otto/security/middleware/ip_privacy_middleware.rb
+++ b/lib/otto/security/middleware/ip_privacy_middleware.rb
@@ -134,6 +134,17 @@ class Otto
           env['otto.privacy.hashed_ip'] = fingerprint.hashed_ip
           env['otto.privacy.geo_country'] = fingerprint.country
 
+          # Stable-keyed correlation hash over the FULL, still-unmasked client
+          # IP. Computed here — while client_ip is the resolved raw address and
+          # before REMOTE_ADDR is overwritten with the masked value below — so
+          # it captures per-host granularity, not the /24 the app would be left
+          # with. Unlike hashed_ip (daily-rotating key, for short-lived session
+          # correlation), this uses a caller-configured STABLE secret, so the
+          # same IP hashes identically across days for long-horizon records.
+          # nil when no correlation secret is configured. The raw IP itself is
+          # never written to env; only this hash escapes the middleware.
+          env['otto.privacy.correlation_hash'] = correlation_hash(client_ip)
+
           # CRITICAL: Replace REMOTE_ADDR and forwarded headers with masked values
           # This ensures downstream code (rate limiting, auth, logging, Rack's request.ip)
           # automatically uses the masked values without modification
@@ -158,6 +169,27 @@ class Otto
           # or env['otto.original_referer']. This prevents accidental leakage of the real values.
         end
 
+        # Compute the stable-keyed correlation hash over the full client IP.
+        #
+        # HMAC-SHA256 keyed with the caller-configured, non-rotating
+        # correlation secret (distinct from the daily rotation_key behind
+        # hashed_ip). Same IP + same secret => same hash, indefinitely — the
+        # long-horizon correlation the daily hash cannot provide.
+        #
+        # Returns nil when no correlation secret is configured. We never hash
+        # under a nil/empty key (that would be trivially guessable and defeat
+        # the privacy guarantee) — mirroring IPPrivacy.hash_ip's own empty-key
+        # guard, but degrading to nil here rather than raising, since a missing
+        # secret is a valid "feature not enabled" state, not a caller error.
+        #
+        # @param client_ip [String] Resolved full client IP (pre-masking)
+        # @return [String, nil] Hex HMAC-SHA256 digest, or nil when unconfigured
+        def correlation_hash(client_ip)
+          secret = @config.correlation_secret
+          return nil if secret.nil? || secret.empty?
+
+          Otto::Privacy::IPPrivacy.hash_ip(client_ip, secret)
+        end
 
         # Set or clear a Rack env header in a SPEC-compliant way.
         #

--- a/spec/otto/ip_privacy_spec.rb
+++ b/spec/otto/ip_privacy_spec.rb
@@ -2331,5 +2331,52 @@ RSpec.describe 'IP Privacy Features' do
       config.correlation_secret = 'later'
       expect(config.correlation_secret).to eq('later')
     end
+
+    it 'accepts an empty string (the feature-disabled sentinel)' do
+      expect(Otto::Privacy::Config.new(correlation_secret: '').correlation_secret).to eq('')
+    end
+
+    it 'rejects a non-String, non-nil secret at construction (fail fast)' do
+      expect { Otto::Privacy::Config.new(correlation_secret: 123) }
+        .to raise_error(ArgumentError, /correlation_secret must be a String or nil, got: Integer/)
+    end
+
+    it 'rejects a non-String, non-nil secret assigned after construction' do
+      config = Otto::Privacy::Config.new
+      expect { config.correlation_secret = :nope }
+        .to raise_error(ArgumentError, /correlation_secret must be a String or nil/)
+    end
+  end
+
+  describe 'Otto#configure_ip_privacy(correlation_secret:)' do
+    it 'stores the correlation secret on the privacy config' do
+      otto = create_minimal_otto(['GET / TestApp.index'])
+      otto.configure_ip_privacy(correlation_secret: 'stable-secret')
+
+      expect(otto.security_config.ip_privacy_config.correlation_secret).to eq('stable-secret')
+    end
+
+    it 'leaves an existing secret unchanged when omitted (nil means "no change")' do
+      otto = create_minimal_otto(['GET / TestApp.index'])
+      otto.configure_ip_privacy(correlation_secret: 'stable-secret')
+      otto.configure_ip_privacy(octet_precision: 2)
+
+      expect(otto.security_config.ip_privacy_config.correlation_secret).to eq('stable-secret')
+    end
+
+    it 'disables a previously configured secret when given an empty string' do
+      otto = create_minimal_otto(['GET / TestApp.index'])
+      otto.configure_ip_privacy(correlation_secret: 'stable-secret')
+      otto.configure_ip_privacy(correlation_secret: '')
+
+      expect(otto.security_config.ip_privacy_config.correlation_secret).to eq('')
+    end
+
+    it 'fails fast on a non-String secret' do
+      otto = create_minimal_otto(['GET / TestApp.index'])
+
+      expect { otto.configure_ip_privacy(correlation_secret: 123) }
+        .to raise_error(ArgumentError, /correlation_secret must be a String or nil/)
+    end
   end
 end

--- a/spec/otto/ip_privacy_spec.rb
+++ b/spec/otto/ip_privacy_spec.rb
@@ -2185,4 +2185,151 @@ RSpec.describe 'IP Privacy Features' do
       expect(log_line).to include('127.0.0.1')
     end
   end
+
+  describe 'Stable-keyed IP correlation hash (otto#192)' do
+    let(:app) { ->(env) { [200, {}, ['OK']] } }
+    let(:security_config) { Otto::Security::Config.new }
+    let(:correlation_secret) { 'stable-correlation-secret-v1' }
+    let(:middleware) do
+      security_config.ip_privacy_config.correlation_secret = correlation_secret
+      Otto::Security::Middleware::IPPrivacyMiddleware.new(app, security_config)
+    end
+
+    # Run one request through the middleware and return the correlation hash.
+    def correlation_hash_for(remote_addr)
+      env = { 'REMOTE_ADDR' => remote_addr }
+      middleware.call(env)
+      env['otto.privacy.correlation_hash']
+    end
+
+    it 'computes an HMAC-SHA256 hex digest over the FULL client IP' do
+      hash = correlation_hash_for('9.9.9.9')
+
+      expect(hash).to match(/^[0-9a-f]{64}$/)
+      # Keyed with the configured stable secret over the full address...
+      expect(hash).to eq(Otto::Privacy::IPPrivacy.hash_ip('9.9.9.9', correlation_secret))
+      # ...NOT over the masked /24 the app is otherwise left with.
+      expect(hash).not_to eq(Otto::Privacy::IPPrivacy.hash_ip('9.9.9.0', correlation_secret))
+    end
+
+    it 'is stable for the same IP + secret across requests' do
+      expect(correlation_hash_for('9.9.9.9')).to eq(correlation_hash_for('9.9.9.9'))
+    end
+
+    it 'remains stable across daily key rotations (unlike hashed_ip)' do
+      env1 = { 'REMOTE_ADDR' => '9.9.9.9' }
+      middleware.call(env1)
+
+      # Simulate crossing into a new "day": the daily rotation-key store is
+      # regenerated, so the next request's hashed_ip is keyed differently.
+      Otto::Privacy::Config.rotation_keys_store.clear
+
+      env2 = { 'REMOTE_ADDR' => '9.9.9.9' }
+      middleware.call(env2)
+
+      # The daily session hash rotated away...
+      expect(env2['otto.privacy.hashed_ip']).not_to eq(env1['otto.privacy.hashed_ip'])
+      # ...but the stable correlation hash survived the boundary.
+      expect(env2['otto.privacy.correlation_hash']).to eq(env1['otto.privacy.correlation_hash'])
+    end
+
+    it 'diverges for different IPs' do
+      expect(correlation_hash_for('9.9.9.9')).not_to eq(correlation_hash_for('8.8.8.8'))
+    end
+
+    it 'supports IPv6 addresses' do
+      hash = correlation_hash_for('2606:4700:4700::1111')
+
+      expect(hash).to match(/^[0-9a-f]{64}$/)
+      expect(hash).to eq(Otto::Privacy::IPPrivacy.hash_ip('2606:4700:4700::1111', correlation_secret))
+    end
+
+    it 'is provably distinct from the daily-rotating hashed_ip for the same IP' do
+      env = { 'REMOTE_ADDR' => '9.9.9.9' }
+      middleware.call(env)
+
+      expect(env['otto.privacy.correlation_hash']).to match(/^[0-9a-f]{64}$/)
+      expect(env['otto.privacy.hashed_ip']).to match(/^[0-9a-f]{64}$/)
+      expect(env['otto.privacy.correlation_hash']).not_to eq(env['otto.privacy.hashed_ip'])
+    end
+
+    it 'never writes the raw IP into env (only the hash escapes)' do
+      env = { 'REMOTE_ADDR' => '9.9.9.9' }
+      middleware.call(env)
+
+      expect(env['REMOTE_ADDR']).to eq('9.9.9.0')     # masked in place
+      expect(env['otto.original_ip']).to be_nil        # raw never stored
+      expect(env.values).not_to include('9.9.9.9')     # raw absent everywhere
+    end
+
+    context 'when no correlation secret is configured' do
+      let(:correlation_secret) { nil }
+
+      it 'sets the correlation hash to nil (never hashes under an empty key)' do
+        env = { 'REMOTE_ADDR' => '9.9.9.9' }
+        middleware.call(env)
+
+        expect(env['otto.privacy.correlation_hash']).to be_nil
+        # The daily hash is still produced — only the correlation hash opts out.
+        expect(env['otto.privacy.hashed_ip']).to match(/^[0-9a-f]{64}$/)
+      end
+    end
+
+    context 'when the correlation secret is an empty string' do
+      let(:correlation_secret) { '' }
+
+      it 'sets the correlation hash to nil' do
+        env = { 'REMOTE_ADDR' => '9.9.9.9' }
+        middleware.call(env)
+
+        expect(env['otto.privacy.correlation_hash']).to be_nil
+      end
+    end
+
+    context 'when IP privacy is disabled' do
+      before { security_config.ip_privacy_config.disable! }
+
+      it 'does not compute a correlation hash' do
+        env = { 'REMOTE_ADDR' => '9.9.9.9' }
+        middleware.call(env)
+
+        expect(env['otto.privacy.correlation_hash']).to be_nil
+        expect(env['REMOTE_ADDR']).to eq('9.9.9.9') # unmasked (privacy off)
+      end
+    end
+
+    describe 'Otto::Request#ip_correlation_hash' do
+      it 'reads env["otto.privacy.correlation_hash"]' do
+        env = { 'REMOTE_ADDR' => '9.9.9.9' }
+        middleware.call(env)
+        req = Otto::Request.new(env)
+
+        expect(req.ip_correlation_hash).to eq(env['otto.privacy.correlation_hash'])
+        expect(req.ip_correlation_hash).to match(/^[0-9a-f]{64}$/)
+      end
+
+      it 'returns nil when the middleware never computed one' do
+        req = Otto::Request.new({})
+
+        expect(req.ip_correlation_hash).to be_nil
+      end
+    end
+  end
+
+  describe 'Otto::Privacy::Config correlation_secret' do
+    it 'defaults to nil' do
+      expect(Otto::Privacy::Config.new.correlation_secret).to be_nil
+    end
+
+    it 'accepts a correlation secret at construction' do
+      config = Otto::Privacy::Config.new(correlation_secret: 'abc')
+      expect(config.correlation_secret).to eq('abc')
+    end
+
+    it 'is settable after construction' do
+      config = Otto::Privacy::Config.new
+      config.correlation_secret = 'later'
+      expect(config.correlation_secret).to eq('later')
+    end
+  end
 end

--- a/spec/otto/ip_privacy_spec.rb
+++ b/spec/otto/ip_privacy_spec.rb
@@ -2298,6 +2298,38 @@ RSpec.describe 'IP Privacy Features' do
       end
     end
 
+    context 'for private / localhost IPs (exempt from masking by default)' do
+      # Private/localhost IPs take the early-return exempt path, which skips the
+      # whole fingerprint — masked_ip, hashed_ip AND correlation_hash. Assert it
+      # explicitly so this intentional "nil on the local dev path" behavior is
+      # documented and a future refactor can't silently change it.
+      it 'produces no correlation hash for a loopback IP, even with a secret configured' do
+        env = { 'REMOTE_ADDR' => '127.0.0.1' }
+        middleware.call(env)
+
+        expect(env['otto.privacy.correlation_hash']).to be_nil
+        expect(env['otto.privacy.hashed_ip']).to be_nil     # same exemption
+        expect(env['REMOTE_ADDR']).to eq('127.0.0.1')       # exempt: not masked
+      end
+
+      it 'produces no correlation hash for an RFC-1918 IP, even with a secret configured' do
+        env = { 'REMOTE_ADDR' => '192.168.1.100' }
+        middleware.call(env)
+
+        expect(env['otto.privacy.correlation_hash']).to be_nil
+      end
+
+      it 'DOES produce one for a private IP when mask_private_ips is enabled' do
+        security_config.ip_privacy_config.mask_private_ips = true
+        env = { 'REMOTE_ADDR' => '192.168.1.100' }
+        middleware.call(env)
+
+        # Now the private IP runs the full path: hash keyed over the FULL IP.
+        expect(env['otto.privacy.correlation_hash'])
+          .to eq(Otto::Privacy::IPPrivacy.hash_ip('192.168.1.100', correlation_secret))
+      end
+    end
+
     describe 'Otto::Request#ip_correlation_hash' do
       it 'reads env["otto.privacy.correlation_hash"]' do
         env = { 'REMOTE_ADDR' => '9.9.9.9' }


### PR DESCRIPTION
## Summary

Adds a stable-keyed correlation hash of the client IP that persists across daily key rotations, enabling long-lived audit records and cross-day IP correlation without exposing raw IP addresses to the application.

## Key Changes

- **New `otto.privacy.correlation_hash` env key**: Computed pre-masking over the full client IP using a caller-configured stable secret (distinct from the daily-rotating `hashed_ip` key). Exposed via `Otto::Request#ip_correlation_hash`.

- **Configuration support**: Extended `configure_ip_privacy()` to accept a `correlation_secret` parameter. The secret is stored in `Otto::Privacy::Config` and defaults to `nil` (feature disabled).

- **Middleware integration**: `IPPrivacyMiddleware` now computes the correlation hash via a new `correlation_hash()` method before masking the IP. Returns `nil` when no secret is configured or privacy is disabled.

- **Documentation and env keys**: Added comprehensive docstrings explaining the distinction from `hashed_ip` (daily-rotating vs. stable), and registered the new `CORRELATION_HASH` env key in `Otto::EnvKeys::Privacy`.

- **Comprehensive test coverage**: 13 new test cases covering:
  - HMAC-SHA256 computation and format validation
  - Stability across requests and daily key rotations
  - IPv6 support
  - Distinction from daily-rotating `hashed_ip`
  - Raw IP never stored in env
  - Behavior when secret is unconfigured or empty
  - Behavior when privacy is disabled
  - `Otto::Request#ip_correlation_hash` accessor

## Implementation Details

- The correlation hash is computed **before** IP masking, capturing per-host granularity (not the /24 masked value).
- Uses `Otto::Privacy::IPPrivacy.hash_ip()` with the stable secret, mirroring its empty-key guard but degrading to `nil` rather than raising (valid "feature not enabled" state).
- Never hashes under a `nil` or empty key to prevent trivially guessable hashes.
- Complements the existing daily-rotating `hashed_ip` for session-scoped correlation; this enables long-horizon records (audit trails, fraud detection) across days without raw IP exposure.

https://claude.ai/code/session_014ux4fsNDAzB8sx9g8YsDVg