### PR TITLE
Fail fast on malformed security options in route definitions

### DIFF
--- a/changelog.d/20260709_100000_ops_malformed_routes_fail_open.rst
+++ b/changelog.d/20260709_100000_ops_malformed_routes_fail_open.rst
@@ -1,0 +1,10 @@
+Security
+--------
+
+- Route loading no longer fails open on malformed input (#191). A route line
+  with a missing handler and any unparseable option token now emit a warning
+  unconditionally (previously silent, or gated behind ``Otto.debug``). A
+  malformed security-gating option — a bare or empty ``auth``, ``role``, or
+  ``csrf`` token (e.g. ``csrf exempt`` instead of ``csrf=exempt``) — now
+  raises ``Otto::RouteDefinitionError`` at load so the app fails at boot
+  instead of quietly serving the route without its intended protection.

--- a/changelog.d/20260709_110000_ops_malformed_routes_review_followup.rst
+++ b/changelog.d/20260709_110000_ops_malformed_routes_review_followup.rst
@@ -1,0 +1,16 @@
+Security
+--------
+
+- Closed two gaps left by the #191 fail-fast fix (PR review follow-up).
+  Security-gating option tokens with mismatched case (e.g. ``Auth=session``,
+  ``CSRF=exempt``) previously slipped past the check and were stored as an
+  unrecognized option, silently disabling the gate; they now raise
+  ``Otto::RouteDefinitionError`` like any other malformed security option.
+  A token with an empty key (e.g. ``=foo``) previously stored an empty-symbol
+  option silently; it now emits the same "malformed route option ignored"
+  warning as other unparseable tokens.
+- MCP and TOOL route handler definitions (``MCP ...`` / ``TOOL ...`` route
+  lines) now apply the same fail-fast validation: a bare or malformed
+  ``auth``, ``role``, or ``csrf`` token in the handler definition raises
+  ``Otto::RouteDefinitionError`` instead of silently registering the route
+  without its intended protection.

--- a/lib/otto/core/router.rb
+++ b/lib/otto/core/router.rb
@@ -17,7 +17,13 @@ class Otto
           # Enhanced parsing: split only on first two whitespace boundaries
           # This preserves parameters in the definition part
           parts = entry.split(/\s+/, 3)
-          next if parts.size < 3 # Skip malformed entries
+          if parts.size < 3
+            # A missing/blank handler must not make the route vanish silently
+            # (issue #191): warn unconditionally, not gated behind Otto.debug.
+            Otto.structured_log(:warn, 'Malformed route line skipped',
+              { line: entry, expected: 'VERB /path Handler [options]' })
+            next
+          end
 
           verb = parts[0]
           path = parts[1]
@@ -49,6 +55,11 @@ class Otto
           @routes[route.verb] << route
           @routes_literal[route.verb]           ||= {}
           @routes_literal[route.verb][path_clean] = route
+        rescue Otto::RouteDefinitionError
+          # A malformed security-gating option (auth/role/csrf) fails fast at
+          # boot rather than serving the route without its intended protection
+          # (issue #191). Deliberately not swallowed like other per-line errors.
+          raise
         rescue StandardError => e
           Otto.structured_log(:error, 'Route load failed',
             {

--- a/lib/otto/core/router.rb
+++ b/lib/otto/core/router.rb
@@ -230,6 +230,10 @@ class Otto
         route_info = Otto::MCP::RouteParser.parse_mcp_route(verb, path, definition)
         @mcp_server.register_mcp_route(route_info)
         Otto.logger.debug "[MCP] Registered resource route: #{definition}" if Otto.debug
+      rescue Otto::RouteDefinitionError
+        # Same fail-fast contract as the normal route loader: a malformed
+        # security-gating option must abort boot, not just log-and-drop.
+        raise
       rescue StandardError => e
         Otto.logger.error "[MCP] Failed to parse MCP route: #{definition} - #{e.message}"
       end
@@ -240,6 +244,8 @@ class Otto
         route_info = Otto::MCP::RouteParser.parse_tool_route(verb, path, definition)
         @mcp_server.register_mcp_route(route_info)
         Otto.logger.debug "[MCP] Registered tool route: #{definition}" if Otto.debug
+      rescue Otto::RouteDefinitionError
+        raise
       rescue StandardError => e
         Otto.logger.error "[MCP] Failed to parse TOOL route: #{definition} - #{e.message}"
       end

--- a/lib/otto/errors.rb
+++ b/lib/otto/errors.rb
@@ -11,6 +11,13 @@
 #   otto.register_error_handler(MyApp::ResourceNotFound, status: 404, log_level: :info)
 #
 class Otto
+  # Raised at route-load time when a route definition is malformed in a way
+  # that must not be silently ignored — e.g. a security-gating option
+  # (auth/role/csrf) without a value. Unlike generic per-line load errors,
+  # this error propagates out of Otto#load so the app fails at boot instead
+  # of serving the route with default (less safe) behavior.
+  class RouteDefinitionError < StandardError; end
+
   # Base class for all Otto HTTP errors
   #
   # Provides default_status and default_log_level class methods that

--- a/lib/otto/mcp/route_parser.rb
+++ b/lib/otto/mcp/route_parser.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require_relative '../route_definition'
+
 class Otto
   module MCP
     # Parser for MCP route definitions and resource URIs
@@ -64,10 +66,19 @@ class Otto
         parts   = handler_definition.split(/\s+/)
         options = {}
 
-        # First part is the handler class.method
-        parts[1..-1]&.each do |part|
-          key, value = part.split('=', 2)
-          options[key.to_sym] = value if key && value
+        # First part is the handler class.method. Delegate token parsing to
+        # Otto::RouteDefinition so a bare/empty auth|role|csrf token here
+        # fails fast exactly like it does for normal routes (issue #191
+        # MCP/TOOL follow-up), instead of silently registering the route
+        # without its intended protection.
+        parts[1..]&.each do |part|
+          pair = Otto::RouteDefinition.parse_option_token(part, "handler #{handler_definition.inspect}")
+          if pair
+            options[pair[0]] = pair[1]
+          else
+            Otto.structured_log(:warn, 'Malformed MCP/tool route option ignored',
+              { option: part, handler: handler_definition })
+          end
         end
 
         options

--- a/lib/otto/route_definition.rb
+++ b/lib/otto/route_definition.rb
@@ -120,6 +120,32 @@ class Otto
       option(:response, 'default')
     end
 
+    # Parse a single whitespace-delimited `key=value` option token, applying
+    # the security-gating fail-fast rule shared by normal routes and the MCP
+    # RouteParser (issue #191 and its MCP/TOOL follow-up).
+    # @param part [String] a single option token, e.g. "auth=session"
+    # @param context [String] human-readable source description for the
+    #   raised error message, e.g. "route definition \"GET /admin ...\""
+    # @return [Array(Symbol, String), nil] the [key, value] pair to store,
+    #   or nil if the token is malformed and should only be warned about
+    # @raise [Otto::RouteDefinitionError] if a security-gating option
+    #   (auth/role/csrf) is malformed
+    def self.parse_option_token(part, context)
+      key, value = part.split('=', 2)
+      normalized_key = key&.downcase
+
+      if SECURITY_GATING_OPTIONS.include?(normalized_key)
+        if key != normalized_key || value.nil? || value.empty?
+          raise Otto::RouteDefinitionError,
+                "Malformed security option #{part.inspect} in #{context}: " \
+                "expected #{normalized_key}=value"
+        end
+        [key.to_sym, value]
+      elsif key && !key.empty? && value
+        [key.to_sym, value]
+      end
+    end
+
     # Check if CSRF is exempt for this route
     # @return [Boolean]
     def csrf_exempt?
@@ -185,13 +211,9 @@ class Otto
       options = {}
 
       parts.each do |part|
-        key, value = part.split('=', 2)
-        if SECURITY_GATING_OPTIONS.include?(key) && (value.nil? || value.empty?)
-          raise Otto::RouteDefinitionError,
-                "Malformed security option #{part.inspect} in route definition " \
-                "#{definition.inspect}: expected #{key}=value"
-        elsif key && value
-          options[key.to_sym] = value
+        pair = self.class.parse_option_token(part, "route definition #{definition.inspect}")
+        if pair
+          options[pair[0]] = pair[1]
         else
           Otto.structured_log(:warn, 'Malformed route option ignored',
             { option: part, definition: definition })

--- a/lib/otto/route_definition.rb
+++ b/lib/otto/route_definition.rb
@@ -2,10 +2,18 @@
 #
 # frozen_string_literal: true
 
+require_relative 'errors'
+
 class Otto
   # Immutable data class representing a complete route definition
   # This encapsulates all aspects of a route: path, target, and options
   class RouteDefinition
+    # Options that gate access to a route. A malformed token for one of these
+    # (e.g. `csrf` instead of `csrf=exempt`, or a bare `auth`) must not fall
+    # back to the default behavior silently — the route would serve without
+    # its intended protection (issue #191).
+    SECURITY_GATING_OPTIONS = %w[auth role csrf].freeze
+
     # @return [String] The HTTP verb (GET, POST, etc.)
     attr_reader :verb
 
@@ -168,6 +176,9 @@ class Otto
     # Parse route definition into target and options
     # @param definition [String] The route definition
     # @return [Hash] Hash with :target and :options keys
+    # @raise [Otto::RouteDefinitionError] if a security-gating option token
+    #   (auth/role/csrf) has no value — failing fast instead of serving the
+    #   route with default (less safe) behavior
     def parse_definition(definition)
       parts   = definition.split(/\s+/)
       target  = parts.shift
@@ -175,11 +186,15 @@ class Otto
 
       parts.each do |part|
         key, value = part.split('=', 2)
-        if key && value
+        if SECURITY_GATING_OPTIONS.include?(key) && (value.nil? || value.empty?)
+          raise Otto::RouteDefinitionError,
+                "Malformed security option #{part.inspect} in route definition " \
+                "#{definition.inspect}: expected #{key}=value"
+        elsif key && value
           options[key.to_sym] = value
-        elsif Otto.debug
-          # Malformed parameter, log warning if debug enabled
-          Otto.logger.warn "Ignoring malformed route parameter: #{part}"
+        else
+          Otto.structured_log(:warn, 'Malformed route option ignored',
+            { option: part, definition: definition })
         end
       end
 

--- a/spec/otto/route_loading_diagnostics_spec.rb
+++ b/spec/otto/route_loading_diagnostics_spec.rb
@@ -1,0 +1,95 @@
+# spec/otto/route_loading_diagnostics_spec.rb
+#
+# frozen_string_literal: true
+
+# Issue #191: malformed route lines and unparseable route options must not
+# fail open silently. Skipped lines and dropped option tokens warn
+# unconditionally; malformed security-gating options (auth/role/csrf) fail
+# fast at load.
+require 'spec_helper'
+
+RSpec.describe 'Route loading diagnostics (issue #191)' do
+  describe 'malformed route lines' do
+    it 'warns when a line is missing its handler' do
+      routes_file = create_test_routes_file('test_routes_no_handler.txt', ['GET /path'])
+
+      allow(Otto).to receive(:structured_log)
+      expect(Otto).to receive(:structured_log)
+        .with(:warn, 'Malformed route line skipped', hash_including(line: 'GET /path'))
+
+      Otto.new(routes_file)
+    end
+
+    it 'still skips the malformed line and loads the rest' do
+      routes_file = create_test_routes_file('test_routes_partial.txt', [
+                                              'GET /broken',
+                                              'GET / TestApp.index',
+                                            ])
+
+      otto = Otto.new(routes_file)
+      expect(otto.routes[:GET].size).to eq(1)
+      expect(otto.routes[:GET].first.path).to eq('/')
+    end
+  end
+
+  describe 'unparseable option tokens' do
+    it 'warns (without Otto.debug) when a non-security option token has no value' do
+      allow(Otto).to receive(:structured_log)
+      expect(Otto).to receive(:structured_log)
+        .with(:warn, 'Malformed route option ignored',
+          hash_including(option: 'response', definition: 'TestApp.index response json'))
+      expect(Otto).to receive(:structured_log)
+        .with(:warn, 'Malformed route option ignored',
+          hash_including(option: 'json', definition: 'TestApp.index response json'))
+
+      route = Otto::Route.new('GET', '/test', 'TestApp.index response json')
+      expect(route.route_options).to eq({})
+    end
+
+    it 'still stores well-formed options alongside a dropped token' do
+      allow(Otto).to receive(:structured_log)
+      route = Otto::Route.new('GET', '/test', 'TestApp.index badparam auth=authenticated')
+      expect(route.route_options).to eq({ auth: 'authenticated' })
+    end
+
+    it 'preserves empty values for non-security options' do
+      route = Otto::Route.new('GET', '/test', 'TestApp.index empty=')
+      expect(route.route_options).to eq({ empty: '' })
+    end
+  end
+
+  describe 'security-gating options fail fast' do
+    %w[auth role csrf].each do |option|
+      it "raises Otto::RouteDefinitionError for a bare `#{option}` token" do
+        expect do
+          Otto::Route.new('GET', '/test', "TestApp.index #{option}")
+        end.to raise_error(Otto::RouteDefinitionError, /#{option}=value/)
+      end
+
+      it "raises Otto::RouteDefinitionError for an empty `#{option}=` value" do
+        expect do
+          Otto::Route.new('GET', '/test', "TestApp.index #{option}=")
+        end.to raise_error(Otto::RouteDefinitionError, /#{option}=value/)
+      end
+    end
+
+    it 'raises for `csrf exempt` (missing =) instead of serving with CSRF enabled silently' do
+      expect do
+        Otto::Route.new('GET', '/test', 'TestApp.index csrf exempt')
+      end.to raise_error(Otto::RouteDefinitionError)
+    end
+
+    it 'propagates out of Otto#load so boot fails instead of dropping the route' do
+      routes_file = create_test_routes_file('test_routes_bad_auth.txt', [
+                                              'GET /admin TestApp.index auth',
+                                            ])
+
+      expect { Otto.new(routes_file) }.to raise_error(Otto::RouteDefinitionError)
+    end
+
+    it 'accepts well-formed security options' do
+      route = Otto::Route.new('GET', '/test', 'TestApp.index auth=session csrf=exempt role=admin')
+      expect(route.route_options).to eq({ auth: 'session', csrf: 'exempt', role: 'admin' })
+    end
+  end
+end

--- a/spec/otto/route_loading_diagnostics_spec.rb
+++ b/spec/otto/route_loading_diagnostics_spec.rb
@@ -9,6 +9,16 @@
 require 'spec_helper'
 
 RSpec.describe 'Route loading diagnostics (issue #191)' do
+  around do |example|
+    # These specs assert on warnings that must fire "without Otto.debug"
+    # (i.e. always). Force the flag deterministically instead of relying on
+    # whatever OTTO_DEBUG happened to leave it as, and restore it after.
+    original_debug = Otto.debug
+    Otto.debug      = false
+    example.run
+    Otto.debug = original_debug
+  end
+
   describe 'malformed route lines' do
     it 'warns when a line is missing its handler' do
       routes_file = create_test_routes_file('test_routes_no_handler.txt', ['GET /path'])
@@ -56,6 +66,16 @@ RSpec.describe 'Route loading diagnostics (issue #191)' do
       route = Otto::Route.new('GET', '/test', 'TestApp.index empty=')
       expect(route.route_options).to eq({ empty: '' })
     end
+
+    it 'warns (does not silently store) a token with an empty key' do
+      allow(Otto).to receive(:structured_log)
+      expect(Otto).to receive(:structured_log)
+        .with(:warn, 'Malformed route option ignored',
+          hash_including(option: '=foo', definition: 'TestApp.index =foo'))
+
+      route = Otto::Route.new('GET', '/test', 'TestApp.index =foo')
+      expect(route.route_options).to eq({})
+    end
   end
 
   describe 'security-gating options fail fast' do
@@ -90,6 +110,43 @@ RSpec.describe 'Route loading diagnostics (issue #191)' do
     it 'accepts well-formed security options' do
       route = Otto::Route.new('GET', '/test', 'TestApp.index auth=session csrf=exempt role=admin')
       expect(route.route_options).to eq({ auth: 'session', csrf: 'exempt', role: 'admin' })
+    end
+
+    %w[Auth AUTH Csrf CSRF Role ROLE].each do |key|
+      it "raises Otto::RouteDefinitionError for wrong-case `#{key}=value` " \
+         'instead of silently storing it as an unrecognized option' do
+        expect do
+          Otto::Route.new('GET', '/test', "TestApp.index #{key}=session")
+        end.to raise_error(Otto::RouteDefinitionError)
+      end
+    end
+  end
+
+  describe 'MCP and TOOL route handler options fail fast (security parity with normal routes)' do
+    let(:mcp_app) { Otto.new }
+
+    before do
+      mcp_app.instance_variable_set(:@mcp_server, Otto::MCP::Server.new(mcp_app))
+      allow(Otto).to receive(:structured_log)
+    end
+
+    it 'raises Otto::RouteDefinitionError for a bare auth token in an MCP handler definition' do
+      expect do
+        mcp_app.send(:handle_mcp_route, 'GET', '/resource', 'MCP files/test TestHandler.handle auth')
+      end.to raise_error(Otto::RouteDefinitionError)
+    end
+
+    it 'raises Otto::RouteDefinitionError for a bare csrf token in a TOOL handler definition' do
+      expect do
+        mcp_app.send(:handle_tool_route, 'POST', '/tool', 'TOOL search_files SearchTool.execute csrf')
+      end.to raise_error(Otto::RouteDefinitionError)
+    end
+
+    it 'accepts well-formed security options on an MCP handler definition' do
+      expect(mcp_app.instance_variable_get(:@mcp_server)).to receive(:register_mcp_route)
+        .with(hash_including(options: { auth: 'session' }))
+
+      mcp_app.send(:handle_mcp_route, 'GET', '/resource', 'MCP files/test TestHandler.handle auth=session')
     end
   end
 end


### PR DESCRIPTION
## Summary

This PR addresses issue #191 by improving route loading diagnostics to prevent silent failures when routes are malformed, particularly around security-gating options. Routes with missing handlers or unparseable options now emit warnings unconditionally, and malformed security options (auth/role/csrf) now raise an error at boot time instead of serving with default (less safe) behavior.

## Key Changes

- **New `RouteDefinitionError` exception** (`lib/otto/errors.rb`): A dedicated error class for route definition problems that must fail fast at boot time, distinct from transient per-line load errors.

- **Security-gating option validation** (`lib/otto/route_definition.rb`):
  - Added `SECURITY_GATING_OPTIONS` constant identifying auth, role, and csrf as options that gate access
  - Modified `parse_definition` to raise `RouteDefinitionError` if any security option is bare (e.g., `auth`) or has an empty value (e.g., `auth=`)
  - Changed non-security option handling to always warn via `structured_log` instead of only when `Otto.debug` is enabled

- **Router malformed line handling** (`lib/otto/core/router.rb`):
  - Routes with missing handlers now emit an unconditional warning instead of silently skipping
  - Added explicit error handling to allow `RouteDefinitionError` to propagate while catching other per-line errors
  - Improved error context in structured logs

- **Comprehensive test coverage** (`spec/otto/route_loading_diagnostics_spec.rb`):
  - Tests for malformed route lines (missing handler)
  - Tests for unparseable option tokens (non-security options)
  - Tests for security-gating option validation (bare tokens, empty values, well-formed options)
  - Tests confirming errors propagate through Otto initialization

## Notable Implementation Details

- Security-gating options fail fast because serving a route without its intended protection (auth, role, or CSRF) is a security risk that should not be silently ignored
- Non-security options that are malformed are warned about but don't prevent the route from loading, allowing partial route definitions to still function
- All warnings now use `Otto.structured_log` for consistent, unconditional logging rather than being gated behind `Otto.debug`

https://claude.ai/code/session_01HK9SxMxmuu6MpA3aURoPo8