### PR TITLE
Extract User-Agent anonymization to public UserAgentPrivacy class

### DIFF
--- a/changelog.d/20260709_000000_user_agent_privacy.rst
+++ b/changelog.d/20260709_000000_user_agent_privacy.rst
@@ -1,0 +1,18 @@
+Added
+-----
+
+- ``Otto::Privacy::UserAgentPrivacy.anonymize(ua, max_length:)`` — a public
+  User-Agent anonymization surface (the analogue of ``Otto::Privacy::IPPrivacy``
+  for the User-Agent header). Strips build identifiers and version numbers and
+  truncates, preserving browser/OS family text; idempotent, so re-anonymizing
+  already-anonymized output is a no-op. Lets downstream consumers reduce a UA
+  outside of the full RedactedFingerprint / middleware flow without
+  re-implementing (and drifting from) the regexes. (delano/otto#194)
+
+Changed
+-------
+
+- ``Otto::Privacy::RedactedFingerprint#anonymize_user_agent`` now delegates to
+  ``Otto::Privacy::UserAgentPrivacy.anonymize``, making the public class the
+  single source of truth for User-Agent reduction. Behavior is unchanged.
+  (delano/otto#194)

--- a/lib/otto/privacy.rb
+++ b/lib/otto/privacy.rb
@@ -5,6 +5,7 @@
 require_relative 'privacy/core'
 require_relative 'privacy/config'
 require_relative 'privacy/ip_privacy'
+require_relative 'privacy/user_agent_privacy'
 require_relative 'privacy/geo_resolver'
 require_relative 'privacy/redacted_fingerprint'
 

--- a/lib/otto/privacy/redacted_fingerprint.rb
+++ b/lib/otto/privacy/redacted_fingerprint.rb
@@ -92,30 +92,14 @@ class Otto
 
       # Anonymize user agent string by removing version numbers and build identifiers
       #
-      # Removes specific version numbers (*.*.* pattern) and build identifiers
-      # (e.g., Build/MRA58N) to reduce fingerprinting granularity while maintaining
-      # browser/OS info.
+      # Delegates to the public {UserAgentPrivacy.anonymize} so there is a single
+      # source of truth for the reduction (removes version numbers and build
+      # identifiers, preserving browser/OS info) shared with downstream consumers.
       #
       # @param ua [String, nil] User agent string
       # @return [String, nil] Anonymized user agent or nil
       def anonymize_user_agent(ua)
-        return nil if ua.nil? || ua.empty?
-
-        # Remove build identifiers (e.g., Build/MRA58N, Build/MPJ24.139-64)
-        # This must run BEFORE version stripping to avoid partial matches.
-        # If we strip versions first, Build/MPJ24.139-64 becomes Build/MPJ*.*-64,
-        # and the regex won't match properly (asterisks not in [\w.-] class).
-        anonymized = ua.gsub(/Build\/[\w.-]+/, 'Build/*')
-
-        # Remove version patterns (*.*.*.*, *.*.*, *.*)
-        # Support both dot and underscore separators (e.g., 10.15.7 and 10_15_7)
-        anonymized = anonymized
-                     .gsub(/\d+[._]\d+[._]\d+[._]\d+/, '*.*.*.*')
-                     .gsub(/\d+[._]\d+[._]\d+/, '*.*.*')
-                     .gsub(/\d+[._]\d+/, '*.*')
-
-        # Truncate if too long (prevent DoS via huge UA strings)
-        anonymized.length > 500 ? anonymized[0..499] : anonymized
+        UserAgentPrivacy.anonymize(ua)
       end
 
       # Anonymize referer URL

--- a/lib/otto/privacy/user_agent_privacy.rb
+++ b/lib/otto/privacy/user_agent_privacy.rb
@@ -1,0 +1,64 @@
+# lib/otto/privacy/user_agent_privacy.rb
+#
+# frozen_string_literal: true
+
+class Otto
+  module Privacy
+    # User-Agent anonymization utilities.
+    #
+    # Reduces a User-Agent string to a lower-entropy form by stripping build
+    # identifiers and version numbers and truncating, so it can be logged or
+    # stored for analytics without a high-entropy fingerprint while preserving
+    # browser/OS family information. This is the User-Agent analogue of
+    # {IPPrivacy} for IP addresses, exposed as a public surface so downstream
+    # consumers can reduce a UA outside of the full RedactedFingerprint /
+    # middleware flow without re-implementing (and drifting from) these regexes.
+    #
+    # @example
+    #   UserAgentPrivacy.anonymize(
+    #     'Mozilla/5.0 (Windows NT 10.0) Chrome/119.0.0.0 Safari/537.36'
+    #   )
+    #   # => 'Mozilla/*.* (Windows NT *.*) Chrome/*.*.*.* Safari/*.*'
+    #
+    # @note Idempotent: re-anonymizing already-anonymized output is a no-op, so
+    #   a UA reduced at the edge and one reduced again downstream agree.
+    class UserAgentPrivacy
+      # Default cap on the returned string, guarding against a DoS via a huge
+      # User-Agent header. Matches the length RedactedFingerprint has always
+      # applied.
+      DEFAULT_MAX_LENGTH = 500
+
+      # Anonymize a User-Agent string.
+      #
+      # Removes build identifiers (e.g. +Build/MRA58N+) and version numbers
+      # (+*.*.*.*+, +*.*.*+, +*.*+; dot- or underscore-separated), then
+      # truncates to +max_length+. Browser/OS family text is preserved -- the
+      # point is a partial, not a full redaction.
+      #
+      # Build identifiers are stripped BEFORE versions: if versions went first,
+      # a token like +Build/MPJ24.139-64+ would become +Build/MPJ*.*-64+ and the
+      # build regex (which matches only +[\w.-]+) would no longer catch it.
+      #
+      # @param ua [String, nil] the raw User-Agent string.
+      # @param max_length [Integer] maximum length of the returned string.
+      # @return [String, nil] the anonymized UA, or nil for nil/empty input.
+      def self.anonymize(ua, max_length: DEFAULT_MAX_LENGTH)
+        return nil if ua.nil? || ua.empty?
+
+        # Remove build identifiers (e.g., Build/MRA58N, Build/MPJ24.139-64).
+        # Must run BEFORE version stripping (see method note).
+        anonymized = ua.gsub(%r{Build/[\w.-]+}, 'Build/*')
+
+        # Remove version patterns (*.*.*.*, *.*.*, *.*), longest first.
+        # Support both dot and underscore separators (e.g. 10.15.7 and 10_15_7).
+        anonymized = anonymized
+                     .gsub(/\d+[._]\d+[._]\d+[._]\d+/, '*.*.*.*')
+                     .gsub(/\d+[._]\d+[._]\d+/, '*.*.*')
+                     .gsub(/\d+[._]\d+/, '*.*')
+
+        # Truncate if too long (prevent DoS via huge UA strings).
+        anonymized.length > max_length ? anonymized[0...max_length] : anonymized
+      end
+    end
+  end
+end

--- a/spec/otto/user_agent_privacy_spec.rb
+++ b/spec/otto/user_agent_privacy_spec.rb
@@ -1,0 +1,86 @@
+# spec/otto/user_agent_privacy_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Otto::Privacy::UserAgentPrivacy do
+  describe '.anonymize' do
+    it 'strips a two-part version (dot-separated)' do
+      expect(described_class.anonymize('Safari/537.36')).to eq('Safari/*.*')
+    end
+
+    it 'strips three- and four-part versions, longest first' do
+      expect(described_class.anonymize('Chrome/119.0.0.0')).to eq('Chrome/*.*.*.*')
+      expect(described_class.anonymize('Chrome/57.0.2987')).to eq('Chrome/*.*.*')
+    end
+
+    it 'strips underscore-separated versions (e.g. macOS 10_15_7)' do
+      ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)'
+      expect(described_class.anonymize(ua)).to eq('Mozilla/*.* (Macintosh; Intel Mac OS X *.*.*)')
+    end
+
+    it 'strips build identifiers' do
+      ua = 'Mozilla/5.0 (Linux; Android 5.0; Nexus 5 Build/MRA58N) Chrome/141.0.0.0'
+      out = described_class.anonymize(ua)
+      expect(out).to include('Build/*')
+      expect(out).not_to include('MRA58N')
+    end
+
+    it 'strips build identifiers that contain their own version-like tokens' do
+      # Build/MPJ24.139-64 must be caught as a build id; this only works because
+      # build stripping runs BEFORE version stripping.
+      ua = 'Mozilla/5.0 (Linux; Android 6.0.1; Moto G (4) Build/MPJ24.139-64) Chrome/51.0.2704.81'
+      out = described_class.anonymize(ua)
+      expect(out).to include('Build/*')
+      expect(out).not_to include('MPJ24.139-64')
+      expect(out).not_to include('MPJ')
+    end
+
+    it 'preserves browser/OS family text (a partial, not a redaction)' do
+      ua  = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/119.0.0.0 Safari/537.36'
+      out = described_class.anonymize(ua)
+      expect(out).to include('Windows NT')
+      expect(out).to include('Chrome')
+      expect(out).to include('Safari')
+      expect(out).not_to include('119.0.0.0')
+    end
+
+    it 'is idempotent (re-anonymizing already-anonymized output is a no-op)' do
+      ua    = 'Mozilla/5.0 (Windows NT 10.0) Chrome/119.0.0.0 Safari/537.36'
+      once  = described_class.anonymize(ua)
+      twice = described_class.anonymize(once)
+      expect(twice).to eq(once)
+    end
+
+    it 'truncates to DEFAULT_MAX_LENGTH' do
+      long = "Agent/#{'x' * 1000}"
+      expect(described_class.anonymize(long).length).to eq(described_class::DEFAULT_MAX_LENGTH)
+    end
+
+    it 'honors a custom max_length' do
+      long = "Agent/#{'x' * 1000}"
+      expect(described_class.anonymize(long, max_length: 50).length).to eq(50)
+    end
+
+    it 'returns nil for nil or empty input' do
+      expect(described_class.anonymize(nil)).to be_nil
+      expect(described_class.anonymize('')).to be_nil
+    end
+  end
+
+  # The reason this surface exists: RedactedFingerprint must stay a thin
+  # delegator so there is one source of truth for UA reduction. Pin that the
+  # fingerprint's anonymized_ua equals the public method's output for the same
+  # UA, so the two can never drift.
+  describe 'RedactedFingerprint delegation' do
+    it 'produces byte-identical output to the public surface' do
+      ua     = 'Mozilla/5.0 (Linux; Android 9; Pixel 3 Build/PD1A.180720.030) Chrome/69.0.3497.100 Mobile Safari/537.36'
+      config = Otto::Privacy::Config.new(geo_enabled: false)
+      env    = { 'REMOTE_ADDR' => '203.0.113.42', 'HTTP_USER_AGENT' => ua }
+
+      fingerprint = Otto::Privacy::RedactedFingerprint.new(env, config)
+      expect(fingerprint.anonymized_ua).to eq(described_class.anonymize(ua))
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Extracts the User-Agent anonymization logic from `RedactedFingerprint` into a new public `UserAgentPrivacy` class, making it available as a standalone utility similar to `IPPrivacy`. This allows downstream consumers to anonymize User-Agent strings outside the full fingerprinting flow without duplicating or drifting from the core reduction logic.

## Key Changes
- **New public class**: `Otto::Privacy::UserAgentPrivacy` with a `.anonymize(ua, max_length:)` method that strips build identifiers and version numbers while preserving browser/OS family text
- **Idempotent design**: Re-anonymizing already-anonymized output is a no-op, ensuring consistency across edge and downstream processing
- **Refactored RedactedFingerprint**: `#anonymize_user_agent` now delegates to `UserAgentPrivacy.anonymize`, establishing a single source of truth for UA reduction
- **Comprehensive test coverage**: 86 lines of specs covering version stripping (dot and underscore-separated), build identifier removal, truncation, nil handling, and delegation consistency
- **Documentation**: Changelog entry and inline documentation explaining the public surface and its use cases

## Implementation Details
- Build identifiers are stripped **before** version patterns to prevent partial matches (e.g., `Build/MPJ24.139-64` must be caught as a build ID, not left with asterisks that would break the build regex)
- Supports both dot-separated (`10.15.7`) and underscore-separated (`10_15_7`) version formats
- Truncates to `DEFAULT_MAX_LENGTH` (500 chars) to prevent DoS via oversized User-Agent headers
- Includes a delegation test ensuring `RedactedFingerprint.anonymized_ua` and the public method produce byte-identical output

https://claude.ai/code/session_011S57TVKW6YZVvyiSEj8dsY