### PR TITLE
CSP: fix default worker-src (blob:) and add per-directive overrides for nonce policies

### DIFF
--- a/changelog.d/20260710_073000_ops_csp_directive_overrides.rst
+++ b/changelog.d/20260710_073000_ops_csp_directive_overrides.rst
@@ -18,4 +18,7 @@ Added
   validated — a value containing ``;``, a newline, or a carriage return raises
   ``ArgumentError`` rather than injecting extra directives (a footgun when
   overrides come from env/config files) — and override keys are normalized on
-  store so mixed key styles never accumulate duplicate entries.
+  store so mixed key styles never accumulate duplicate entries. Overriding
+  ``script-src`` while nonce mode is enabled logs a warning: the per-request
+  nonce cannot be reproduced in a static override, so such an override disables
+  nonce-based script protection for that policy.

--- a/changelog.d/20260710_073000_ops_csp_directive_overrides.rst
+++ b/changelog.d/20260710_073000_ops_csp_directive_overrides.rst
@@ -1,0 +1,17 @@
+Added
+-----
+
+- CSP nonce policies can now be customized per-directive (#201).
+  ``Otto::Security::Config#enable_csp_with_nonce!`` accepts a ``directives:``
+  hash, and the new ``#csp_directive_overrides=`` / ``#merge_csp_directives``
+  setters let a consuming app override, add, or remove ANY directive rather
+  than only ``report-uri``/``report-to``. Overrides merge into Otto's base
+  directive sets (``Otto::Security::CSP::Policy.merge_directives``): a String
+  or Array value replaces a directive's source list, and a ``nil``/``false``
+  value removes the directive. This gives apps a supported escape hatch — for
+  example ``enable_csp_with_nonce!(directives: { 'worker-src' => "'self' blob:" })``
+  to permit ``blob:`` workers (Sentry Replay, VueUse ``useWebWorkerFn``,
+  bundler-emitted workers, WASM loaders) — without vendoring the gem. Output
+  is byte-identical to Otto's historical policy when no overrides are set; the
+  default ``worker-src 'self' data:`` is unchanged so the production policy is
+  not relaxed for every consumer.

--- a/changelog.d/20260710_073000_ops_csp_directive_overrides.rst
+++ b/changelog.d/20260710_073000_ops_csp_directive_overrides.rst
@@ -14,4 +14,8 @@ Added
   bundler-emitted workers, WASM loaders) — without vendoring the gem. Output
   is byte-identical to Otto's historical policy when no overrides are set; the
   default ``worker-src 'self' data:`` is unchanged so the production policy is
-  not relaxed for every consumer.
+  not relaxed for every consumer. Directive names and source tokens are
+  validated — a value containing ``;``, a newline, or a carriage return raises
+  ``ArgumentError`` rather than injecting extra directives (a footgun when
+  overrides come from env/config files) — and override keys are normalized on
+  store so mixed key styles never accumulate duplicate entries.

--- a/changelog.d/20260710_073000_ops_csp_directive_overrides.rst
+++ b/changelog.d/20260710_073000_ops_csp_directive_overrides.rst
@@ -1,3 +1,19 @@
+Changed
+-------
+
+- The nonce CSP's default ``worker-src`` directive now emits ``'self' blob:``
+  instead of ``'self' data:`` in both the production and development directive
+  sets (#201). Browsers instantiate Web Workers from ``blob:`` URLs
+  (``new Worker(URL.createObjectURL(...))``) — the mechanism used by Sentry
+  Replay, VueUse ``useWebWorkerFn``, bundler-emitted workers, and WASM
+  loaders — so the previous default blocked mainstream worker libraries while
+  granting ``data:``, a token real libraries don't use and one that is riskier
+  under content injection (an attacker fully controls a ``data:`` URL's
+  content, whereas a ``blob:`` URL must be minted by same-origin script
+  already gated by the ``script-src`` nonce). Apps that genuinely rely on
+  ``data:`` workers can restore the old behavior in one line:
+  ``enable_csp_with_nonce!(directives: { worker_src: "'self' data: blob:" })``.
+
 Added
 -----
 
@@ -8,17 +24,12 @@ Added
   than only ``report-uri``/``report-to``. Overrides merge into Otto's base
   directive sets (``Otto::Security::CSP::Policy.merge_directives``): a String
   or Array value replaces a directive's source list, and a ``nil``/``false``
-  value removes the directive. This gives apps a supported escape hatch — for
-  example ``enable_csp_with_nonce!(directives: { 'worker-src' => "'self' blob:" })``
-  to permit ``blob:`` workers (Sentry Replay, VueUse ``useWebWorkerFn``,
-  bundler-emitted workers, WASM loaders) — without vendoring the gem. Output
-  is byte-identical to Otto's historical policy when no overrides are set; the
-  default ``worker-src 'self' data:`` is unchanged so the production policy is
-  not relaxed for every consumer. Directive names and source tokens are
-  validated — a value containing ``;``, a newline, or a carriage return raises
-  ``ArgumentError`` rather than injecting extra directives (a footgun when
-  overrides come from env/config files) — and override keys are normalized on
-  store so mixed key styles never accumulate duplicate entries. Overriding
-  ``script-src`` while nonce mode is enabled logs a warning: the per-request
-  nonce cannot be reproduced in a static override, so such an override disables
-  nonce-based script protection for that policy.
+  value removes the directive. Output is byte-identical to the (updated)
+  default policy when no overrides are set. Directive names and source tokens
+  are validated — a value containing ``;``, a newline, or a carriage return
+  raises ``ArgumentError`` rather than injecting extra directives (a footgun
+  when overrides come from env/config files) — and override keys are
+  normalized on store so mixed key styles never accumulate duplicate entries.
+  Overriding ``script-src`` while nonce mode is enabled logs a warning: the
+  per-request nonce cannot be reproduced in a static override, so such an
+  override disables nonce-based script protection for that policy.

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -102,6 +102,7 @@ class Otto
         @csp_report_to_url      = nil
         @csp_violation_callback = nil
         @csp_directive_overrides = {}
+        @csp_script_src_override_warned = false
         @rate_limiting_config   = { custom_rules: {} }
         @ip_privacy_config      = Otto::Privacy::Config.new
 
@@ -412,9 +413,11 @@ class Otto
       # never accumulates logically-identical entries under different key styles
       # (`'WORKER-SRC'` and `:worker_src` both read back as `'worker-src'`).
       #
-      # @note Replacing `script-src` without keeping the per-request nonce token
-      #   in the source list defeats nonce protection — see
-      #   {Otto::Security::CSP::Policy.merge_directives}.
+      # @note Overriding `script-src` while nonce mode is enabled disables
+      #   nonce-based script protection: the per-request nonce cannot be
+      #   included in a static override, so it is stripped from the emitted
+      #   header. A warning is logged when a `script-src` override is stored.
+      #   See {Otto::Security::CSP::Policy.merge_directives}.
       #
       # @param overrides [Hash] directive name => source list / nil
       # @return [void]
@@ -425,7 +428,9 @@ class Otto
       def csp_directive_overrides=(overrides)
         ensure_not_frozen!
 
-        @csp_directive_overrides = Otto::Security::CSP::Policy.normalize_overrides(overrides || {})
+        normalized = Otto::Security::CSP::Policy.normalize_overrides(overrides || {})
+        warn_if_script_src_overridden(normalized)
+        @csp_directive_overrides = normalized
       end
 
       # Merge additional per-directive overrides into the existing set, leaving
@@ -440,6 +445,7 @@ class Otto
         ensure_not_frozen!
 
         normalized = Otto::Security::CSP::Policy.normalize_overrides(overrides || {})
+        warn_if_script_src_overridden(normalized)
         @csp_directive_overrides = @csp_directive_overrides.merge(normalized)
       end
 
@@ -882,6 +888,29 @@ class Otto
           generated per-process secret; they will not survive restarts or be
           valid across workers. Set OTTO_CSRF_SECRET (or config.csrf_secret=)
           for stable CSRF tokens in multi-process deployments.
+        MSG
+      end
+
+      # Warn once per config instance when a `script-src` override is stored for
+      # the nonce CSP policy. The per-request nonce is generated at response time
+      # and therefore cannot be present in a static override, so replacing (or
+      # removing) `script-src` necessarily strips the nonce from the emitted
+      # header — the browser then accepts any inline script the page carries the
+      # nonce attribute on, voiding nonce-based protection. Overriding any other
+      # directive (e.g. `worker-src`) is unaffected and stays silent.
+      #
+      # @param normalized [Hash] normalized (lowercased/hyphenated) overrides
+      # @return [void]
+      def warn_if_script_src_overridden(normalized)
+        return unless normalized.key?('script-src')
+        return if @csp_script_src_override_warned
+
+        @csp_script_src_override_warned = true
+        Otto.structured_log(:warn, <<~MSG.gsub(/\s+/, ' ').strip, directive: 'script-src')
+          [Otto::CSP] A script-src override was configured while nonce mode is in
+          use. The per-request nonce cannot be included in a static override, so
+          nonce-based script protection is disabled for this policy. Remove the
+          script-src override to keep nonce enforcement.
         MSG
       end
 

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -386,8 +386,8 @@ class Otto
       # @example
       #   config.enable_csp_with_nonce!(debug: true)
       #
-      # @example Allow blob: workers (Sentry Replay, VueUse useWebWorkerFn, …)
-      #   config.enable_csp_with_nonce!(directives: { 'worker-src' => "'self' blob:" })
+      # @example Restore data: workers (blob: is the default worker-src token)
+      #   config.enable_csp_with_nonce!(directives: { 'worker-src' => "'self' data: blob:" })
       def enable_csp_with_nonce!(debug: false, directives: {})
         ensure_not_frozen!
 
@@ -424,7 +424,7 @@ class Otto
       # @raise [FrozenError] if configuration is frozen
       #
       # @example
-      #   config.csp_directive_overrides = { 'worker-src' => "'self' blob:" }
+      #   config.csp_directive_overrides = { 'worker-src' => "'self' data: blob:" }
       def csp_directive_overrides=(overrides)
         ensure_not_frozen!
 

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -390,9 +390,12 @@ class Otto
       def enable_csp_with_nonce!(debug: false, directives: {})
         ensure_not_frozen!
 
+        # Apply overrides before toggling state so a bad +directives+ argument
+        # raises without leaving the config half-updated (nonce enabled but
+        # overrides not merged).
+        merge_csp_directives(directives) unless directives.nil? || directives.empty?
         @csp_nonce_enabled = true
         @debug_csp         = debug
-        merge_csp_directives(directives) unless directives.nil? || directives.empty?
       end
 
       # Replace the per-directive overrides applied to the nonce CSP policy.
@@ -404,6 +407,15 @@ class Otto
       # are the source list as a String (`"'self' blob:"`) or Array
       # (`%w['self' blob:]`), or nil/false to REMOVE the directive.
       #
+      # Keys are normalized on store (lowercased, hyphenated) via
+      # {Otto::Security::CSP::Policy.normalize_overrides}, so the stored hash
+      # never accumulates logically-identical entries under different key styles
+      # (`'WORKER-SRC'` and `:worker_src` both read back as `'worker-src'`).
+      #
+      # @note Replacing `script-src` without keeping the per-request nonce token
+      #   in the source list defeats nonce protection — see
+      #   {Otto::Security::CSP::Policy.merge_directives}.
+      #
       # @param overrides [Hash] directive name => source list / nil
       # @return [void]
       # @raise [FrozenError] if configuration is frozen
@@ -413,7 +425,7 @@ class Otto
       def csp_directive_overrides=(overrides)
         ensure_not_frozen!
 
-        @csp_directive_overrides = (overrides || {}).dup
+        @csp_directive_overrides = Otto::Security::CSP::Policy.normalize_overrides(overrides || {})
       end
 
       # Merge additional per-directive overrides into the existing set, leaving
@@ -427,7 +439,8 @@ class Otto
       def merge_csp_directives(overrides)
         ensure_not_frozen!
 
-        @csp_directive_overrides = @csp_directive_overrides.merge(overrides || {})
+        normalized = Otto::Security::CSP::Policy.normalize_overrides(overrides || {})
+        @csp_directive_overrides = @csp_directive_overrides.merge(normalized)
       end
 
       # Disable CSP nonce support

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -72,7 +72,8 @@ class Otto
                   :security_headers,
                   :csp_nonce_enabled, :debug_csp, :mcp_auth, :csp_nonce_key,
                   :ip_privacy_config, :trusted_proxy_depth, :trusted_proxy_header,
-                  :csp_report_uri, :csp_report_to_url, :csp_violation_callback
+                  :csp_report_uri, :csp_report_to_url, :csp_violation_callback,
+                  :csp_directive_overrides
 
       # Initialize security configuration with safe defaults
       #
@@ -100,6 +101,7 @@ class Otto
         @csp_report_uri         = nil
         @csp_report_to_url      = nil
         @csp_violation_callback = nil
+        @csp_directive_overrides = {}
         @rate_limiting_config   = { custom_rules: {} }
         @ip_privacy_config      = Otto::Privacy::Config.new
 
@@ -367,17 +369,65 @@ class Otto
       # Unlike enable_csp!, this doesn't set a static policy but enables the response
       # helper to generate CSP headers with nonces on a per-request basis.
       #
+      # Per-directive overrides may be supplied to customize the emitted nonce
+      # policy without vendoring the gem. They merge into Otto's base directive
+      # sets ({Otto::Security::CSP::Policy.development_directives} /
+      # {Otto::Security::CSP::Policy.production_directives}): a matching directive
+      # is replaced in place, a new directive is appended, and a nil/false value
+      # removes a directive. See {#csp_directive_overrides=} for the accepted
+      # shape.
+      #
       # @param debug [Boolean] Enable debug logging for CSP headers (default: false)
+      # @param directives [Hash] per-directive overrides merged into the base set
       # @return [void]
       # @raise [FrozenError] if configuration is frozen
       #
       # @example
       #   config.enable_csp_with_nonce!(debug: true)
-      def enable_csp_with_nonce!(debug: false)
+      #
+      # @example Allow blob: workers (Sentry Replay, VueUse useWebWorkerFn, …)
+      #   config.enable_csp_with_nonce!(directives: { 'worker-src' => "'self' blob:" })
+      def enable_csp_with_nonce!(debug: false, directives: {})
         ensure_not_frozen!
 
         @csp_nonce_enabled = true
         @debug_csp         = debug
+        merge_csp_directives(directives) unless directives.nil? || directives.empty?
+      end
+
+      # Replace the per-directive overrides applied to the nonce CSP policy.
+      #
+      # Overrides merge into Otto's base directive sets when
+      # {#generate_nonce_csp} builds the policy, so a consuming app can adjust
+      # ANY directive rather than only `report-uri`/`report-to`. Keys are
+      # directive names (String or Symbol, matched case-insensitively); values
+      # are the source list as a String (`"'self' blob:"`) or Array
+      # (`%w['self' blob:]`), or nil/false to REMOVE the directive.
+      #
+      # @param overrides [Hash] directive name => source list / nil
+      # @return [void]
+      # @raise [FrozenError] if configuration is frozen
+      #
+      # @example
+      #   config.csp_directive_overrides = { 'worker-src' => "'self' blob:" }
+      def csp_directive_overrides=(overrides)
+        ensure_not_frozen!
+
+        @csp_directive_overrides = (overrides || {}).dup
+      end
+
+      # Merge additional per-directive overrides into the existing set, leaving
+      # untouched any directive not named in +overrides+ (last write wins for a
+      # repeated directive). Use this to accumulate overrides incrementally;
+      # use {#csp_directive_overrides=} to replace them wholesale.
+      #
+      # @param overrides [Hash] directive name => source list / nil
+      # @return [void]
+      # @raise [FrozenError] if configuration is frozen
+      def merge_csp_directives(overrides)
+        ensure_not_frozen!
+
+        @csp_directive_overrides = @csp_directive_overrides.merge(overrides || {})
       end
 
       # Disable CSP nonce support
@@ -527,8 +577,10 @@ class Otto
       # Generate a CSP policy string with the provided nonce
       #
       # Thin facade over {Otto::Security::CSP::Policy.nonce_policy}; the directive
-      # sets and report-uri/report-to assembly live there now. Output is
-      # byte-identical to Otto's historical policy.
+      # sets and report-uri/report-to assembly live there now. Any configured
+      # {#csp_directive_overrides} are merged into the base directive set. Output
+      # is byte-identical to Otto's historical policy when no overrides or
+      # reporting are configured.
       #
       # @param nonce [String] The nonce value to include in the CSP
       # @param development_mode [Boolean] Whether to use development-friendly directives
@@ -538,7 +590,8 @@ class Otto
           nonce,
           development_mode: development_mode,
           report_uri: @csp_report_uri,
-          report_to_url: @csp_report_to_url
+          report_to_url: @csp_report_to_url,
+          directive_overrides: @csp_directive_overrides
         )
       end
 

--- a/lib/otto/security/csp/policy.rb
+++ b/lib/otto/security/csp/policy.rb
@@ -112,12 +112,14 @@ class Otto
         # Directive names are matched case-insensitively (CSP directive names are
         # case-insensitive) and may be given as Strings or Symbols.
         #
-        # @note Replacing `script-src` (or `default-src`, which `script-src`
-        #   falls back to) without re-including the per-request nonce
-        #   (`'nonce-<value>'`) removes the nonce from the emitted header and
+        # @note The per-request nonce is embedded in `script-src` (production)
+        #   and cannot be reproduced in a static override, so replacing (or
+        #   removing) `script-src` strips the nonce from the emitted header and
         #   DEFEATS nonce protection: the browser then accepts any inline script
-        #   the page carries the nonce attribute on. Only override `script-src`
-        #   if you understand this, and keep the nonce token in your source list.
+        #   the page carries the nonce attribute on. Overriding `script-src`
+        #   while nonce mode is enabled therefore disables nonce enforcement;
+        #   {Otto::Security::Config} logs a warning when such an override is
+        #   configured. Override other directives freely.
         #
         # @param directives [Array<String>] base directive strings, each `;`-terminated
         # @param overrides [Hash, nil] directive name => source list / nil

--- a/lib/otto/security/csp/policy.rb
+++ b/lib/otto/security/csp/policy.rb
@@ -112,9 +112,18 @@ class Otto
         # Directive names are matched case-insensitively (CSP directive names are
         # case-insensitive) and may be given as Strings or Symbols.
         #
+        # @note Replacing `script-src` (or `default-src`, which `script-src`
+        #   falls back to) without re-including the per-request nonce
+        #   (`'nonce-<value>'`) removes the nonce from the emitted header and
+        #   DEFEATS nonce protection: the browser then accepts any inline script
+        #   the page carries the nonce attribute on. Only override `script-src`
+        #   if you understand this, and keep the nonce token in your source list.
+        #
         # @param directives [Array<String>] base directive strings, each `;`-terminated
         # @param overrides [Hash, nil] directive name => source list / nil
         # @return [Array<String>] merged directive strings, each `;`-terminated
+        # @raise [ArgumentError] if an override name or source token contains a
+        #   `;`, newline, or carriage return (see {.build_directive})
         def merge_directives(directives, overrides)
           return directives if overrides.nil? || overrides.empty?
 
@@ -166,14 +175,46 @@ class Otto
         # Build a single `;`-terminated directive string from a name and an
         # override value, or nil when the value signals removal (nil/false).
         #
+        # The directive name and each source token are validated against CSP's
+        # separator characters: a name or token containing `;` (which separates
+        # directives), a newline, or a carriage return raises {ArgumentError}
+        # rather than silently injecting extra directives — a real footgun when
+        # overrides come from env/config files. (The `false` removal sentinel is
+        # checked before {Array} so a bare `false` never becomes a `[false]`
+        # source list.)
+        #
         # @param name [String] directive name
         # @param value [String, Array, nil, false] source list, or nil/false to remove
         # @return [String, nil]
+        # @raise [ArgumentError] if the name or a source token contains a `;`,
+        #   newline, or carriage return
         def build_directive(name, value)
           return nil if value.nil? || value == false
 
-          sources = Array(value).map { |token| token.to_s.strip }.reject(&:empty?).join(' ')
+          reject_injection!('directive name', name)
+          sources = Array(value).filter_map do |token|
+            str = token.to_s.strip
+            next if str.empty?
+
+            reject_injection!("source for #{name}", str)
+            str
+          end.join(' ')
           sources.empty? ? "#{name};" : "#{name} #{sources};"
+        end
+
+        # Raise {ArgumentError} when +text+ carries a CSP directive/token
+        # separator (`;`, newline, or carriage return) that would let an
+        # override break out of its directive and inject another.
+        #
+        # @param label [String] what is being validated (for the error message)
+        # @param text [String]
+        # @return [void]
+        # @raise [ArgumentError] if +text+ contains `;`, `\n`, or `\r`
+        def reject_injection!(label, text)
+          return unless text.match?(/[;\r\n]/)
+
+          raise ArgumentError,
+                "invalid CSP #{label}: #{text.inspect} contains a ';', newline, or carriage return"
         end
 
         # CSP directives for the development environment.

--- a/lib/otto/security/csp/policy.rb
+++ b/lib/otto/security/csp/policy.rb
@@ -96,8 +96,9 @@ class Otto
         # Merge per-directive overrides into a base directive set.
         #
         # This is the customization seam the hardcoded directive sets previously
-        # lacked: a consuming app can adjust ANY directive (e.g. opt into
-        # `worker-src 'self' blob:`) without vendoring the gem. Order is
+        # lacked: a consuming app can adjust ANY directive (e.g. re-allow
+        # `data:` workers via `worker-src 'self' data: blob:`) without
+        # vendoring the gem. Order is
         # preserved — an override that matches an existing directive replaces it
         # in place; an override for a directive not in the base set is appended
         # after the base directives (before any reporting directives).
@@ -239,7 +240,7 @@ class Otto
             "form-action 'self';",
             "frame-ancestors 'none';",
             "manifest-src 'self';",
-            "worker-src 'self' data:;",
+            "worker-src 'self' blob:;",
           ]
         end
 
@@ -263,7 +264,7 @@ class Otto
             "form-action 'self';",                     # Restrict form submissions to same origin
             "frame-ancestors 'none';",                 # Prevent site from being embedded in frames
             "manifest-src 'self';",                    # Allow web app manifests from same origin
-            "worker-src 'self' data:;",                # Allow Workers from same origin and data blobs
+            "worker-src 'self' blob:;",                # Allow Workers from same origin and blob: URLs
           ]
         end
       end

--- a/lib/otto/security/csp/policy.rb
+++ b/lib/otto/security/csp/policy.rb
@@ -43,9 +43,14 @@ class Otto
         # @param report_to_url [String, nil] absolute URL configured for the
         #   modern Reporting API; its presence (not its value) toggles the
         #   `report-to <group>` directive (omitted when nil/empty)
+        # @param directive_overrides [Hash, nil] per-directive overrides merged
+        #   into the base set before reporting directives are appended. See
+        #   {.merge_directives} for the accepted shape (replace a directive's
+        #   sources, add a new directive, or remove one with a nil/false value).
         # @return [String] complete CSP policy string
-        def nonce_policy(nonce, development_mode: false, report_uri: nil, report_to_url: nil)
+        def nonce_policy(nonce, development_mode: false, report_uri: nil, report_to_url: nil, directive_overrides: nil)
           directives = development_mode ? development_directives(nonce) : production_directives(nonce)
+          directives = merge_directives(directives, directive_overrides)
           uri_directive = report_uri_directive(report_uri)
           to_directive  = report_to_directive(report_to_url)
           directives += ["#{uri_directive};"] if uri_directive
@@ -86,6 +91,89 @@ class Otto
           return nil if url.nil? || url.empty?
 
           "report-to #{REPORTING_GROUP}"
+        end
+
+        # Merge per-directive overrides into a base directive set.
+        #
+        # This is the customization seam the hardcoded directive sets previously
+        # lacked: a consuming app can adjust ANY directive (e.g. opt into
+        # `worker-src 'self' blob:`) without vendoring the gem. Order is
+        # preserved — an override that matches an existing directive replaces it
+        # in place; an override for a directive not in the base set is appended
+        # after the base directives (before any reporting directives).
+        #
+        # Override values:
+        # - a String  → the directive's source list verbatim, e.g.
+        #   `'worker-src' => "'self' blob:"` yields `worker-src 'self' blob:;`
+        # - an Array   → sources joined with a single space, e.g.
+        #   `%w['self' blob:]`
+        # - `nil`/`false` → REMOVE the directive from the emitted policy
+        #
+        # Directive names are matched case-insensitively (CSP directive names are
+        # case-insensitive) and may be given as Strings or Symbols.
+        #
+        # @param directives [Array<String>] base directive strings, each `;`-terminated
+        # @param overrides [Hash, nil] directive name => source list / nil
+        # @return [Array<String>] merged directive strings, each `;`-terminated
+        def merge_directives(directives, overrides)
+          return directives if overrides.nil? || overrides.empty?
+
+          normalized = normalize_overrides(overrides)
+          consumed   = {}
+
+          merged = directives.filter_map do |directive|
+            name = directive_name(directive)
+            next directive unless normalized.key?(name)
+
+            consumed[name] = true
+            build_directive(name, normalized[name])
+          end
+
+          normalized.each do |name, value|
+            next if consumed[name]
+
+            appended = build_directive(name, value)
+            merged << appended if appended
+          end
+
+          merged
+        end
+
+        # Normalize an overrides hash to lowercased, hyphenated String keys so
+        # lookups are case-insensitive and Symbol/String keys are
+        # interchangeable. Underscores map to hyphens (no CSP directive contains
+        # an underscore) so a Symbol key like `:worker_src` addresses the
+        # `worker-src` directive. Blank keys are dropped.
+        #
+        # @param overrides [Hash]
+        # @return [Hash{String=>Object}]
+        def normalize_overrides(overrides)
+          overrides.each_with_object({}) do |(key, value), acc|
+            name = key.to_s.strip.downcase.tr('_', '-')
+            acc[name] = value unless name.empty?
+          end
+        end
+
+        # The directive name (first token) of a `;`-terminated directive string,
+        # lowercased for case-insensitive matching.
+        #
+        # @param directive [String]
+        # @return [String]
+        def directive_name(directive)
+          directive.to_s.strip.delete_suffix(';').split(/\s+/, 2).first.to_s.downcase
+        end
+
+        # Build a single `;`-terminated directive string from a name and an
+        # override value, or nil when the value signals removal (nil/false).
+        #
+        # @param name [String] directive name
+        # @param value [String, Array, nil, false] source list, or nil/false to remove
+        # @return [String, nil]
+        def build_directive(name, value)
+          return nil if value.nil? || value == false
+
+          sources = Array(value).map { |token| token.to_s.strip }.reject(&:empty?).join(' ')
+          sources.empty? ? "#{name};" : "#{name} #{sources};"
         end
 
         # CSP directives for the development environment.

--- a/spec/otto/security/csp/policy_spec.rb
+++ b/spec/otto/security/csp/policy_spec.rb
@@ -45,6 +45,55 @@ RSpec.describe Otto::Security::CSP::Policy do
     it 'omits reporting directives for nil/blank values' do
       expect(described_class.nonce_policy('N', report_uri: '', report_to_url: nil)).to eq(production)
     end
+
+    it 'is byte-identical when directive_overrides is nil or empty' do
+      expect(described_class.nonce_policy('N', directive_overrides: nil)).to eq(production)
+      expect(described_class.nonce_policy('N', directive_overrides: {})).to eq(production)
+    end
+
+    it 'replaces a directive in place with a String override (preserving order)' do
+      csp = described_class.nonce_policy('N', directive_overrides: { 'worker-src' => "'self' blob:" })
+      expect(csp).to include("worker-src 'self' blob:;")
+      expect(csp).not_to include("worker-src 'self' data:;")
+      expect(csp).to end_with("worker-src 'self' blob:;")
+    end
+
+    it 'accepts an Array source list and a Symbol key (underscore maps to hyphen)' do
+      csp = described_class.nonce_policy('N', directive_overrides: { worker_src: ["'self'", 'blob:'] })
+      expect(csp).to include("worker-src 'self' blob:;")
+      expect(csp).not_to include("worker-src 'self' data:;")
+    end
+
+    it 'appends a directive that is not in the base set' do
+      csp = described_class.nonce_policy('N', directive_overrides: { 'media-src' => "'self'" })
+      expect(csp).to include("media-src 'self';")
+    end
+
+    it 'removes a directive when the override value is nil or false' do
+      csp = described_class.nonce_policy('N', directive_overrides: { 'worker-src' => nil })
+      expect(csp).not_to include('worker-src')
+    end
+
+    it 'appends reporting directives after merged overrides' do
+      csp = described_class.nonce_policy(
+        'N', report_uri: '/r', directive_overrides: { 'worker-src' => "'self' blob:" }
+      )
+      expect(csp).to eq("#{production.sub("worker-src 'self' data:;", "worker-src 'self' blob:;")} report-uri /r;")
+    end
+  end
+
+  describe '.merge_directives' do
+    it 'returns the base set unchanged for nil/empty overrides' do
+      base = ["default-src 'none';", "worker-src 'self' data:;"]
+      expect(described_class.merge_directives(base, nil)).to eq(base)
+      expect(described_class.merge_directives(base, {})).to eq(base)
+    end
+
+    it 'matches directive names case-insensitively' do
+      base = ["worker-src 'self' data:;"]
+      expect(described_class.merge_directives(base, { 'WORKER-SRC' => "'self' blob:" }))
+        .to eq(["worker-src 'self' blob:;"])
+    end
   end
 
   describe '.static_policy' do

--- a/spec/otto/security/csp/policy_spec.rb
+++ b/spec/otto/security/csp/policy_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Otto::Security::CSP::Policy do
     "default-src 'none'; script-src 'nonce-N'; style-src 'self' 'unsafe-inline'; " \
       "connect-src 'self' wss: https:; img-src 'self' data:; font-src 'self'; " \
       "object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; " \
-      "manifest-src 'self'; worker-src 'self' data:;"
+      "manifest-src 'self'; worker-src 'self' blob:;"
   end
 
   describe '.nonce_policy' do
@@ -52,16 +52,16 @@ RSpec.describe Otto::Security::CSP::Policy do
     end
 
     it 'replaces a directive in place with a String override (preserving order)' do
-      csp = described_class.nonce_policy('N', directive_overrides: { 'worker-src' => "'self' blob:" })
-      expect(csp).to include("worker-src 'self' blob:;")
-      expect(csp).not_to include("worker-src 'self' data:;")
-      expect(csp).to end_with("worker-src 'self' blob:;")
+      csp = described_class.nonce_policy('N', directive_overrides: { 'worker-src' => "'self' data:" })
+      expect(csp).to include("worker-src 'self' data:;")
+      expect(csp).not_to include("worker-src 'self' blob:;")
+      expect(csp).to end_with("worker-src 'self' data:;")
     end
 
     it 'accepts an Array source list and a Symbol key (underscore maps to hyphen)' do
-      csp = described_class.nonce_policy('N', directive_overrides: { worker_src: ["'self'", 'blob:'] })
-      expect(csp).to include("worker-src 'self' blob:;")
-      expect(csp).not_to include("worker-src 'self' data:;")
+      csp = described_class.nonce_policy('N', directive_overrides: { worker_src: ["'self'", 'data:'] })
+      expect(csp).to include("worker-src 'self' data:;")
+      expect(csp).not_to include("worker-src 'self' blob:;")
     end
 
     it 'appends a directive that is not in the base set' do
@@ -76,9 +76,9 @@ RSpec.describe Otto::Security::CSP::Policy do
 
     it 'appends reporting directives after merged overrides' do
       csp = described_class.nonce_policy(
-        'N', report_uri: '/r', directive_overrides: { 'worker-src' => "'self' blob:" }
+        'N', report_uri: '/r', directive_overrides: { 'worker-src' => "'self' data:" }
       )
-      expect(csp).to eq("#{production.sub("worker-src 'self' data:;", "worker-src 'self' blob:;")} report-uri /r;")
+      expect(csp).to eq("#{production.sub("worker-src 'self' blob:;", "worker-src 'self' data:;")} report-uri /r;")
     end
   end
 

--- a/spec/otto/security/csp/policy_spec.rb
+++ b/spec/otto/security/csp/policy_spec.rb
@@ -94,6 +94,24 @@ RSpec.describe Otto::Security::CSP::Policy do
       expect(described_class.merge_directives(base, { 'WORKER-SRC' => "'self' blob:" }))
         .to eq(["worker-src 'self' blob:;"])
     end
+
+    it 'rejects a source token that would inject another directive' do
+      base = ["worker-src 'self' data:;"]
+      expect { described_class.merge_directives(base, { 'worker-src' => "'self'; script-src *" }) }
+        .to raise_error(ArgumentError, /contains a ';'/)
+    end
+
+    it 'rejects a source token containing a newline' do
+      base = ["worker-src 'self' data:;"]
+      expect { described_class.merge_directives(base, { 'worker-src' => "'self'\nscript-src *" }) }
+        .to raise_error(ArgumentError, /newline/)
+    end
+
+    it 'rejects a directive name containing a separator' do
+      base = ["default-src 'none';"]
+      expect { described_class.merge_directives(base, { 'media-src; script-src *' => "'self'" }) }
+        .to raise_error(ArgumentError)
+    end
   end
 
   describe '.static_policy' do

--- a/spec/otto/security/csp_config_spec.rb
+++ b/spec/otto/security/csp_config_spec.rb
@@ -177,6 +177,56 @@ RSpec.describe Otto::Security::Config, 'CSP reporting' do
     end
   end
 
+  describe 'CSP directive overrides' do
+    it 'defaults to an empty override set with byte-identical nonce output' do
+      config.enable_csp_with_nonce!
+      expect(config.csp_directive_overrides).to eq({})
+      expect(config.generate_nonce_csp('N')).to end_with("worker-src 'self' data:;")
+    end
+
+    it 'accepts directive overrides through enable_csp_with_nonce!' do
+      config.enable_csp_with_nonce!(directives: { 'worker-src' => "'self' blob:" })
+      csp = config.generate_nonce_csp('N')
+      expect(csp).to include("worker-src 'self' blob:;")
+      expect(csp).not_to include("worker-src 'self' data:;")
+    end
+
+    it 'applies overrides in development mode too' do
+      config.enable_csp_with_nonce!(directives: { 'worker-src' => "'self' blob:" })
+      expect(config.generate_nonce_csp('N', development_mode: true)).to include("worker-src 'self' blob:;")
+    end
+
+    it 'merges overrides alongside reporting directives' do
+      config.enable_csp_with_nonce!(directives: { 'worker-src' => "'self' blob:" })
+      config.csp_report_uri = '/_/csp-report'
+      csp = config.generate_nonce_csp('N')
+      expect(csp).to include("worker-src 'self' blob:;")
+      expect(csp).to include('report-uri /_/csp-report;')
+    end
+
+    it 'replaces the override set via csp_directive_overrides=' do
+      config.enable_csp_with_nonce!
+      config.csp_directive_overrides = { 'worker-src' => "'self' blob:" }
+      expect(config.generate_nonce_csp('N')).to include("worker-src 'self' blob:;")
+    end
+
+    it 'accumulates overrides via merge_csp_directives' do
+      config.enable_csp_with_nonce!(directives: { 'worker-src' => "'self' blob:" })
+      config.merge_csp_directives('media-src' => "'self'")
+      csp = config.generate_nonce_csp('N')
+      expect(csp).to include("worker-src 'self' blob:;")
+      expect(csp).to include("media-src 'self';")
+    end
+
+    it 'raises when overrides are set on a frozen configuration' do
+      config.deep_freeze!
+      expect { config.csp_directive_overrides = { 'worker-src' => "'self' blob:" } }
+        .to raise_error(FrozenError)
+      expect { config.merge_csp_directives('worker-src' => "'self' blob:") }
+        .to raise_error(FrozenError)
+    end
+  end
+
   describe '#on_csp_violation / #dispatch_csp_violation' do
     let(:report) { Otto::Security::CSP::Report.from_raw('violated-directive' => 'script-src') }
 

--- a/spec/otto/security/csp_config_spec.rb
+++ b/spec/otto/security/csp_config_spec.rb
@@ -232,6 +232,32 @@ RSpec.describe Otto::Security::Config, 'CSP reporting' do
       expect(config.csp_directive_overrides.keys).to eq(['worker-src'])
     end
 
+    it 'warns when a script-src override is stored (nonce protection is voided)' do
+      expect(Otto).to receive(:structured_log)
+        .with(:warn, /script-src override/i, hash_including(directive: 'script-src'))
+      config.enable_csp_with_nonce!(directives: { 'script-src' => "'self' 'unsafe-inline'" })
+    end
+
+    it 'warns for a script-src override given with a Symbol key' do
+      expect(Otto).to receive(:structured_log)
+        .with(:warn, /nonce/i, hash_including(directive: 'script-src'))
+      config.csp_directive_overrides = { script_src: "'self'" }
+    end
+
+    it 'warns only once across repeated script-src overrides' do
+      expect(Otto).to receive(:structured_log)
+        .with(:warn, anything, hash_including(directive: 'script-src')).once
+      config.merge_csp_directives('script-src' => "'self'")
+      config.merge_csp_directives('script-src' => "'self' 'unsafe-inline'")
+    end
+
+    it 'does not warn for overrides that leave script-src untouched' do
+      expect(Otto).not_to receive(:structured_log)
+        .with(:warn, anything, hash_including(directive: 'script-src'))
+      config.enable_csp_with_nonce!(directives: { 'worker-src' => "'self' blob:" })
+      config.merge_csp_directives('media-src' => "'self'")
+    end
+
     it 'raises when overrides are set on a frozen configuration' do
       config.deep_freeze!
       expect { config.csp_directive_overrides = { 'worker-src' => "'self' blob:" } }

--- a/spec/otto/security/csp_config_spec.rb
+++ b/spec/otto/security/csp_config_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Otto::Security::Config, 'CSP reporting' do
 
     it 'is byte-identical to the historical output when no report URI is set' do
       expect(config.generate_nonce_csp('N')).not_to include('report-uri')
-      expect(config.generate_nonce_csp('N')).to end_with("worker-src 'self' data:;")
+      expect(config.generate_nonce_csp('N')).to end_with("worker-src 'self' blob:;")
     end
 
     it 'appends a report-uri directive when a report URI is set' do
@@ -181,49 +181,49 @@ RSpec.describe Otto::Security::Config, 'CSP reporting' do
     it 'defaults to an empty override set with byte-identical nonce output' do
       config.enable_csp_with_nonce!
       expect(config.csp_directive_overrides).to eq({})
-      expect(config.generate_nonce_csp('N')).to end_with("worker-src 'self' data:;")
+      expect(config.generate_nonce_csp('N')).to end_with("worker-src 'self' blob:;")
     end
 
     it 'accepts directive overrides through enable_csp_with_nonce!' do
-      config.enable_csp_with_nonce!(directives: { 'worker-src' => "'self' blob:" })
+      config.enable_csp_with_nonce!(directives: { 'worker-src' => "'self' data:" })
       csp = config.generate_nonce_csp('N')
-      expect(csp).to include("worker-src 'self' blob:;")
-      expect(csp).not_to include("worker-src 'self' data:;")
+      expect(csp).to include("worker-src 'self' data:;")
+      expect(csp).not_to include("worker-src 'self' blob:;")
     end
 
     it 'applies overrides in development mode too' do
-      config.enable_csp_with_nonce!(directives: { 'worker-src' => "'self' blob:" })
-      expect(config.generate_nonce_csp('N', development_mode: true)).to include("worker-src 'self' blob:;")
+      config.enable_csp_with_nonce!(directives: { 'worker-src' => "'self' data:" })
+      expect(config.generate_nonce_csp('N', development_mode: true)).to include("worker-src 'self' data:;")
     end
 
     it 'merges overrides alongside reporting directives' do
-      config.enable_csp_with_nonce!(directives: { 'worker-src' => "'self' blob:" })
+      config.enable_csp_with_nonce!(directives: { 'worker-src' => "'self' data:" })
       config.csp_report_uri = '/_/csp-report'
       csp = config.generate_nonce_csp('N')
-      expect(csp).to include("worker-src 'self' blob:;")
+      expect(csp).to include("worker-src 'self' data:;")
       expect(csp).to include('report-uri /_/csp-report;')
     end
 
     it 'replaces the override set via csp_directive_overrides=' do
       config.enable_csp_with_nonce!
-      config.csp_directive_overrides = { 'worker-src' => "'self' blob:" }
-      expect(config.generate_nonce_csp('N')).to include("worker-src 'self' blob:;")
+      config.csp_directive_overrides = { 'worker-src' => "'self' data:" }
+      expect(config.generate_nonce_csp('N')).to include("worker-src 'self' data:;")
     end
 
     it 'accumulates overrides via merge_csp_directives' do
-      config.enable_csp_with_nonce!(directives: { 'worker-src' => "'self' blob:" })
+      config.enable_csp_with_nonce!(directives: { 'worker-src' => "'self' data:" })
       config.merge_csp_directives('media-src' => "'self'")
       csp = config.generate_nonce_csp('N')
-      expect(csp).to include("worker-src 'self' blob:;")
+      expect(csp).to include("worker-src 'self' data:;")
       expect(csp).to include("media-src 'self';")
     end
 
     it 'normalizes keys on store so mixed key styles do not accumulate duplicates' do
-      config.merge_csp_directives('WORKER-SRC' => "'self' data:")
-      config.merge_csp_directives(worker_src: "'self' blob:")
+      config.merge_csp_directives('WORKER-SRC' => "'self' blob:")
+      config.merge_csp_directives(worker_src: "'self' data:")
       expect(config.csp_directive_overrides.keys).to eq(['worker-src'])
-      expect(config.csp_directive_overrides['worker-src']).to eq("'self' blob:")
-      expect(config.generate_nonce_csp('N')).to include("worker-src 'self' blob:;")
+      expect(config.csp_directive_overrides['worker-src']).to eq("'self' data:")
+      expect(config.generate_nonce_csp('N')).to include("worker-src 'self' data:;")
     end
 
     it 'normalizes keys stored via csp_directive_overrides=' do

--- a/spec/otto/security/csp_config_spec.rb
+++ b/spec/otto/security/csp_config_spec.rb
@@ -218,6 +218,20 @@ RSpec.describe Otto::Security::Config, 'CSP reporting' do
       expect(csp).to include("media-src 'self';")
     end
 
+    it 'normalizes keys on store so mixed key styles do not accumulate duplicates' do
+      config.merge_csp_directives('WORKER-SRC' => "'self' data:")
+      config.merge_csp_directives(worker_src: "'self' blob:")
+      expect(config.csp_directive_overrides.keys).to eq(['worker-src'])
+      expect(config.csp_directive_overrides['worker-src']).to eq("'self' blob:")
+      expect(config.generate_nonce_csp('N')).to include("worker-src 'self' blob:;")
+    end
+
+    it 'normalizes keys stored via csp_directive_overrides=' do
+      config.enable_csp_with_nonce!
+      config.csp_directive_overrides = { worker_src: "'self' blob:" }
+      expect(config.csp_directive_overrides.keys).to eq(['worker-src'])
+    end
+
     it 'raises when overrides are set on a frozen configuration' do
       config.deep_freeze!
       expect { config.csp_directive_overrides = { 'worker-src' => "'self' blob:" } }


### PR DESCRIPTION
## Summary

Resolves #201 in full — both halves of the issue's recommended fix:

1. **Corrects the default `worker-src` token** from `data:` to `blob:` in both nonce directive sets, so worker-spawning libraries work out of the box.
2. **Adds a per-directive override/merge API** so consuming applications can override, add, or remove any CSP directive without vendoring the gem.

## Key Changes

### Default `worker-src` corrected to `blob:`

Both the production and development nonce directive sets now emit `worker-src 'self' blob:;` instead of `worker-src 'self' data:;`. Browsers instantiate Web Workers from `blob:` URLs (`new Worker(URL.createObjectURL(...))`) — the mechanism used by Sentry Replay, VueUse `useWebWorkerFn`, bundler-emitted workers, and WASM loaders — not from `data:` URLs. The old default blocked mainstream worker libraries while granting a token real libraries don't use, and one that is riskier under content injection (an attacker fully controls a `data:` URL's content, whereas a `blob:` URL must be minted by same-origin script already gated by the `script-src` nonce).

Apps that genuinely rely on `data:` workers can restore them in one line via the new override API:

```ruby
config.enable_csp_with_nonce!(directives: { worker_src: "'self' data: blob:" })
```

### Per-directive override API

- **New `merge_directives` method** in `Otto::Security::CSP::Policy` that merges per-directive overrides into base directive sets. Supports:
  - String values to replace a directive's source list
  - Array values (joined with spaces)
  - `nil`/`false` values to remove a directive
  - Case-insensitive directive name matching
  - Symbol keys with underscores mapping to hyphens (e.g., `worker_src` → `worker-src`)
- **Enhanced `nonce_policy` method** to accept a `directive_overrides` parameter that merges into the base directive set before reporting directives are appended
- **New configuration methods** in `Otto::Security::Config`:
  - `enable_csp_with_nonce!(directives: {})` accepts a `directives:` parameter for inline overrides
  - `csp_directive_overrides=` to replace the override set wholesale
  - `merge_csp_directives` to accumulate overrides incrementally

### Hardening (from review feedback)

- **CSP-injection guard**: directive names and source tokens containing `;`, newline, or carriage return raise `ArgumentError` instead of silently injecting extra directives — a footgun when overrides come from env/config files
- **Keys normalized on store**: `csp_directive_overrides=` / `merge_csp_directives` normalize keys, so mixed key styles (`'WORKER-SRC'`, `:worker_src`) never accumulate logically-duplicate entries
- **`enable_csp_with_nonce!` reordered** to merge directives before toggling state, so a bad `:directives` argument can't leave the config half-updated
- **`script-src` override warning**: the per-request nonce cannot be reproduced in a static override, so overriding `script-src` under nonce mode disables nonce protection — a one-time warning is logged via `Otto.structured_log`, and the docs carry a matching `@note`

## Implementation Details

- Output is byte-identical to the (updated) default policy when no overrides are configured
- Overrides that match existing directives replace them in place (preserving order); new directives are appended after base directives but before reporting directives
- Reporting directives (`report-uri`, `report-to`) are always appended after overrides, so an override cannot suppress reporting
- Comprehensive test coverage: override behaviors, injection rejection, key normalization, warning semantics, frozen-config guards (full suite: 1809 examples, 0 failures)

https://claude.ai/code/session_015A47xpg5seFEMCHMdG2r95