### PR TITLE
fix(route): stop double request/response setup when handler factory present

### DIFF
--- a/changelog.d/20260709_103000_ops_route_call_single_setup.rst
+++ b/changelog.d/20260709_103000_ops_route_call_single_setup.rst
@@ -1,0 +1,12 @@
+Fixed
+-----
+
+- ``Route#call`` no longer builds and decorates a request/response pair that
+  is immediately discarded when the route handler factory is present (#189).
+  The handler (``BaseHandler#setup_request_response``) now owns all
+  request/response construction and setup — param merging, indifferent
+  access, security headers, CSRF/validation helpers each run exactly once
+  per dispatch instead of twice on different objects. ``Route#call`` only
+  sets the env keys that must be visible before the handler runs
+  (``otto.security_config``, ``otto.route_definition``,
+  ``otto.route_options``). The legacy no-factory path is unchanged.

--- a/changelog.d/20260709_112000_ops_route_call_single_setup_review_followup.rst
+++ b/changelog.d/20260709_112000_ops_route_call_single_setup_review_followup.rst
@@ -1,0 +1,11 @@
+Fixed
+-----
+
+- Addressed PR review follow-up on the #189 single-setup fix. The legacy
+  no-factory fallback path in ``Route#call`` now builds the request/response
+  pair *before* populating the ``otto.security_config`` /
+  ``otto.route_definition`` / ``otto.route_options`` env keys, restoring the
+  exact ordering it always had. A prior revision set those env keys first
+  regardless of which path ran, which meant a custom
+  ``request_class``/``response_class#initialize`` that reads env would see
+  different state on the legacy path than it did before #189.

--- a/lib/otto/route.rb
+++ b/lib/otto/route.rb
@@ -110,29 +110,38 @@ class Otto
     def call(env, extra_params = {})
       extra_params ||= {}
 
-      # Make security config available to response helpers
-      env['otto.security_config'] = otto.security_config if otto.respond_to?(:security_config) && otto.security_config
-
-      # Make route definition and options available to middleware and handlers.
-      # Set before delegating so wrappers that run ahead of the handler's own
-      # setup (RouteAuthWrapper, the centralized error handler) can see them.
-      env['otto.route_definition'] = @route_definition
-      env['otto.route_options'] = @route_definition.options
-
       # Pluggable route handler factory (Phase 4). The handler owns
       # request/response construction and decoration — param merging,
       # indifferent access, security headers, CSRF/validation helpers all
       # happen once in BaseHandler#setup_request_response. Building them here
       # too would duplicate that work on objects that get discarded (issue #189).
       if otto&.route_handler_factory
+        # Make security config, route definition, and options available to
+        # middleware and handlers before delegating, so wrappers that run
+        # ahead of the handler's own setup (RouteAuthWrapper, the centralized
+        # error handler) can see them.
+        env['otto.security_config'] = otto.security_config if otto.respond_to?(:security_config) && otto.security_config
+        env['otto.route_definition'] = @route_definition
+        env['otto.route_options'] = @route_definition.options
+
         handler = otto.route_handler_factory.create_handler(@route_definition, otto)
         return handler.call(env, extra_params)
       end
 
-      # Fallback to legacy behavior for backward compatibility
+      # Fallback to legacy behavior for backward compatibility. Build req/res
+      # before touching env, preserving the exact ordering this path always
+      # had — a custom request_class/response_class#initialize that reads env
+      # must keep seeing it unpopulated, same as before #189 (review follow-up).
       req         = otto.request_class.new(env)
       res         = otto.response_class.new
       res.request = req
+
+      # Make security config available to response helpers
+      env['otto.security_config'] = otto.security_config if otto.respond_to?(:security_config) && otto.security_config
+
+      # Make route definition and options available to middleware and handlers
+      env['otto.route_definition'] = @route_definition
+      env['otto.route_options'] = @route_definition.options
 
       # Process parameters through security layer
       req.params.merge! extra_params

--- a/lib/otto/route.rb
+++ b/lib/otto/route.rb
@@ -109,16 +109,30 @@ class Otto
     # @return [Array] Rack response array [status, headers, body]
     def call(env, extra_params = {})
       extra_params ||= {}
-      req            = otto.request_class.new(env)
-      res            = otto.response_class.new
-      res.request = req
 
       # Make security config available to response helpers
       env['otto.security_config'] = otto.security_config if otto.respond_to?(:security_config) && otto.security_config
 
-      # NEW: Make route definition and options available to middleware and handlers
+      # Make route definition and options available to middleware and handlers.
+      # Set before delegating so wrappers that run ahead of the handler's own
+      # setup (RouteAuthWrapper, the centralized error handler) can see them.
       env['otto.route_definition'] = @route_definition
       env['otto.route_options'] = @route_definition.options
+
+      # Pluggable route handler factory (Phase 4). The handler owns
+      # request/response construction and decoration — param merging,
+      # indifferent access, security headers, CSRF/validation helpers all
+      # happen once in BaseHandler#setup_request_response. Building them here
+      # too would duplicate that work on objects that get discarded (issue #189).
+      if otto&.route_handler_factory
+        handler = otto.route_handler_factory.create_handler(@route_definition, otto)
+        return handler.call(env, extra_params)
+      end
+
+      # Fallback to legacy behavior for backward compatibility
+      req         = otto.request_class.new(env)
+      res         = otto.response_class.new
+      res.request = req
 
       # Process parameters through security layer
       req.params.merge! extra_params
@@ -145,39 +159,31 @@ class Otto
       # Add validation helpers
       res.extend Otto::Security::ValidationHelpers
 
-      # NEW: Use the pluggable route handler factory (Phase 4)
-      # This replaces the hardcoded execution pattern with a factory approach
-      if otto&.route_handler_factory
-        handler = otto.route_handler_factory.create_handler(@route_definition, otto)
-        handler.call(env, extra_params)
-      else
-        # Fallback to legacy behavior for backward compatibility
-        inst = nil
-        result = case kind
-                 when :instance
-                   inst = klass.new req, res
-                   inst.send(name)
-                 when :class
-                   klass.send(name, req, res)
-                 else
-                   raise "Unsupported kind for #{definition}: #{kind}"
-                 end
+      inst = nil
+      result = case kind
+               when :instance
+                 inst = klass.new req, res
+                 inst.send(name)
+               when :class
+                 klass.send(name, req, res)
+               else
+                 raise "Unsupported kind for #{definition}: #{kind}"
+               end
 
-        # Handle response based on route options
-        response_type = @route_definition.response_type
-        if response_type != 'default'
-          context = {
-            logic_instance: (kind == :instance ? inst : nil),
-               status_code: nil,
-             redirect_path: nil,
-          }
+      # Handle response based on route options
+      response_type = @route_definition.response_type
+      if response_type != 'default'
+        context = {
+          logic_instance: (kind == :instance ? inst : nil),
+             status_code: nil,
+           redirect_path: nil,
+        }
 
-          Otto::ResponseHandlers::HandlerFactory.handle_response(result, res, response_type, context)
-        end
-
-        res.body = [res.body] unless res.body.respond_to?(:each)
-        res.finish
+        Otto::ResponseHandlers::HandlerFactory.handle_response(result, res, response_type, context)
       end
+
+      res.body = [res.body] unless res.body.respond_to?(:each)
+      res.finish
     end
 
     private

--- a/spec/otto/route_single_setup_spec.rb
+++ b/spec/otto/route_single_setup_spec.rb
@@ -71,4 +71,23 @@ RSpec.describe 'Route dispatch single setup (issue #189)' do
       expect(captured_env['otto.route_options']).to eq({})
     end
   end
+
+  describe 'legacy fallback ordering (review follow-up)' do
+    it 'builds req/res before populating env route keys, same as before #189' do
+      # With no route_handler_factory, Route#call takes the legacy path.
+      # A custom request_class#initialize reading env must keep seeing it
+      # unpopulated, exactly as it did before the #189 refactor.
+      otto.instance_variable_set(:@route_handler_factory, nil)
+
+      route_definition_at_construction = :not_called
+      allow(otto.request_class).to receive(:new).and_wrap_original do |original, env|
+        route_definition_at_construction = env['otto.route_definition']
+        original.call(env)
+      end
+
+      otto.call(mock_rack_env(method: 'GET', path: '/'))
+
+      expect(route_definition_at_construction).to be_nil
+    end
+  end
 end

--- a/spec/otto/route_single_setup_spec.rb
+++ b/spec/otto/route_single_setup_spec.rb
@@ -1,0 +1,74 @@
+# spec/otto/route_single_setup_spec.rb
+#
+# frozen_string_literal: true
+
+# Issue #189: with the handler factory present, Route#call used to build and
+# decorate a req/res pair, then discard it when BaseHandler#call built its
+# own from the same env and re-ran the identical setup. Request/response
+# construction and param processing must happen exactly once per dispatch.
+require 'spec_helper'
+
+RSpec.describe 'Route dispatch single setup (issue #189)' do
+  let(:routes) do
+    [
+      'GET / TestApp.index',
+      'GET /show/:id TestApp.show',
+    ]
+  end
+
+  let(:routes_file) { create_test_routes_file('test_routes_single_setup.txt', routes) }
+  let(:otto) { Otto.new(routes_file) }
+
+  it 'constructs exactly one request and one response per route dispatch' do
+    # handle_request isolates route dispatch from Otto#call, which builds its
+    # own top-level request for lifecycle hooks.
+    allow(otto.request_class).to receive(:new).and_call_original
+    allow(otto.response_class).to receive(:new).and_call_original
+
+    otto.handle_request(mock_rack_env(method: 'GET', path: '/show/42'))
+
+    expect(otto.request_class).to have_received(:new).once
+    expect(otto.response_class).to have_received(:new).once
+  end
+
+  it 'processes params through indifferent_params exactly once per dispatch' do
+    allow(Otto::Static).to receive(:indifferent_params).and_call_original
+
+    otto.call(mock_rack_env(method: 'GET', path: '/show/42'))
+
+    expect(Otto::Static).to have_received(:indifferent_params).once
+  end
+
+  describe 'behavior parity after consolidating setup in BaseHandler' do
+    it 'still merges route path params into the request' do
+      status, _headers, body = otto.call(mock_rack_env(method: 'GET', path: '/show/42'))
+
+      expect(status).to eq(200)
+      expect(body.join).to eq('Showing 42')
+    end
+
+    it 'still applies security headers to the response' do
+      _status, headers, = otto.call(mock_rack_env(method: 'GET', path: '/'))
+
+      expected = otto.security_config.security_headers
+      expect(expected).not_to be_empty
+      expected.each do |header, value|
+        expect(headers[header]).to eq(value)
+      end
+    end
+
+    it 'still exposes the route definition and options in env before the handler runs' do
+      captured_env = nil
+      allow(TestApp).to receive(:index) do |req, res|
+        captured_env = req.env
+        res.write('ok')
+      end
+
+      otto.call(mock_rack_env(method: 'GET', path: '/'))
+
+      expect(captured_env['otto.route_definition']).to be_a(Otto::RouteDefinition)
+      expect(captured_env['otto.route_definition'].definition).to eq('TestApp.index')
+      expect(captured_env['otto.route_options']).to eq({})
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #189. With the default handler factory, `Route#call` built and decorated a request/response pair — merged `extra_params`, applied `indifferent_params`, set security headers, extended CSRF/validation helpers — then delegated to the handler, whose `BaseHandler#call` rebuilt a second pair from the same env and re-ran the identical setup. The `Route#call` objects were discarded, so every request paid for two request/response objects and duplicate param processing, and the two near-identical setup blocks could silently diverge over time.

## Changes

- When the handler factory is present, `Route#call` now sets only the env keys that must be visible before the handler runs — `otto.security_config`, `otto.route_definition`, `otto.route_options` (read by `RouteAuthWrapper` and the centralized error handler) — and delegates immediately.
- `BaseHandler#setup_request_response` is now the single owner of request/response construction and decoration; param merging, indifferent access, security headers, and CSRF/validation helpers each run exactly once per dispatch.
- The legacy no-factory fallback path keeps its previous behavior unchanged.

## Testing

- 5 new specs in `spec/otto/route_single_setup_spec.rb`: exactly-once request/response construction and exactly-once `indifferent_params` per dispatch (both fail against the old code), plus behavior-parity checks for path-param merging, security headers, and env keys.
- Full suite: 1743 examples, 0 failures. No new rubocop offenses (the method actually shrank slightly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HK9SxMxmuu6MpA3aURoPo8

---
_Generated by [Claude Code](https://claude.ai/code/session_01HK9SxMxmuu6MpA3aURoPo8)_