### PR TITLE
fix(uri): stop duplicate targets corrupting reverse URI lookup

### DIFF
--- a/changelog.d/20260709_101500_ops_uri_duplicate_targets.rst
+++ b/changelog.d/20260709_101500_ops_uri_duplicate_targets.rst
@@ -1,0 +1,14 @@
+Fixed
+-----
+
+- Reverse URI generation (``Otto#uri``) no longer corrupts when the same
+  handler/target is mounted at multiple paths (#190). Previously
+  ``@route_definitions`` was keyed only by the definition string, so
+  duplicate targets overwrote each other and ``uri()`` returned whichever
+  path loaded last. All routes per definition are now kept (exposed via
+  ``Otto#routes_by_definition``) and ``uri()`` picks the route whose path
+  placeholders match the params given — e.g. with ``GET /users/:id
+  Account#show`` and ``GET /me Account#show``, ``uri('Account#show', id: 5)``
+  returns ``/users/5`` and ``uri('Account#show')`` returns ``/me``.
+  ``Otto#route_definitions`` now deterministically keeps the first-loaded
+  route per definition, and loading a duplicate definition logs a warning.

--- a/changelog.d/20260709_101500_ops_uri_duplicate_targets.rst
+++ b/changelog.d/20260709_101500_ops_uri_duplicate_targets.rst
@@ -11,4 +11,5 @@ Fixed
   Account#show`` and ``GET /me Account#show``, ``uri('Account#show', id: 5)``
   returns ``/users/5`` and ``uri('Account#show')`` returns ``/me``.
   ``Otto#route_definitions`` now deterministically keeps the first-loaded
-  route per definition, and loading a duplicate definition logs a warning.
+  route per definition, and loading a duplicate definition logs at debug
+  level.

--- a/changelog.d/20260709_111500_ops_uri_duplicate_targets_review_followup.rst
+++ b/changelog.d/20260709_111500_ops_uri_duplicate_targets_review_followup.rst
@@ -1,0 +1,13 @@
+Fixed
+-----
+
+- Addressed PR review follow-up on the #190 duplicate-target fix. Loading a
+  duplicate route definition now logs at ``:debug`` instead of ``:warn`` --
+  mounting one handler at several paths is a fully supported pattern, so
+  warning on every boot made valid configurations (e.g. ``/users/:id`` and
+  ``/me`` aliases) look unhealthy.
+- ``Otto#uri``'s candidate selection no longer excludes a wildcard (``*``)
+  route from the "satisfied" pool just because its synthetic ``splat`` key
+  isn't among the caller's params -- ``splat`` isn't something callers ever
+  pass by name, so requiring it always disqualified wildcard routes sharing
+  a definition with a named-param route.

--- a/lib/otto.rb
+++ b/lib/otto.rb
@@ -75,7 +75,8 @@ class Otto
            end
   @logger = Logger.new($stdout, Logger::INFO)
 
-  attr_reader :routes, :routes_literal, :routes_static, :route_definitions, :option,
+  attr_reader :routes, :routes_literal, :routes_static, :route_definitions,
+              :routes_by_definition, :option,
               :static_route, :security_config, :locale_config, :auth_config,
               :route_handler_factory, :mcp_server, :caddy_tls_server, :security, :middleware,
               :error_handlers, :request_class, :response_class
@@ -174,6 +175,11 @@ class Otto
     @routes            = { GET: [] }
     @routes_literal    = { GET: {} }
     @route_definitions = {}
+    # All routes per definition string, in load order. A definition string is
+    # not unique — the same handler can be mounted at several verb/path pairs —
+    # so reverse lookups (Otto#uri) consult this index instead of the
+    # single-route @route_definitions entry (issue #190).
+    @routes_by_definition = {}
     @security_config   = Otto::Security::Config.new
     @middleware        = Otto::Core::MiddlewareStack.new
     # Initialize @auth_config first so it can be shared with the configurator

--- a/lib/otto/core/configuration.rb
+++ b/lib/otto/core/configuration.rb
@@ -284,6 +284,7 @@ class Otto
         deep_freeze_value(@routes_literal) if @routes_literal
         deep_freeze_value(@routes_static) if @routes_static
         deep_freeze_value(@route_definitions) if @route_definitions
+        deep_freeze_value(@routes_by_definition) if @routes_by_definition
 
         @configuration_frozen = true
 

--- a/lib/otto/core/router.rb
+++ b/lib/otto/core/router.rb
@@ -32,10 +32,27 @@ class Otto
             next
           end
 
-          route                                   = Otto::Route.new verb, path, definition
-          route.otto                              = self
-          path_clean                              = path.gsub(%r{/$}, '')
-          @route_definitions[route.definition]    = route
+          route      = Otto::Route.new verb, path, definition
+          route.otto = self
+          path_clean = path.gsub(%r{/$}, '')
+
+          # A definition string is not unique (the same handler can be mounted
+          # at several verb/path pairs), so @route_definitions keeps the
+          # first-loaded route per definition — deterministic, instead of the
+          # last-loaded route silently winning — and @routes_by_definition
+          # keeps them all for uri() disambiguation (issue #190).
+          if (existing = @route_definitions[route.definition])
+            Otto.structured_log(:warn, 'Duplicate route definition',
+              {
+                definition: route.definition,
+                kept: "#{existing.verb} #{existing.path}",
+                also: "#{route.verb} #{route.path}",
+                hint: 'uri() picks the route whose path params match the given params',
+              })
+          else
+            @route_definitions[route.definition] = route
+          end
+          (@routes_by_definition[route.definition] ||= []) << route
           if Otto.debug
             Otto.structured_log(:debug, 'Route loaded',
               {

--- a/lib/otto/core/router.rb
+++ b/lib/otto/core/router.rb
@@ -42,7 +42,12 @@ class Otto
           # last-loaded route silently winning — and @routes_by_definition
           # keeps them all for uri() disambiguation (issue #190).
           if (existing = @route_definitions[route.definition])
-            Otto.structured_log(:warn, 'Duplicate route definition',
+            # Mounting one handler at several paths is a fully supported
+            # pattern (issue #190) — uri() disambiguates by params, so this
+            # is informational, not a problem. Debug-gated like other
+            # routing diagnostics rather than warning on every boot for
+            # valid configs (e.g. `/users/:id` and `/me` aliases).
+            Otto.structured_log(:debug, 'Duplicate route definition',
               {
                 definition: route.definition,
                 kept: "#{existing.verb} #{existing.path}",

--- a/lib/otto/core/uri_generator.rb
+++ b/lib/otto/core/uri_generator.rb
@@ -14,8 +14,7 @@ class Otto
       #     Otto.default.path 'YourClass.somemethod'  #=> /some/path
       #
       def uri(route_definition, params = {})
-        # raise RuntimeError, "Not working"
-        route = @route_definitions[route_definition]
+        route = select_uri_route(route_definition, params)
         return if route.nil?
 
         local_params = params.clone
@@ -38,6 +37,33 @@ class Otto
           uri.query = query_string
         end
         uri.to_s
+      end
+
+      private
+
+      # Pick which route a reverse lookup means when one definition string is
+      # mounted at several verb/path pairs (issue #190). Routes whose path
+      # placeholders are all present in +params+ are preferred; among those,
+      # the route consuming the most params wins. Ties keep load order, so a
+      # single-route definition behaves exactly as before.
+      #
+      # e.g. with `GET /users/:id Account#show` and `GET /me Account#show`:
+      #   uri('Account#show', id: 5) #=> /users/5
+      #   uri('Account#show')        #=> /me
+      def select_uri_route(route_definition, params)
+        candidates = routes_for_definition(route_definition)
+        # @route_definitions fallback covers hand-assembled instances whose
+        # routes never went through Otto#load.
+        return candidates.first || @route_definitions[route_definition] if candidates.size <= 1
+
+        param_keys = params.keys.map(&:to_s)
+        satisfied  = candidates.select { |route| (route.keys - param_keys).empty? }
+        pool       = satisfied.empty? ? candidates : satisfied
+        pool.max_by { |route| (route.keys & param_keys).size }
+      end
+
+      def routes_for_definition(route_definition)
+        (@routes_by_definition && @routes_by_definition[route_definition]) || []
       end
     end
   end

--- a/lib/otto/core/uri_generator.rb
+++ b/lib/otto/core/uri_generator.rb
@@ -57,13 +57,21 @@ class Otto
         return candidates.first || @route_definitions[route_definition] if candidates.size <= 1
 
         param_keys = params.keys.map(&:to_s)
-        satisfied  = candidates.select { |route| (route.keys - param_keys).empty? }
+        satisfied  = candidates.select { |route| (required_keys(route) - param_keys).empty? }
         pool       = satisfied.empty? ? candidates : satisfied
         pool.max_by { |route| (route.keys & param_keys).size }
       end
 
       def routes_for_definition(route_definition)
         (@routes_by_definition && @routes_by_definition[route_definition]) || []
+      end
+
+      # `splat` is a positional catch-all captured from a `*` in the path,
+      # not a named parameter a caller would ever pass to uri(). Requiring
+      # it before a wildcard route counts as "satisfied" would exclude that
+      # route from selection unconditionally (issue #190 review follow-up).
+      def required_keys(route)
+        route.keys - ['splat']
       end
     end
   end

--- a/spec/otto/uri_duplicate_targets_spec.rb
+++ b/spec/otto/uri_duplicate_targets_spec.rb
@@ -1,0 +1,88 @@
+# spec/otto/uri_duplicate_targets_spec.rb
+#
+# frozen_string_literal: true
+
+# Issue #190: one definition string mounted at several verb/path pairs used
+# to overwrite the single @route_definitions entry, so uri() returned
+# whichever path loaded last. Reverse lookups now consult all routes per
+# definition and pick by the params given.
+require 'spec_helper'
+
+RSpec.describe 'Otto#uri with duplicate targets (issue #190)' do
+  subject(:otto) { Otto.new(routes_file) }
+
+  let(:duplicate_target_routes) do
+    [
+      'GET /users/:id TestApp.show',
+      'GET /me TestApp.show',
+      'GET / TestApp.index',
+    ]
+  end
+
+  let(:routes_file) { create_test_routes_file('test_routes_dup.txt', duplicate_target_routes) }
+
+  describe 'reverse URI generation' do
+    it 'picks the parameterized path when its params are given' do
+      expect(otto.uri('TestApp.show', id: '123')).to eq('/users/123')
+    end
+
+    it 'picks the parameterless path when no params are given' do
+      expect(otto.uri('TestApp.show')).to eq('/me')
+    end
+
+    it 'is independent of load order' do
+      reversed_file = create_test_routes_file('test_routes_dup_rev.txt', [
+                                                'GET /me TestApp.show',
+                                                'GET /users/:id TestApp.show',
+                                              ])
+      reversed = Otto.new(reversed_file)
+
+      expect(reversed.uri('TestApp.show', id: '123')).to eq('/users/123')
+      expect(reversed.uri('TestApp.show')).to eq('/me')
+    end
+
+    it 'routes extra params to the query string of the selected path' do
+      expect(otto.uri('TestApp.show', id: '123', page: '2')).to eq('/users/123?page=2')
+    end
+
+    it 'still generates URIs for unique definitions' do
+      expect(otto.uri('TestApp.index')).to eq('/')
+    end
+
+    it 'still returns nil for unknown definitions' do
+      expect(otto.uri('NonExistent.method')).to be_nil
+    end
+  end
+
+  describe 'load-time diagnostics' do
+    it 'warns when a definition string is loaded more than once' do
+      allow(Otto).to receive(:structured_log)
+      expect(Otto).to receive(:structured_log)
+        .with(:warn, 'Duplicate route definition',
+          hash_including(definition: 'TestApp.show', kept: 'GET /users/:id', also: 'GET /me'))
+
+      Otto.new(routes_file)
+    end
+  end
+
+  describe 'route_definitions determinism' do
+    it 'keeps the first-loaded route per definition' do
+      expect(otto.route_definitions['TestApp.show'].path).to eq('/users/:id')
+    end
+
+    it 'exposes every route per definition via routes_by_definition' do
+      paths = otto.routes_by_definition['TestApp.show'].map(&:path)
+      expect(paths).to eq(['/users/:id', '/me'])
+    end
+  end
+
+  describe 'dispatch' do
+    it 'still serves both paths' do
+      env_me    = mock_rack_env(method: 'GET', path: '/me')
+      env_users = mock_rack_env(method: 'GET', path: '/users/42')
+
+      expect(otto.call(env_me)[0]).to eq(200)
+      expect(otto.call(env_users)[0]).to eq(200)
+    end
+  end
+end

--- a/spec/otto/uri_duplicate_targets_spec.rb
+++ b/spec/otto/uri_duplicate_targets_spec.rb
@@ -55,10 +55,13 @@ RSpec.describe 'Otto#uri with duplicate targets (issue #190)' do
   end
 
   describe 'load-time diagnostics' do
-    it 'warns when a definition string is loaded more than once' do
+    it 'logs (at debug level) when a definition string is loaded more than once' do
+      # Mounting one handler at several paths is a fully supported pattern,
+      # not a problem — debug-gated so valid configs (like this one) don't
+      # warn on every boot.
       allow(Otto).to receive(:structured_log)
       expect(Otto).to receive(:structured_log)
-        .with(:warn, 'Duplicate route definition',
+        .with(:debug, 'Duplicate route definition',
           hash_including(definition: 'TestApp.show', kept: 'GET /users/:id', also: 'GET /me'))
 
       Otto.new(routes_file)
@@ -83,6 +86,44 @@ RSpec.describe 'Otto#uri with duplicate targets (issue #190)' do
 
       expect(otto.call(env_me)[0]).to eq(200)
       expect(otto.call(env_users)[0]).to eq(200)
+    end
+  end
+
+  describe 'three-way tie-breaking (review follow-up)' do
+    let(:tied_routes) do
+      [
+        'GET /a/:id TestApp.show',
+        'GET /b/:id TestApp.show',
+        'GET /c/:id TestApp.show',
+      ]
+    end
+    let(:routes_file) { create_test_routes_file('test_routes_tied.txt', tied_routes) }
+
+    it 'keeps first-loaded-wins when multiple candidates consume the same number of params' do
+      # Enumerable#max_by returns the first element among ties, so this
+      # already matches the "ties keep load order" contract documented on
+      # select_uri_route -- this spec locks that behavior in explicitly.
+      expect(otto.uri('TestApp.show', id: '1')).to eq('/a/1')
+    end
+  end
+
+  describe 'wildcard (splat) routes sharing a definition (review follow-up)' do
+    let(:wildcard_routes) do
+      [
+        'GET /files/*   TestApp.show',
+        'GET /files/:id TestApp.show',
+      ]
+    end
+    let(:routes_file) { create_test_routes_file('test_routes_wildcard.txt', wildcard_routes) }
+
+    it 'is still selectable when no candidate has its named params satisfied' do
+      # `splat` is not a param callers would pass, so the wildcard route
+      # must not be permanently excluded from the "satisfied" pool.
+      expect(otto.uri('TestApp.show')).to eq('/files/*')
+    end
+
+    it 'prefers the route whose named param is actually satisfied' do
+      expect(otto.uri('TestApp.show', id: '42')).to eq('/files/42')
     end
   end
 end


### PR DESCRIPTION
## Summary

Fixes #190. `@route_definitions` was keyed only by the definition string, so mounting the same handler at several verb/path pairs overwrote the entry and `uri()` returned whichever path loaded last.

## Changes

- **New `@routes_by_definition` index** keeps every route per definition string in load order, exposed via `Otto#routes_by_definition` and deep-frozen with the other route structures.
- **`uri()` disambiguates by params**: routes whose path placeholders are all satisfied by the given params are preferred, and among those the route consuming the most params wins; ties keep load order. With `GET /users/:id Account#show` and `GET /me Account#show`:
  - `uri('Account#show', id: 5)` → `/users/5`
  - `uri('Account#show')` → `/me`
  - …independent of load order.
- **`route_definitions` stays a `String → Route` hash** (downstream code destructures its entries and calls `route.klass`, so the value shape is public API). It now deterministically keeps the *first*-loaded route per definition instead of the last silently winning, and loading a duplicate definition logs a warning.

Dispatch is unaffected — it never used `@route_definitions`.

## Testing

- 10 new specs in `spec/otto/uri_duplicate_targets_spec.rb` covering param-based selection, load-order independence, the duplicate-definition warning, first-loaded determinism, and that both duplicate paths still dispatch.
- Full suite: 1748 examples, 0 failures. No new rubocop offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HK9SxMxmuu6MpA3aURoPo8

---
_Generated by [Claude Code](https://claude.ai/code/session_01HK9SxMxmuu6MpA3aURoPo8)_