### PR TITLE
fix(router): share one path normalization across all dispatch paths (#187)

### DIFF
--- a/changelog.d/20260710_051500_ops_dynamic_route_path_normalization.rst
+++ b/changelog.d/20260710_051500_ops_dynamic_route_path_normalization.rst
@@ -1,0 +1,14 @@
+Security
+--------
+
+- Dynamic-route and static-file dispatch now normalize the request path the
+  same way literal matching and ``Otto::CaddyTLS::LocalhostGuard`` do (#187).
+  Previously the dynamic matcher and the ``safe_file?`` branch matched against
+  the raw (unescape-only) path while literal lookup used the trailing-slash-
+  stripped, UTF-8-scrubbed path. Two divergences resulted: dynamic routes were
+  stricter about trailing slashes than literal routes (so ``/show/123/`` missed
+  a ``/show/:id`` route that ``/about/`` would hit as a literal), and invalid
+  UTF-8 bytes scrubbed for the guard survived into the dynamic matcher and the
+  static branch — the guard-bypass class ``normalize_path`` exists to close. All
+  dispatch paths now share the single normalization; root still routes correctly
+  (a catch-all ``/*`` continues to match ``/``).

--- a/lib/otto/core/router.rb
+++ b/lib/otto/core/router.rb
@@ -191,14 +191,18 @@ class Otto
 
       private
 
-      def match_dynamic_route(env, path_info_clean, http_verb, literal_routes)
+      # +dispatch_path+ is the normalized path from #handle_request (see the
+      # +dispatch_path+ comment there): +Otto::Utils.normalize_path+ output with
+      # root's empty string mapped back to '/' so the anchored route regexes can
+      # match. It is deliberately NOT the raw +normalize_path+ value.
+      def match_dynamic_route(env, dispatch_path, http_verb, literal_routes)
         extra_params  = {}
         found_route   = nil
         valid_routes  = routes[http_verb] || []
         valid_routes.push(*routes[:GET]) if http_verb == :HEAD
 
         valid_routes.each do |route|
-          next unless (match = route.pattern.match(path_info_clean))
+          next unless (match = route.pattern.match(dispatch_path))
 
           values = match.captures.to_a
           # The first capture returned is the entire matched string b/c

--- a/lib/otto/core/router.rb
+++ b/lib/otto/core/router.rb
@@ -124,6 +124,20 @@ class Otto
         literal_routes = routes_literal[http_verb] || {}
         literal_routes.merge! routes_literal[:GET] if http_verb == :HEAD
 
+        # Dynamic-route and static-file dispatch match against the SAME
+        # normalized path the literal table and the LocalhostGuard use, so all
+        # dispatch paths share one normalization (issue #187). Without this,
+        # dynamic routes matched the raw (unescape-only) path: they were
+        # stricter about trailing slashes than literal routes (equivalent URLs
+        # matched or missed depending on route kind), and invalid-UTF-8 bytes
+        # scrubbed for the guard and literal matching survived into the dynamic
+        # matcher and safe_file? — the guard-bypass class normalize_path exists
+        # to close. normalize_path collapses root to '' after stripping the
+        # trailing slash; the regex matcher and safe_file? need a leading slash
+        # to be structural (a catch-all `/*` still matches `/`), so restore '/'
+        # for them. Literal lookup keeps '' — it already keys root that way.
+        dispatch_path = path_info_clean.empty? ? '/' : path_info_clean
+
         if static_route && http_verb == :GET && routes_static[:GET].member?(base_path)
           Otto.structured_log(:debug, 'Route matched',
             Otto::LoggingHelpers.request_context(env).merge(
@@ -144,7 +158,7 @@ class Otto
             @route_matched_callbacks.each { |cb| cb.call(env, route.route_definition) }
           end
           route.call(env)
-        elsif static_route && http_verb == :GET && safe_file?(path_info)
+        elsif static_route && http_verb == :GET && safe_file?(dispatch_path)
           Otto.structured_log(:debug, 'Route matched',
             Otto::LoggingHelpers.request_context(env).merge(
               type: 'static_new',
@@ -153,7 +167,7 @@ class Otto
           routes_static[:GET][base_path] = base_path
           static_route.call(env)
         else
-          match_dynamic_route(env, path_info, http_verb, literal_routes)
+          match_dynamic_route(env, dispatch_path, http_verb, literal_routes)
         end
       end
 
@@ -177,14 +191,14 @@ class Otto
 
       private
 
-      def match_dynamic_route(env, path_info, http_verb, literal_routes)
+      def match_dynamic_route(env, path_info_clean, http_verb, literal_routes)
         extra_params  = {}
         found_route   = nil
         valid_routes  = routes[http_verb] || []
         valid_routes.push(*routes[:GET]) if http_verb == :HEAD
 
         valid_routes.each do |route|
-          next unless (match = route.pattern.match(path_info))
+          next unless (match = route.pattern.match(path_info_clean))
 
           values = match.captures.to_a
           # The first capture returned is the entire matched string b/c

--- a/spec/otto/router_path_normalization_spec.rb
+++ b/spec/otto/router_path_normalization_spec.rb
@@ -1,0 +1,101 @@
+# spec/otto/router_path_normalization_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Issue #187: dynamic-route and static-file dispatch used to match against the
+# raw (unescape-only) path while literal matching and the LocalhostGuard used
+# the normalized path (Otto::Utils.normalize_path). That divergence made
+# dynamic routes stricter about trailing slashes than literal routes, and let
+# invalid-UTF-8 bytes that are scrubbed for the guard survive into the dynamic
+# matcher. All dispatch paths now share the single normalization.
+RSpec.describe Otto, 'router path normalization (issue #187)' do
+  let(:routes) do
+    [
+      'GET / TestApp.index',
+      'GET /custom TestApp.custom_headers',
+      'GET /show/:id TestApp.show',
+      'GET /files/* TestApp.index',
+    ]
+  end
+
+  let(:app) { create_minimal_otto(routes) }
+
+  describe 'trailing-slash symmetry between literal and dynamic routes' do
+    it 'matches a literal route with a trailing slash' do
+      env = mock_rack_env(method: 'GET', path: '/custom/')
+      response = app.call(env)
+
+      expect(response[0]).to eq(200)
+    end
+
+    it 'matches a dynamic route with a trailing slash, like the literal one' do
+      env = mock_rack_env(method: 'GET', path: '/show/123/')
+      response = app.call(env)
+
+      expect(response[0]).to eq(200)
+      expect(response[2].join).to eq('Showing 123')
+    end
+
+    it 'still matches a dynamic route without a trailing slash' do
+      env = mock_rack_env(method: 'GET', path: '/show/123')
+      response = app.call(env)
+
+      expect(response[0]).to eq(200)
+      expect(response[2].join).to eq('Showing 123')
+    end
+
+    it 'captures the same param whether or not a trailing slash is present' do
+      with_slash    = app.call(mock_rack_env(method: 'GET', path: '/show/abc/'))
+      without_slash = app.call(mock_rack_env(method: 'GET', path: '/show/abc'))
+
+      expect(with_slash[2].join).to eq(without_slash[2].join)
+    end
+  end
+
+  describe 'root path handling after trailing-slash stripping' do
+    # normalize_path collapses '/' to '' after stripping the trailing slash.
+    # Dispatch restores '/' for the regex matcher so a catch-all still matches
+    # root; literal lookup keeps '' since it already keys root that way.
+    it 'still dispatches the root path to its literal route' do
+      env = mock_rack_env(method: 'GET', path: '/')
+      response = app.call(env)
+
+      expect(response[0]).to eq(200)
+      expect(response[2].join).to eq('Hello World')
+    end
+
+    it 'matches a catch-all splat route on a nested path' do
+      env = mock_rack_env(method: 'GET', path: '/files/a/b')
+      response = app.call(env)
+
+      expect(response[0]).to eq(200)
+      expect(response[2].join).to eq('Hello World')
+    end
+
+    it 'matches a catch-all splat route even when the root literal is absent' do
+      splat_app = create_minimal_otto(['GET /* TestApp.index'])
+      env = mock_rack_env(method: 'GET', path: '/')
+      response = splat_app.call(env)
+
+      expect(response[0]).to eq(200)
+      expect(response[2].join).to eq('Hello World')
+    end
+  end
+
+  describe 'invalid-UTF-8 scrubbing before dynamic matching' do
+    # A percent-encoded invalid byte (%FF) decodes to a byte the dynamic
+    # matcher's UTF-8 regex would choke on. Matching against the raw path
+    # raised mid-dispatch (500); matching against the scrubbed path drops the
+    # byte and captures a clean param, consistent with literal matching and
+    # the LocalhostGuard.
+    it 'scrubs a percent-encoded invalid byte in a dynamic segment' do
+      env = mock_rack_env(method: 'GET', path: '/show/abc%FF')
+      response = app.call(env)
+
+      expect(response[0]).to eq(200)
+      expect(response[2].join).to eq('Showing abc')
+    end
+  end
+end

--- a/spec/otto/router_path_normalization_spec.rb
+++ b/spec/otto/router_path_normalization_spec.rb
@@ -52,6 +52,15 @@ RSpec.describe Otto, 'router path normalization (issue #187)' do
 
       expect(with_slash[2].join).to eq(without_slash[2].join)
     end
+
+    it 'applies the same normalization to HEAD (which is served by the GET dynamic route)' do
+      # match_dynamic_route folds :GET routes into :HEAD, so a HEAD with a
+      # trailing slash must normalize and match exactly like the GET route.
+      env = mock_rack_env(method: 'HEAD', path: '/show/123/')
+      response = app.call(env)
+
+      expect(response[0]).to eq(200)
+    end
   end
 
   describe 'root path handling after trailing-slash stripping' do
@@ -96,6 +105,34 @@ RSpec.describe Otto, 'router path normalization (issue #187)' do
 
       expect(response[0]).to eq(200)
       expect(response[2].join).to eq('Showing abc')
+    end
+  end
+
+  describe 'the static-file branch matches against the normalized path' do
+    # The other half of the fix: safe_file? must receive the normalized
+    # dispatch path, not the raw unescape-only path, so the static gate shares
+    # the literal/guard normalization (trailing slash stripped, invalid bytes
+    # scrubbed). safe_file? is stubbed to isolate the argument it is handed.
+    let(:public_dir) { Dir.mktmpdir('otto_public') }
+
+    let(:static_app) do
+      File.write(File.join(public_dir, 'asset.txt'), 'body')
+      otto = Otto.new(create_test_routes_file('static_norm.txt', ['GET / TestApp.index']),
+                      public: public_dir)
+      Otto.unfreeze_for_testing(otto)
+      otto
+    end
+
+    after { FileUtils.remove_entry(public_dir) if File.directory?(public_dir) }
+
+    it 'passes the trailing-slash-stripped path to safe_file?' do
+      expect(static_app).to receive(:safe_file?).with('/asset.txt').and_return(false)
+      static_app.call(mock_rack_env(method: 'GET', path: '/asset.txt/'))
+    end
+
+    it 'passes the invalid-byte-scrubbed path to safe_file?' do
+      expect(static_app).to receive(:safe_file?).with('/asset.txt').and_return(false)
+      static_app.call(mock_rack_env(method: 'GET', path: '/asset.txt%FF'))
     end
   end
 end


### PR DESCRIPTION
## Summary

Fixes #187. `handle_request` computed two paths — `path_info` (unescape only) and `path_info_clean` (unescape + UTF-8 scrub + trailing-slash strip via `Otto::Utils.normalize_path`). Literal lookup used `path_info_clean`, but **dynamic-route matching and the static `safe_file?` branch matched against the raw `path_info`**. That left two divergences:

1. **Trailing-slash asymmetry** — dynamic routes were stricter about trailing slashes than literal routes, so `/show/123/` missed a `/show/:id` route that an equivalent literal (`/about/`) would still hit.
2. **Normalization/guard divergence** — invalid-UTF-8 bytes scrubbed for `Otto::CaddyTLS::LocalhostGuard` (and for literal matching) survived into the dynamic matcher and the static branch. A percent-encoded invalid byte (`%FF`) decodes to a byte the matcher's UTF-8 regex chokes on, so the request raised mid-dispatch (500) instead of being scrubbed — exactly the guard-bypass class `normalize_path` exists to close.

## Change

Route the dynamic matcher and the static `safe_file?` decision through the same normalized path the literal table and the guard use. `normalize_path` collapses root `/` to `''` after stripping the trailing slash, so a `dispatch_path` local restores `'/'` for the regex matcher and `safe_file?` (a leading slash is structural there — a catch-all `/*` must still match `/`); literal lookup keeps `''` since it already keys root that way.

- `lib/otto/core/router.rb` — add `dispatch_path`, pass it to `match_dynamic_route` and `safe_file?`.
- The static-cached `base_path` key is left on the raw path deliberately: it is an internal directory cache, and the file itself is served by `Rack::Files` from `env['PATH_INFO']` (which does its own normalization/traversal protection). The security-relevant decision (`safe_file?`) is what moves to the normalized path.

## Behavior notes

- `/show/123/` and `/show/123` now both match `/show/:id` and capture the same param.
- A catch-all `/*` still matches `/` and nested paths.
- `/show/abc%FF` now returns `200` with the byte scrubbed (`Showing abc`) instead of `500`.

## Tests

New `spec/otto/router_path_normalization_spec.rb` (8 examples) covers trailing-slash symmetry between literal and dynamic routes, root/splat handling after the `'' → '/'` remap, and invalid-UTF-8 scrubbing before dynamic matching.

Full suite: **1793 examples, 0 failures**. No new RuboCop offenses in `router.rb` (baseline unchanged at 9 pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HK9SxMxmuu6MpA3aURoPo8)_