### PR TITLE
Fix FrozenError on static file serving after configuration freeze

### DIFF
--- a/changelog.d/20260710_090000_ops_frozen_routes_static_fix.rst
+++ b/changelog.d/20260710_090000_ops_frozen_routes_static_fix.rst
@@ -1,0 +1,13 @@
+Fixed
+-----
+
+- Dynamic static-file serving no longer raises ``FrozenError`` in production
+  (delano/otto#185). ``freeze_configuration!`` deep-froze ``@routes_static``
+  along with the rest of the routing state, but lazy static-file discovery
+  writes into ``routes_static[:GET]`` at request time — after the lazy
+  first-request freeze has already run — so the first request for any
+  as-yet-uncached asset raised ``FrozenError`` and was turned into a 500. The
+  failure was masked in the test suite because the lazy freeze is skipped
+  under RSpec. ``routes_static[:GET]`` is now a ``Concurrent::Map`` and is
+  excluded from the deep freeze, so it stays writable — and safe under
+  concurrent request threads — after configuration is otherwise locked down.

--- a/lib/otto.rb
+++ b/lib/otto.rb
@@ -2,6 +2,7 @@
 #
 # frozen_string_literal: true
 
+require 'concurrent'
 require 'json'
 require 'logger'
 require 'securerandom'
@@ -171,7 +172,16 @@ class Otto
   private
 
   def initialize_core_state
-    @routes_static     = { GET: {} }
+    # The GET cache is a Concurrent::Map, not a plain Hash: lazy static-file
+    # discovery (Core::Router#handle_request, Core::FileSafety#add_static_path)
+    # writes into it at request time, after freeze_configuration! has already
+    # deep-frozen the rest of the routing state. Deep-freezing this cache too
+    # would turn every as-yet-uncached static file request into a 500
+    # (FrozenError) in production (issue #185), so it is intentionally excluded
+    # from deep_freeze_value in Configuration#freeze_configuration! and kept as
+    # a structure that is both mutable post-freeze and safe under concurrent
+    # request threads.
+    @routes_static     = { GET: Concurrent::Map.new }
     @routes            = { GET: [] }
     @routes_literal    = { GET: {} }
     @route_definitions = {}

--- a/lib/otto/core/configuration.rb
+++ b/lib/otto/core/configuration.rb
@@ -285,9 +285,13 @@ class Otto
         # @routes_static is intentionally NOT deep-frozen: its :GET entry is a
         # Concurrent::Map that lazy static-file discovery writes into at
         # request time (Core::Router#handle_request, Core::FileSafety#add_static_path),
-        # after this method has already run. Freezing it would turn the first
-        # request for any as-yet-uncached static file into a FrozenError / 500
-        # in production (issue #185).
+        # after this method has already run. Deep-freezing it would turn the
+        # first request for any as-yet-uncached static file into a
+        # FrozenError / 500 in production (issue #185). The outer hash is
+        # still shallow-frozen so its verb-key structure (currently just
+        # :GET) can't be altered post-freeze, while the Concurrent::Map value
+        # stays writable.
+        @routes_static.freeze if @routes_static && !@routes_static.frozen?
         deep_freeze_value(@route_definitions) if @route_definitions
         deep_freeze_value(@routes_by_definition) if @routes_by_definition
 

--- a/lib/otto/core/configuration.rb
+++ b/lib/otto/core/configuration.rb
@@ -282,7 +282,12 @@ class Otto
         # Deep freeze route structures (prevent modification of nested hashes/arrays)
         deep_freeze_value(@routes) if @routes
         deep_freeze_value(@routes_literal) if @routes_literal
-        deep_freeze_value(@routes_static) if @routes_static
+        # @routes_static is intentionally NOT deep-frozen: its :GET entry is a
+        # Concurrent::Map that lazy static-file discovery writes into at
+        # request time (Core::Router#handle_request, Core::FileSafety#add_static_path),
+        # after this method has already run. Freezing it would turn the first
+        # request for any as-yet-uncached static file into a FrozenError / 500
+        # in production (issue #185).
         deep_freeze_value(@route_definitions) if @route_definitions
         deep_freeze_value(@routes_by_definition) if @routes_by_definition
 

--- a/lib/otto/core/router.rb
+++ b/lib/otto/core/router.rb
@@ -138,7 +138,7 @@ class Otto
         # for them. Literal lookup keeps '' — it already keys root that way.
         dispatch_path = path_info_clean.empty? ? '/' : path_info_clean
 
-        if static_route && http_verb == :GET && routes_static[:GET].member?(base_path)
+        if static_route && http_verb == :GET && routes_static[:GET].key?(base_path)
           Otto.structured_log(:debug, 'Route matched',
             Otto::LoggingHelpers.request_context(env).merge(
               type: 'static_cached',

--- a/spec/otto/static_file_freezing_spec.rb
+++ b/spec/otto/static_file_freezing_spec.rb
@@ -1,0 +1,48 @@
+# spec/otto/static_file_freezing_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Regression coverage for issue #185: lazy static-file discovery
+# (Core::Router#handle_request / Core::FileSafety#add_static_path) writes into
+# routes_static[:GET] at request time, but freeze_configuration! runs before
+# any request is served. Under RSpec that freeze is skipped for #call, so
+# these specs freeze explicitly to exercise the path the way production does
+# (lazy freeze on the first real request).
+RSpec.describe Otto, 'static file serving after configuration freeze' do
+  subject(:otto) { described_class.new(nil, { public: '/tmp/test_static_freezing' }) }
+
+  before do
+    Dir.mkdir('/tmp/test_static_freezing') unless Dir.exist?('/tmp/test_static_freezing')
+    File.write('/tmp/test_static_freezing/asset.txt', 'asset content')
+  end
+
+  after do
+    FileUtils.rm_rf('/tmp/test_static_freezing') if Dir.exist?('/tmp/test_static_freezing')
+  end
+
+  it 'serves an uncached static file without raising FrozenError' do
+    otto.freeze_configuration!
+    expect(otto.frozen_configuration?).to be true
+    expect(otto.routes_static[:GET].key?('/asset.txt')).to be false
+
+    status, = otto.call(Rack::MockRequest.env_for('/asset.txt'))
+
+    expect(status).to eq(200)
+  end
+
+  it 'caches the base path in routes_static[:GET] for subsequent requests' do
+    otto.freeze_configuration!
+
+    otto.call(Rack::MockRequest.env_for('/asset.txt'))
+
+    expect(otto.routes_static[:GET].key?('/asset.txt')).to be true
+  end
+
+  it 'does not deep-freeze routes_static, so the request-time cache write succeeds' do
+    otto.freeze_configuration!
+
+    expect { otto.routes_static[:GET]['/manual.txt'] = '/manual.txt' }.not_to raise_error
+  end
+end

--- a/spec/otto/static_file_freezing_spec.rb
+++ b/spec/otto/static_file_freezing_spec.rb
@@ -45,4 +45,26 @@ RSpec.describe Otto, 'static file serving after configuration freeze' do
 
     expect { otto.routes_static[:GET]['/manual.txt'] = '/manual.txt' }.not_to raise_error
   end
+
+  it 'survives concurrent requests for distinct uncached files without error or lost writes' do
+    file_count = 50
+    file_count.times { |i| File.write("/tmp/test_static_freezing/concurrent_#{i}.txt", "content #{i}") }
+    otto.freeze_configuration!
+
+    errors = Queue.new
+    threads = Array.new(file_count) do |i|
+      Thread.new do
+        status, = otto.call(Rack::MockRequest.env_for("/concurrent_#{i}.txt"))
+        errors << "unexpected status #{status} for concurrent_#{i}.txt" unless status == 200
+      rescue StandardError => e
+        errors << "#{e.class}: #{e.message}"
+      end
+    end
+    threads.each(&:join)
+
+    expect(errors).to be_empty
+    file_count.times do |i|
+      expect(otto.routes_static[:GET].key?("/concurrent_#{i}.txt")).to be true
+    end
+  end
 end

--- a/spec/otto/static_file_freezing_spec.rb
+++ b/spec/otto/static_file_freezing_spec.rb
@@ -46,6 +46,13 @@ RSpec.describe Otto, 'static file serving after configuration freeze' do
     expect { otto.routes_static[:GET]['/manual.txt'] = '/manual.txt' }.not_to raise_error
   end
 
+  it 'shallow-freezes the outer routes_static hash so its verb-key structure cannot change' do
+    otto.freeze_configuration!
+
+    expect(otto.routes_static).to be_frozen
+    expect { otto.routes_static[:DELETE] = {} }.to raise_error(FrozenError)
+  end
+
   it 'survives concurrent requests for distinct uncached files without error or lost writes' do
     file_count = 50
     file_count.times { |i| File.write("/tmp/test_static_freezing/concurrent_#{i}.txt", "content #{i}") }


### PR DESCRIPTION
## Summary
Fixes issue #185 where serving uncached static files in production raised `FrozenError` after `freeze_configuration!` was called. The configuration freeze was deep-freezing the `@routes_static` hash, but lazy static-file discovery writes into `routes_static[:GET]` at request time, causing the first request for any uncached asset to fail.

## Key Changes
- **lib/otto.rb**: Changed `@routes_static[:GET]` from a plain `Hash` to a `Concurrent::Map` to support both post-freeze mutations and thread-safe concurrent access
- **lib/otto/core/configuration.rb**: Removed deep-freezing of `@routes_static` to allow the `Concurrent::Map` to remain writable after configuration is locked down
- **lib/otto/core/router.rb**: Updated route lookup from `member?` to `key?` for compatibility with `Concurrent::Map` API
- **spec/otto/static_file_freezing_spec.rb**: Added comprehensive regression tests covering:
  - Serving uncached static files after freeze without raising `FrozenError`
  - Caching behavior for subsequent requests
  - Shallow freeze allowing request-time cache writes
  - Concurrent request handling for multiple distinct files

## Implementation Details
The fix uses `Concurrent::Map` instead of a plain `Hash` for the static file cache because it:
1. Remains mutable after the configuration is frozen
2. Provides thread-safe concurrent access without explicit locking
3. Allows lazy population of the cache at request time, which is the intended behavior for dynamic static file discovery

The `@routes_static` hash itself is still frozen (shallow freeze), but its `:GET` entry is excluded from deep-freezing, preserving the ability to add new cached routes during request handling.

https://claude.ai/code/session_015A47xpg5seFEMCHMdG2r95