### PR TITLE
Add configurable geo-location resolution with database fallback

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -77,12 +77,6 @@ Metrics/ModuleLength:
   Max: 250
   CountAsOne: ["method_call"]
 
-# Keyword arguments are self-documenting at the call site, so they don't incur
-# the positional-argument readability cost this cop guards against. Config
-# methods like configure_ip_privacy legitimately take many keyword options.
-Metrics/ParameterLists:
-  CountKeywordArgs: false
-
 Performance/Size:
   Enabled: true
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -77,6 +77,12 @@ Metrics/ModuleLength:
   Max: 250
   CountAsOne: ["method_call"]
 
+# Keyword arguments are self-documenting at the call site, so they don't incur
+# the positional-argument readability cost this cop guards against. Config
+# methods like configure_ip_privacy legitimately take many keyword options.
+Metrics/ParameterLists:
+  CountKeywordArgs: false
+
 Performance/Size:
   Enabled: true
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ end
 group :development, :test, optional: true do
   # Keep gems that need to be in both environments
   gem 'json_schemer'
+  gem 'maxmind-db', '~> 1.2' # Optional geo DB reader; exercised by geo specs
   gem 'rack-attack'
   gem 'reek', '~> 6.5'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
     loofah (2.25.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
+    maxmind-db (1.4.0)
     minitest (5.26.0)
     nokogiri (1.19.4-aarch64-linux-gnu)
       racc (~> 1.4)
@@ -218,6 +219,7 @@ DEPENDENCIES
   debug
   json_schemer
   kramdown
+  maxmind-db (~> 1.2)
   otto!
   rack-attack
   rack-test

--- a/README.md
+++ b/README.md
@@ -231,7 +231,16 @@ app = Otto.new("./routes")
 # IP hashing: daily-rotating hashes enable analytics without tracking
 ```
 
-Private and localhost IPs are exempted by default for development convenience, but this behavior can be customized via `configure_ip_privacy()` method. Geolocation uses CDN headers (Cloudflare, AWS, etc.) with fallback to IP ranges—no external services required. See [CLAUDE.md](CLAUDE.md) for detailed configuration options.
+Private and localhost IPs are exempted by default for development convenience, but this behavior can be customized via `configure_ip_privacy()` method. Geolocation checks CDN headers (Cloudflare, AWS, Vercel, etc.) first, then an optional local country database—no external services required. You can name a trusted header to check first, plug in a MaxMind-format `.mmdb` file for an offline fallback, or bring your own reader:
+
+```ruby
+otto.configure_ip_privacy(
+  geo_header: 'X-Client-Country',        # trusted app header, checked first
+  geo_db_path: 'data/country.mmdb'       # offline fallback (needs the maxmind-db gem)
+)
+```
+
+Geo headers are only trusted for requests that arrive via a configured trusted proxy (they are client-spoofable otherwise), the database is looked up on the already-masked IP, and `configure_ip_privacy(geo: false)` disables geo entirely. See [CLAUDE.md](CLAUDE.md) for detailed configuration options.
 
 ## Internationalization Support
 

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ otto.configure_ip_privacy(
 )
 ```
 
-Geo headers are only trusted for requests that arrive via a configured trusted proxy (they are client-spoofable otherwise), the database is looked up on the already-masked IP, and `configure_ip_privacy(geo: false)` disables geo entirely. See [CLAUDE.md](CLAUDE.md) for detailed configuration options.
+Geo headers are only trusted for requests that arrive via a configured trusted proxy (they are client-spoofable otherwise), the database is looked up on the already-masked IP, and `configure_ip_privacy(geo: false)` disables geo entirely. See [AGENTS.md](AGENTS.md) for detailed configuration options.
 
 ## Internationalization Support
 
@@ -366,7 +366,7 @@ gem install otto
 
 ## Documentation
 
-- **[CLAUDE.md](CLAUDE.md)** - Comprehensive developer guidance covering authentication architecture, configuration freezing, IP privacy, structured logging, and multi-app patterns
+- **[AGENTS.md](AGENTS.md)** - Comprehensive developer guidance covering authentication architecture, configuration freezing, IP privacy, structured logging, and multi-app patterns
 - **[docs/](docs/)** - Technical guides and migration guides
 - **[CHANGELOG.rst](CHANGELOG.rst)** - Version history, breaking changes, and upgrade notes
 

--- a/changelog.d/20260715_geo_country_header_source.rst
+++ b/changelog.d/20260715_geo_country_header_source.rst
@@ -24,10 +24,15 @@ Changed
   the masked IP (and masked env); direct ``GeoResolver.resolve`` callers are
   unchanged. (#206)
 
-- A configured geo database is authoritative: a lookup miss (or an unusable
-  result) resolves to ``'**'`` rather than falling back to the built-in
-  best-effort IP-range table, which is only consulted when no database is
-  configured. (#206)
+Removed
+-------
+
+- The built-in ``KNOWN_RANGES`` IP-range guess table (and ``detect_by_range``).
+  Geo resolution is now honest: when no header, custom resolver, or database
+  resolves a country, the result is ``'**'`` (unknown) rather than a guess from
+  a hardcoded ~14-entry table that mislabeled whole cloud regions. Configure a
+  database or an edge header for real geo-location. Callers that relied on the
+  table (e.g. ``8.8.8.8`` -> ``US``) now get ``'**'``. (#206)
 
 Security
 --------

--- a/changelog.d/20260715_geo_country_header_source.rst
+++ b/changelog.d/20260715_geo_country_header_source.rst
@@ -5,11 +5,10 @@ Added
   ``geo_header:`` — a trusted, app-configured request header checked *before*
   the built-in CDN headers (e.g. ``geo_header: 'X-Client-Country'``);
   ``geo_db_path:`` — a MaxMind-format ``.mmdb`` country database giving an
-  offline IP->country fallback (looked up on the masked IP; needs the optional
-  ``maxmind-db`` gem); and ``geo_db_reader:`` — bring your own reader (any
-  object responding to ``#get``), keeping the reader/data-source choice
-  independent of Otto. A bad ``geo_db_path`` fails at boot, not per-request.
-  (#206)
+  offline IP->country fallback (needs the optional ``maxmind-db`` gem); and
+  ``geo_db_reader:`` — bring your own reader (any object responding to
+  ``#get``), keeping the reader/data-source choice independent of Otto. A bad
+  ``geo_db_path`` fails at boot, not per-request. (#206)
 
 - ``X-Vercel-IP-Country`` is now recognized among the built-in CDN/provider
   geo headers. (#206)
@@ -17,25 +16,35 @@ Added
 Changed
 -------
 
-- Geo resolution now runs on the privacy-masked IP, so the unmasked address
-  never reaches the resolver (custom resolver or database). Country-level
+- Geo resolution now runs against a privacy-masked view — the masked IP and an
+  env with the IP-bearing headers masked — so the unmasked address never
+  reaches a custom resolver or the database, by argument or via env. Country
   networks are >= /24, so /24-masked results are identical at the default
-  masking level. Custom resolvers invoked through the middleware now receive
-  the masked IP. (#206)
+  masking level. A custom resolver invoked through the middleware now receives
+  the masked IP (and masked env); direct ``GeoResolver.resolve`` callers are
+  unchanged. (#206)
+
+- A configured geo database is authoritative: a lookup miss (or an unusable
+  result) resolves to ``'**'`` rather than falling back to the built-in
+  best-effort IP-range table, which is only consulted when no database is
+  configured. (#206)
 
 Security
 --------
 
 - Geo headers (``CF-IPCountry`` and friends, plus any configured
-  ``geo_header``) are now ignored for a request that did not arrive via a
-  configured trusted proxy — every geo header is client-spoofable unless you
-  are actually behind that CDN. When no trusted proxies are configured,
-  behavior is unchanged. (#206)
+  ``geo_header``) are ignored unless Otto can trust their origin: honored only
+  for a request that arrived via a configured trusted proxy (CIDR mode); never
+  trusted in count-based depth mode, where the header-setting hop can't be
+  verified as a geo-CDN (resolution falls to the local database). When no
+  trusted proxies are configured, behavior is unchanged. Every geo header is
+  client-spoofable unless you are actually behind that CDN. (#206)
 
 AI Assistance
 -------------
 
 - Configurable geo-header source and local IP->country database fallback
-  designed and implemented with AI assistance, including test coverage for
-  header precedence, spoofing, IPv6, ``geo: false``, and boot-time validation.
-  (#206)
+  designed and implemented with AI assistance, including adversarial review and
+  test coverage for header precedence, spoofing, depth-mode trust, IPv6,
+  ``geo: false``, custom-resolver sealing, boot-time validation, and the real
+  ``maxmind-db`` reader against a generated fixture. (#206)

--- a/changelog.d/20260715_geo_country_header_source.rst
+++ b/changelog.d/20260715_geo_country_header_source.rst
@@ -38,12 +38,17 @@ Security
 --------
 
 - Geo headers (``CF-IPCountry`` and friends, plus any configured
-  ``geo_header``) are ignored unless Otto can trust their origin: honored only
-  for a request that arrived via a configured trusted proxy (CIDR mode); never
-  trusted in count-based depth mode, where the header-setting hop can't be
-  verified as a geo-CDN (resolution falls to the local database). When no
-  trusted proxies are configured, behavior is unchanged. Every geo header is
-  client-spoofable unless you are actually behind that CDN. (#206)
+  ``geo_header``) are now trusted ONLY for a request that demonstrably arrived
+  via a configured CIDR trusted proxy. Every geo header is client-spoofable
+  unless you are actually behind the CDN that sets it, so an unverifiable origin
+  is not trusted: count-based depth mode (the header-setting hop can't be
+  verified as a geo-CDN) and — a behavior change — deployments with **no**
+  trusted-proxy configuration. Previously any client could pick its own country
+  by sending ``CF-IPCountry``/``X-Client-Country``. **Migration:** to keep
+  header-based geo, configure ``trusted_proxies`` (or ``trusted_proxy_depth``)
+  so Otto can verify the proxy origin, or set ``geo_db_path`` for a local
+  database; otherwise resolution now returns ``'**'`` for header-only setups.
+  (#206)
 
 Fixed
 -----

--- a/changelog.d/20260715_geo_country_header_source.rst
+++ b/changelog.d/20260715_geo_country_header_source.rst
@@ -45,10 +45,11 @@ Security
   verified as a geo-CDN) and — a behavior change — deployments with **no**
   trusted-proxy configuration. Previously any client could pick its own country
   by sending ``CF-IPCountry``/``X-Client-Country``. **Migration:** to keep
-  header-based geo, configure ``trusted_proxies`` (or ``trusted_proxy_depth``)
-  so Otto can verify the proxy origin, or set ``geo_db_path`` for a local
-  database; otherwise resolution now returns ``'**'`` for header-only setups.
-  (#206)
+  header-based geo, configure ``trusted_proxies`` (CIDR matchers) so Otto can
+  verify the proxy origin. Count-based ``trusted_proxy_depth`` does NOT enable
+  header trust — the header-setting hop can't be verified as a geo-CDN — so
+  depth-mode and header-only setups should set ``geo_db_path`` for a local
+  database instead. Otherwise resolution now returns ``'**'``. (#206)
 
 Fixed
 -----

--- a/changelog.d/20260715_geo_country_header_source.rst
+++ b/changelog.d/20260715_geo_country_header_source.rst
@@ -48,12 +48,15 @@ Security
 Fixed
 -----
 
-- IP privacy now masks the RFC 7239 ``Forwarded`` header (``HTTP_FORWARDED``),
+- IP privacy now redacts the RFC 7239 ``Forwarded`` header (``HTTP_FORWARDED``),
   which Otto reads as an authoritative client-IP source in count-based depth
-  mode. Previously it was left intact while ``X-Forwarded-For`` and friends
-  were masked, so downstream code (and, before the geo seal, a custom geo
-  resolver) could still read the real client IP from its ``for=`` token. It is
-  now rewritten to a valid Forwarded value holding only the masked IP. (#206)
+  mode. Previously it was left intact while ``X-Forwarded-For`` and friends were
+  masked, so downstream code (and, before the geo seal, a custom geo resolver)
+  could read the real client IP from its ``for=`` token. Only the ``for=``
+  value is now replaced with the masked IP; ``proto=``/``host=``/``by=`` and the
+  header structure are preserved. When no client IP can be resolved (no usable
+  ``REMOTE_ADDR``), the forwarded headers are dropped rather than left to leak a
+  raw address. (#206)
 
 AI Assistance
 -------------

--- a/changelog.d/20260715_geo_country_header_source.rst
+++ b/changelog.d/20260715_geo_country_header_source.rst
@@ -1,0 +1,41 @@
+Added
+-----
+
+- Configurable geo-country resolution. ``configure_ip_privacy`` now accepts
+  ``geo_header:`` — a trusted, app-configured request header checked *before*
+  the built-in CDN headers (e.g. ``geo_header: 'X-Client-Country'``);
+  ``geo_db_path:`` — a MaxMind-format ``.mmdb`` country database giving an
+  offline IP->country fallback (looked up on the masked IP; needs the optional
+  ``maxmind-db`` gem); and ``geo_db_reader:`` — bring your own reader (any
+  object responding to ``#get``), keeping the reader/data-source choice
+  independent of Otto. A bad ``geo_db_path`` fails at boot, not per-request.
+  (#206)
+
+- ``X-Vercel-IP-Country`` is now recognized among the built-in CDN/provider
+  geo headers. (#206)
+
+Changed
+-------
+
+- Geo resolution now runs on the privacy-masked IP, so the unmasked address
+  never reaches the resolver (custom resolver or database). Country-level
+  networks are >= /24, so /24-masked results are identical at the default
+  masking level. Custom resolvers invoked through the middleware now receive
+  the masked IP. (#206)
+
+Security
+--------
+
+- Geo headers (``CF-IPCountry`` and friends, plus any configured
+  ``geo_header``) are now ignored for a request that did not arrive via a
+  configured trusted proxy — every geo header is client-spoofable unless you
+  are actually behind that CDN. When no trusted proxies are configured,
+  behavior is unchanged. (#206)
+
+AI Assistance
+-------------
+
+- Configurable geo-header source and local IP->country database fallback
+  designed and implemented with AI assistance, including test coverage for
+  header precedence, spoofing, IPv6, ``geo: false``, and boot-time validation.
+  (#206)

--- a/changelog.d/20260715_geo_country_header_source.rst
+++ b/changelog.d/20260715_geo_country_header_source.rst
@@ -45,6 +45,16 @@ Security
   trusted proxies are configured, behavior is unchanged. Every geo header is
   client-spoofable unless you are actually behind that CDN. (#206)
 
+Fixed
+-----
+
+- IP privacy now masks the RFC 7239 ``Forwarded`` header (``HTTP_FORWARDED``),
+  which Otto reads as an authoritative client-IP source in count-based depth
+  mode. Previously it was left intact while ``X-Forwarded-For`` and friends
+  were masked, so downstream code (and, before the geo seal, a custom geo
+  resolver) could still read the real client IP from its ``for=`` token. It is
+  now rewritten to a valid Forwarded value holding only the masked IP. (#206)
+
 AI Assistance
 -------------
 

--- a/examples/simple_geo_resolver.rb
+++ b/examples/simple_geo_resolver.rb
@@ -3,15 +3,46 @@
 
 # Otto GeoResolver Extension Guide
 #
-# This guide shows two approaches to extend Otto's IP geolocation:
-# 1. Configuration-based (simple, inline)
-# 2. Subclass-based (full control)
+# Otto resolves a country code in this order (first hit wins):
+#   1. App-configured trusted header  (configure_ip_privacy(geo_header:))
+#   2. Built-in CDN/provider headers  (Cloudflare, AWS, Vercel, ...)
+#   3. Custom resolver hook           (GeoResolver.custom_resolver = ...)
+#   4. Local MMDB database            (configure_ip_privacy(geo_db_path:/geo_db_reader:))
+#   5. Built-in IP-range detection    ('**' when nothing matches)
+#
+# This guide shows the extension points:
+# A. Built-in configuration (trusted header + local database) — no code
+# B. Custom resolver hook (inline or a callable object)
+# C. Subclass-based (full control)
 
 require 'bundler/setup'
 require 'otto'
 
 # =============================================================================
-# Quick Start: Configuration-based Extension
+# A. Built-in configuration: trusted header + local country database
+# =============================================================================
+#
+# No custom code needed — just configure the Otto instance. The database is
+# looked up on the already-MASKED IP, and a bad geo_db_path fails at boot.
+#
+#   otto = Otto.new('routes.txt')
+#   otto.configure_ip_privacy(
+#     geo_header: 'X-Client-Country',   # trusted header checked before CDN headers
+#     geo_db_path: 'data/country.mmdb'  # offline fallback (needs the maxmind-db gem)
+#   )
+#
+# Prefer to bring your own reader (any object responding to #get)? Inject it —
+# this keeps the reader/data-source choice independent of Otto:
+#
+#   reader = MaxMind::DB.new('data/country.mmdb', mode: MaxMind::DB::MODE_MEMORY)
+#   otto.configure_ip_privacy(geo_db_reader: reader)
+#
+# Security note: geo headers are only trusted for requests that arrive via a
+# configured trusted proxy (add_trusted_proxy), since they are client-spoofable
+# otherwise. configure_ip_privacy(geo: false) disables geo entirely.
+
+# =============================================================================
+# B. Quick Start: Custom resolver hook
 # =============================================================================
 
 puts 'Simple Custom Geo Resolution'

--- a/examples/simple_geo_resolver.rb
+++ b/examples/simple_geo_resolver.rb
@@ -8,7 +8,7 @@
 #   2. Built-in CDN/provider headers  (Cloudflare, AWS, Vercel, ...)
 #   3. Custom resolver hook           (GeoResolver.custom_resolver = ...)
 #   4. Local MMDB database            (configure_ip_privacy(geo_db_path:/geo_db_reader:))
-#   5. Built-in IP-range detection    ('**' when nothing matches)
+#   5. '**' (unknown)                 Otto does not guess from a hardcoded table
 #
 # This guide shows the extension points:
 # A. Built-in configuration (trusted header + local database) — no code
@@ -62,7 +62,9 @@ Otto::Privacy::GeoResolver.custom_resolver = custom_resolver
 
 # Step 3: Test it
 puts "1.2.3.4 -> #{Otto::Privacy::GeoResolver.resolve('1.2.3.4', {})}"
-puts "8.8.8.8 -> #{Otto::Privacy::GeoResolver.resolve('8.8.8.8', {})} (fallback)"
+# Resolver returns nil for 8.8.8.8, and there is no header or database, so the
+# honest answer is '**' (unknown) — Otto does not guess.
+puts "8.8.8.8 -> #{Otto::Privacy::GeoResolver.resolve('8.8.8.8', {})} (unknown)"
 
 # Reset for next example
 Otto::Privacy::GeoResolver.custom_resolver = nil

--- a/lib/otto/privacy.rb
+++ b/lib/otto/privacy.rb
@@ -18,7 +18,9 @@ require_relative 'privacy/redacted_fingerprint'
 # Features:
 # - Configurable IP masking (1 or 2 octets for IPv4, 80 or 96 bits for IPv6)
 # - Daily-rotating IP hashing for session correlation without tracking
-# - Geo-location resolution (country-level only, via CloudFlare headers)
+# - Geo-location resolution (country-level only): a configurable trusted header,
+#   built-in CDN provider headers, an optional local MaxMind-format (.mmdb)
+#   database looked up on the masked IP, or a custom resolver
 # - User agent anonymization (removes version numbers)
 #
 # Privacy is ENABLED BY DEFAULT. To disable:

--- a/lib/otto/privacy/config.rb
+++ b/lib/otto/privacy/config.rb
@@ -34,32 +34,12 @@ class Otto
       # This is stored at the class level so it persists across frozen config instances
       @rotation_keys_store = nil
 
-      # Class-level geo database (MMDB reader) storage.
-      #
-      # Held at the class level for the SAME reason as rotation_keys_store: a
-      # Config instance is deep-frozen after the first request (see
-      # Otto::Core::Freezable), and deep-freezing recurses into every instance
-      # variable. An MMDB reader (e.g. MaxMind::DB in MODE_MEMORY) is a live
-      # object whose #get may use internal buffers, so freezing it risks a
-      # FrozenError per request. Keeping the reader here — and storing only a
-      # String lookup key on the instance — keeps the frozen Config free of any
-      # live reader reference. Keying by path also de-duplicates: the same mmdb
-      # file is opened once and shared across Config instances.
-      @geo_db_store = nil
-
       class << self
         # Get the class-level rotation keys store
         # @return [Concurrent::Map] Thread-safe map for rotation keys
         def rotation_keys_store
           @rotation_keys_store = Concurrent::Map.new unless defined?(@rotation_keys_store) && @rotation_keys_store
           @rotation_keys_store
-        end
-
-        # Get the class-level geo database store (key => MMDB reader).
-        # @return [Concurrent::Map] Thread-safe map of readers
-        def geo_db_store
-          @geo_db_store = Concurrent::Map.new unless defined?(@geo_db_store) && @geo_db_store
-          @geo_db_store
         end
       end
 
@@ -109,8 +89,8 @@ class Otto
         @redis = options[:redis] # Optional Redis connection for multi-server environments
 
         # Geo-location fallback configuration (all opt-in, boot-time only).
-        @geo_db_key = nil # class-store lookup key for the effective MMDB reader
-        @geo_db_override_key = nil # set when a reader is injected via geo_db_reader=
+        @geo_db_reader = nil # effective MMDB reader (built from path or injected)
+        @geo_db_override = nil # reader injected via geo_db_reader= (wins over path)
         self.geo_header = options[:geo_header] # canonicalized to an HTTP_* env key (or nil)
         self.geo_db_reader = options[:geo_db_reader] if options.key?(:geo_db_reader)
         @geo_db_path = normalize_geo_db_path(options[:geo_db_path])
@@ -165,65 +145,57 @@ class Otto
       # This keeps the reader choice independent of Otto (MaxMind::DB, yhirose's
       # maxminddb, or a custom object all work) and is the seam used by tests.
       # When set, it takes precedence over {#geo_db_path}. Passing nil clears the
-      # override. The reader is stored at the class level (never on this frozen-
-      # able instance); only a lookup key is kept here.
+      # override. Takes effect on the next {#load_geo_database!}.
       #
       # @param reader [#get, nil] MMDB-compatible reader, or nil to clear
       # @raise [ArgumentError] if reader does not respond to :get
       def geo_db_reader=(reader)
-        if reader.nil?
-          @geo_db_override_key = nil
-          return
+        unless reader.nil? || reader.respond_to?(:get)
+          raise ArgumentError, "geo_db_reader must respond to :get, got: #{reader.class}"
         end
 
-        raise ArgumentError, "geo_db_reader must respond to :get, got: #{reader.class}" unless reader.respond_to?(:get)
-
-        key = "reader:#{reader.object_id}"
-        self.class.geo_db_store[key] = reader
-        @geo_db_override_key = key
+        @geo_db_override = reader
       end
 
       # The effective MMDB reader for this config, or nil.
       #
       # Returns nil when geo is disabled (so `geo: false` consults no database
       # even if one was previously configured) or when neither a reader override
-      # nor a database path is set. Reads from the class-level store, so it is
-      # safe to call on a frozen Config.
+      # nor a database path is set.
+      #
+      # The reader is a plain instance variable — no class-level store. A
+      # MaxMind::DB reader computes its IPv4 start node eagerly at construction
+      # and performs no instance mutation on #get, so it is thread-safe under
+      # concurrency and unaffected by the shallow freeze deep_freeze! applies to
+      # it. That removes the only reason to hold it off-instance, and avoids an
+      # unbounded, never-evicted process-lifetime cache — important for a
+      # long-running server.
       #
       # @return [#get, nil] the reader, or nil
       def geo_db_reader
-        return nil unless @geo_enabled
-        return nil unless @geo_db_key
-
-        self.class.geo_db_store[@geo_db_key]
+        @geo_enabled ? @geo_db_reader : nil
       end
 
       # Build/attach the geo database reader for the current configuration.
       #
       # Boot-time only. Resolves the effective reader (injected override wins
-      # over a path) and records its class-store key on this instance. A String
-      # path is opened eagerly here so an unreadable path or a missing
-      # 'maxmind-db' gem raises now, at configuration time, rather than on the
-      # first request that needs a lookup. When geo is disabled, no database is
-      # loaded and no key is retained.
+      # over a path). A String path is opened eagerly here so an unreadable path
+      # or a missing 'maxmind-db' gem raises now, at configuration time, rather
+      # than on the first request that needs a lookup. When geo is disabled, no
+      # database is loaded and no reader is retained.
       #
       # @return [void]
       # @raise [ArgumentError] if the path is unreadable or maxmind-db is absent
       def load_geo_database!
-        @geo_db_key = nil
+        @geo_db_reader = nil
         return unless @geo_enabled
 
-        if @geo_db_override_key
-          @geo_db_key = @geo_db_override_key
-        elsif @geo_db_path
-          # compute_if_absent opens the file once per path across all Config
-          # instances; a failure in the block propagates (nothing is cached),
-          # so a bad path raises here at boot.
-          self.class.geo_db_store.compute_if_absent(@geo_db_path) do
+        @geo_db_reader =
+          if @geo_db_override
+            @geo_db_override
+          elsif @geo_db_path
             build_maxmind_reader(@geo_db_path)
           end
-          @geo_db_key = @geo_db_path
-        end
       end
 
       # Canonicalize a geo header name to a Rack CGI env key ('HTTP_*').

--- a/lib/otto/privacy/config.rb
+++ b/lib/otto/privacy/config.rb
@@ -28,11 +28,24 @@ class Otto
       include Otto::Core::Freezable
 
       attr_accessor :octet_precision, :hash_rotation_period, :geo_enabled, :mask_private_ips
-      attr_reader :disabled, :correlation_secret
+      attr_reader :disabled, :correlation_secret, :geo_header, :geo_db_path
 
       # Class-level rotation key storage (mutable, not frozen with instances)
       # This is stored at the class level so it persists across frozen config instances
       @rotation_keys_store = nil
+
+      # Class-level geo database (MMDB reader) storage.
+      #
+      # Held at the class level for the SAME reason as rotation_keys_store: a
+      # Config instance is deep-frozen after the first request (see
+      # Otto::Core::Freezable), and deep-freezing recurses into every instance
+      # variable. An MMDB reader (e.g. MaxMind::DB in MODE_MEMORY) is a live
+      # object whose #get may use internal buffers, so freezing it risks a
+      # FrozenError per request. Keeping the reader here — and storing only a
+      # String lookup key on the instance — keeps the frozen Config free of any
+      # live reader reference. Keying by path also de-duplicates: the same mmdb
+      # file is opened once and shared across Config instances.
+      @geo_db_store = nil
 
       class << self
         # Get the class-level rotation keys store
@@ -40,6 +53,13 @@ class Otto
         def rotation_keys_store
           @rotation_keys_store = Concurrent::Map.new unless defined?(@rotation_keys_store) && @rotation_keys_store
           @rotation_keys_store
+        end
+
+        # Get the class-level geo database store (key => MMDB reader).
+        # @return [Concurrent::Map] Thread-safe map of readers
+        def geo_db_store
+          @geo_db_store = Concurrent::Map.new unless defined?(@geo_db_store) && @geo_db_store
+          @geo_db_store
         end
       end
 
@@ -49,6 +69,17 @@ class Otto
       # @option options [Integer] :octet_precision Number of trailing octets to mask (1 or 2, default: 1)
       # @option options [Integer] :hash_rotation_period Seconds between key rotation (default: 86400)
       # @option options [Boolean] :geo_enabled Enable geo-location resolution (default: true)
+      # @option options [String] :geo_header Trusted, app-configured request header to read the
+      #   country code from FIRST (before the built-in CDN provider headers). Accepts either
+      #   the HTTP form ('X-Client-Country') or the Rack CGI form ('HTTP_X_CLIENT_COUNTRY');
+      #   both canonicalize to the 'HTTP_*' env key. Default nil (no app-configured header).
+      # @option options [String] :geo_db_path Filesystem path to a MaxMind-format (.mmdb)
+      #   country database used as the local IP->country fallback (looked up on the already
+      #   MASKED IP). Requires the 'maxmind-db' gem. A bad/unreadable path raises at boot,
+      #   not per-request. Default nil (no local database fallback).
+      # @option options [#get] :geo_db_reader Bring-your-own MMDB reader (any object responding
+      #   to #get, e.g. a MaxMind::DB or a compatible reader). Overrides :geo_db_path when set,
+      #   so the reader choice stays independent of Otto. Default nil.
       # @option options [Boolean] :disabled Disable privacy entirely (default: false)
       # @option options [Boolean] :mask_private_ips Mask private/localhost IPs (default: false)
       # @option options [String] :correlation_secret A secret string that turns
@@ -76,6 +107,14 @@ class Otto
         @mask_private_ips = options.fetch(:mask_private_ips, false) # Don't mask private/localhost by default
         self.correlation_secret = options.fetch(:correlation_secret, nil) # Opt-in stable IP-correlation secret
         @redis = options[:redis] # Optional Redis connection for multi-server environments
+
+        # Geo-location fallback configuration (all opt-in, boot-time only).
+        @geo_db_key = nil # class-store lookup key for the effective MMDB reader
+        @geo_db_override_key = nil # set when a reader is injected via geo_db_reader=
+        self.geo_header = options[:geo_header] # canonicalized to an HTTP_* env key (or nil)
+        self.geo_db_reader = options[:geo_db_reader] if options.key?(:geo_db_reader)
+        @geo_db_path = normalize_geo_db_path(options[:geo_db_path])
+        load_geo_database! # build/attach the reader now so a bad path fails at boot
       end
 
       # Set the stable correlation secret, validating its type up front.
@@ -95,6 +134,110 @@ class Otto
         end
 
         @correlation_secret = value
+      end
+
+      # Set the trusted, app-configured geo header.
+      #
+      # Canonicalizes to a Rack CGI env key ('HTTP_*'): 'X-Client-Country',
+      # 'x-client-country' and 'HTTP_X_CLIENT_COUNTRY' all become
+      # 'HTTP_X_CLIENT_COUNTRY'. nil / blank clears it. Rack 3's lowercase rule
+      # applies to RESPONSE headers; request headers remain 'HTTP_*' env keys,
+      # so this is the correct form to read from the request env.
+      #
+      # @param value [String, nil] header name in either HTTP or CGI form
+      def geo_header=(value)
+        @geo_header = self.class.canonicalize_geo_header(value)
+      end
+
+      # Set the geo database path (MMDB file) used for the local fallback.
+      #
+      # Does not build the reader on its own — call {#load_geo_database!} (which
+      # {Otto::Privacy::Core#configure_ip_privacy} does for you) so a bad path
+      # fails at boot rather than per-request.
+      #
+      # @param value [String, nil] filesystem path to a .mmdb file, or nil
+      def geo_db_path=(value)
+        @geo_db_path = normalize_geo_db_path(value)
+      end
+
+      # Inject a ready-made MMDB reader (any object responding to #get).
+      #
+      # This keeps the reader choice independent of Otto (MaxMind::DB, yhirose's
+      # maxminddb, or a custom object all work) and is the seam used by tests.
+      # When set, it takes precedence over {#geo_db_path}. Passing nil clears the
+      # override. The reader is stored at the class level (never on this frozen-
+      # able instance); only a lookup key is kept here.
+      #
+      # @param reader [#get, nil] MMDB-compatible reader, or nil to clear
+      # @raise [ArgumentError] if reader does not respond to :get
+      def geo_db_reader=(reader)
+        if reader.nil?
+          @geo_db_override_key = nil
+          return
+        end
+
+        raise ArgumentError, "geo_db_reader must respond to :get, got: #{reader.class}" unless reader.respond_to?(:get)
+
+        key = "reader:#{reader.object_id}"
+        self.class.geo_db_store[key] = reader
+        @geo_db_override_key = key
+      end
+
+      # The effective MMDB reader for this config, or nil.
+      #
+      # Returns nil when geo is disabled (so `geo: false` consults no database
+      # even if one was previously configured) or when neither a reader override
+      # nor a database path is set. Reads from the class-level store, so it is
+      # safe to call on a frozen Config.
+      #
+      # @return [#get, nil] the reader, or nil
+      def geo_db_reader
+        return nil unless @geo_enabled
+        return nil unless @geo_db_key
+
+        self.class.geo_db_store[@geo_db_key]
+      end
+
+      # Build/attach the geo database reader for the current configuration.
+      #
+      # Boot-time only. Resolves the effective reader (injected override wins
+      # over a path) and records its class-store key on this instance. A String
+      # path is opened eagerly here so an unreadable path or a missing
+      # 'maxmind-db' gem raises now, at configuration time, rather than on the
+      # first request that needs a lookup. When geo is disabled, no database is
+      # loaded and no key is retained.
+      #
+      # @return [void]
+      # @raise [ArgumentError] if the path is unreadable or maxmind-db is absent
+      def load_geo_database!
+        @geo_db_key = nil
+        return unless @geo_enabled
+
+        if @geo_db_override_key
+          @geo_db_key = @geo_db_override_key
+        elsif @geo_db_path
+          # compute_if_absent opens the file once per path across all Config
+          # instances; a failure in the block propagates (nothing is cached),
+          # so a bad path raises here at boot.
+          self.class.geo_db_store.compute_if_absent(@geo_db_path) do
+            build_maxmind_reader(@geo_db_path)
+          end
+          @geo_db_key = @geo_db_path
+        end
+      end
+
+      # Canonicalize a geo header name to a Rack CGI env key ('HTTP_*').
+      #
+      # @param value [String, nil] header in HTTP ('X-Client-Country') or CGI form
+      # @return [String, nil] 'HTTP_*' env key, or nil for nil/blank input
+      def self.canonicalize_geo_header(value)
+        return nil if value.nil?
+
+        key = value.to_s.strip
+        return nil if key.empty?
+
+        key = key.upcase.tr('-', '_')
+        key.start_with?('HTTP_') ? key : "HTTP_#{key}"
       end
 
       # Check if privacy is enabled
@@ -166,6 +309,47 @@ class Otto
       end
 
       private
+
+      # Normalize a geo_db_path option to a non-empty String or nil.
+      #
+      # @param value [String, nil] raw path option
+      # @return [String, nil]
+      def normalize_geo_db_path(value)
+        return nil if value.nil?
+
+        path = value.to_s.strip
+        path.empty? ? nil : path
+      end
+
+      # Open an MMDB file into an in-memory reader, failing fast on problems.
+      #
+      # The 'maxmind-db' gem is an OPTIONAL dependency: it is required lazily
+      # here, only when a database path is actually configured, so Otto stays
+      # dependency-light for the (common) header-only geo setups. Callers who
+      # prefer a different reader can inject one via {#geo_db_reader=} and never
+      # trigger this path.
+      #
+      # @param path [String] filesystem path to a .mmdb file
+      # @return [MaxMind::DB] in-memory reader
+      # @raise [ArgumentError] if the path is unreadable or the gem is missing
+      def build_maxmind_reader(path)
+        raise ArgumentError, "geo_db_path is not readable: #{path.inspect}" unless File.readable?(path)
+
+        begin
+          require 'maxmind/db'
+        rescue LoadError
+          raise ArgumentError,
+                "geo_db_path is set (#{path.inspect}) but the 'maxmind-db' gem is not available. " \
+                "Add `gem 'maxmind-db'` to your Gemfile, or inject your own reader via " \
+                'configure_ip_privacy(geo_db_reader: ...).'
+        end
+
+        begin
+          MaxMind::DB.new(path, mode: MaxMind::DB::MODE_MEMORY)
+        rescue StandardError => e
+          raise ArgumentError, "Failed to open geo_db_path #{path.inspect}: #{e.class}: #{e.message}"
+        end
+      end
 
       # Redis-based rotation key (atomic across multiple servers)
       #

--- a/lib/otto/privacy/core.rb
+++ b/lib/otto/privacy/core.rb
@@ -87,9 +87,14 @@ class Otto
       # @example Multi-server with Redis
       #   redis = Redis.new(url: ENV['REDIS_URL'])
       #   otto.configure_ip_privacy(redis: redis)
+      #
+      # rubocop:disable Metrics/ParameterLists -- a keyword-only configuration
+      # method; the options are self-documenting at the call site and grouping
+      # them into a hash would only obscure the supported settings.
       def configure_ip_privacy(octet_precision: nil, hash_rotation: nil, geo: nil, redis: nil,
                                correlation_secret: nil, geo_header: nil, geo_db_path: nil,
                                geo_db_reader: nil)
+        # rubocop:enable Metrics/ParameterLists
         ensure_not_frozen!
         config = @security_config.ip_privacy_config
 

--- a/lib/otto/privacy/core.rb
+++ b/lib/otto/privacy/core.rb
@@ -130,8 +130,19 @@ class Otto
         geo_touched = [geo, geo_header, geo_db_path, geo_db_reader].any? { |v| !v.nil? }
 
         config.geo_header = geo_header unless geo_header.nil?
-        config.geo_db_reader = geo_db_reader unless geo_db_reader.nil?
-        config.geo_db_path = geo_db_path unless geo_db_path.nil?
+
+        # A newly supplied reader or path replaces the other database source. A
+        # reader given in this call wins over a path (documented precedence); a
+        # path given on its own clears any prior injected reader so it actually
+        # takes effect — otherwise the stale override would silently shadow the
+        # new path (leaving lookups pointed at a closed/old reader).
+        if !geo_db_reader.nil?
+          config.geo_db_reader = geo_db_reader
+          config.geo_db_path = geo_db_path unless geo_db_path.nil?
+        elsif !geo_db_path.nil?
+          config.geo_db_reader = nil
+          config.geo_db_path = geo_db_path
+        end
 
         config.load_geo_database! if geo_touched
       end

--- a/lib/otto/privacy/core.rb
+++ b/lib/otto/privacy/core.rb
@@ -50,7 +50,19 @@ class Otto
       #
       # @param octet_precision [Integer] Number of octets to mask (1 or 2, default: 1)
       # @param hash_rotation [Integer] Seconds between key rotation (default: 86400)
-      # @param geo [Boolean] Enable geo-location resolution (default: true)
+      # @param geo [Boolean] Enable geo-location resolution (default: true). When
+      #   false, geo short-circuits entirely: no headers are read and no database
+      #   is loaded or consulted.
+      # @param geo_header [String] Trusted, app-configured request header checked
+      #   FIRST for the country code (e.g. 'X-Client-Country'). Accepts the HTTP
+      #   or 'HTTP_*' CGI form; both canonicalize to the env key. Pass '' to clear.
+      # @param geo_db_path [String] Path to a MaxMind-format (.mmdb) country
+      #   database for the local IP->country fallback (looked up on the MASKED
+      #   IP). Requires the optional 'maxmind-db' gem. A bad path raises at boot,
+      #   not per-request. Pass '' to clear.
+      # @param geo_db_reader [#get] Bring-your-own MMDB reader (any object
+      #   responding to #get); overrides geo_db_path. Omitted/nil leaves any
+      #   existing reader unchanged; use geo: false to stop consulting a database.
       # @param redis [Redis] Redis connection for multi-server atomic key generation
       # @param correlation_secret [String] A secret string that turns on IP
       #   correlation: it lets you tell whether two requests, even months apart,
@@ -76,7 +88,8 @@ class Otto
       #   redis = Redis.new(url: ENV['REDIS_URL'])
       #   otto.configure_ip_privacy(redis: redis)
       def configure_ip_privacy(octet_precision: nil, hash_rotation: nil, geo: nil, redis: nil,
-                               correlation_secret: nil)
+                               correlation_secret: nil, geo_header: nil, geo_db_path: nil,
+                               geo_db_reader: nil)
         ensure_not_frozen!
         config = @security_config.ip_privacy_config
 
@@ -93,6 +106,29 @@ class Otto
 
         # Validate configuration
         config.validate!
+
+        apply_geo_config(config, geo: geo, geo_header: geo_header,
+                                 geo_db_path: geo_db_path, geo_db_reader: geo_db_reader)
+      end
+
+      private
+
+      # Apply the geo-fallback settings and (re)load the database when needed.
+      #
+      # nil means "leave unchanged"; '' clears a header or path. Any geo-affecting
+      # change triggers a boot-time (re)load so a bad geo_db_path fails here, not
+      # on the first request that needs a lookup.
+      #
+      # @param config [Otto::Privacy::Config] the privacy config to mutate
+      # @api private
+      def apply_geo_config(config, geo:, geo_header:, geo_db_path:, geo_db_reader:)
+        geo_touched = [geo, geo_header, geo_db_path, geo_db_reader].any? { |v| !v.nil? }
+
+        config.geo_header = geo_header unless geo_header.nil?
+        config.geo_db_reader = geo_db_reader unless geo_db_reader.nil?
+        config.geo_db_path = geo_db_path unless geo_db_path.nil?
+
+        config.load_geo_database! if geo_touched
       end
     end
   end

--- a/lib/otto/privacy/geo_resolver.rb
+++ b/lib/otto/privacy/geo_resolver.rb
@@ -265,15 +265,25 @@ class Otto
 
       # Extract an ISO country code from an MMDB lookup result.
       #
+      # Handles the shapes country databases actually use: GeoLite2-Country
+      # style ('country' => {'iso_code' => 'US'}), the flat 'country_code' =>
+      # 'US', and a bare 'country' => 'US'. The nested case is checked with an
+      # explicit Hash guard rather than Hash#dig so a bare-String 'country'
+      # value does not raise (String has no #dig).
+      #
       # @param result [Object] whatever the reader returned for the IP
       # @return [String, nil] country code string, or nil
       # @api private
       def self.extract_db_country(result)
         return nil unless result.is_a?(Hash)
 
-        code = result.dig('country', 'iso_code') ||
-               result['country_code'] ||
-               result['country']
+        country = result['country']
+        code =
+          if country.is_a?(Hash)
+            country['iso_code']
+          else
+            result['country_code'] || country
+          end
         code.is_a?(String) ? code : nil
       end
       private_class_method :extract_db_country

--- a/lib/otto/privacy/geo_resolver.rb
+++ b/lib/otto/privacy/geo_resolver.rb
@@ -373,7 +373,9 @@ class Otto
       # @return [Boolean] true if valid ISO 3166-1 alpha-2 code
       # @api private
       def self.valid_country_code?(code)
-        code.is_a?(String) && code.length == 2 && code.match?(/^[A-Z]{2}$/)
+        # \A / \z (string anchors), not ^ / $ (line anchors), so an embedded
+        # newline can never satisfy the pattern.
+        code.is_a?(String) && code.length == 2 && code.match?(/\A[A-Z]{2}\z/)
       end
       private_class_method :valid_country_code?
     end

--- a/lib/otto/privacy/geo_resolver.rb
+++ b/lib/otto/privacy/geo_resolver.rb
@@ -2,8 +2,6 @@
 #
 # frozen_string_literal: true
 
-require 'ipaddr'
-
 class Otto
   module Privacy
     # Lightweight geo-location resolution for IP addresses
@@ -19,15 +17,16 @@ class Otto
     # 2. Built-in CDN/infrastructure provider headers (see below)
     # 3. Custom resolver hook ({.custom_resolver})
     # 4. Local MMDB lookup, masked before lookup (Config#geo_db_reader)
-    # 5. Built-in IP-range detection (a tiny best-effort table)
-    # 6. '**' (unknown)
+    # 5. '**' (unknown)
     #
     # Steps 1 and 2 are SKIPPED when the request's geo headers are not trusted
     # (a non-trusted-proxy request while trusted proxies are configured) — every
     # geo header is client-spoofable unless you are actually behind that CDN.
     #
-    # When a database is configured it is authoritative: step 4 missing means
-    # step 5 is skipped and the result is '**' (no best-effort range guess).
+    # Resolution is HONEST: when no header, custom resolver, or database resolves
+    # a country, the answer is '**' (unknown). Otto does not guess from a
+    # hardcoded IP-range table — configure a database or an edge header for real
+    # geo-location.
     #
     # Supported CDN/Infrastructure Headers:
     # - Cloudflare: CF-IPCountry
@@ -48,9 +47,9 @@ class Otto
     #   GeoResolver.resolve('1.2.3.4', env)
     #   # => 'GB'
     #
-    # @example Resolve without CDN headers
+    # @example Resolve without any header, resolver, or database
     #   GeoResolver.resolve('8.8.8.8', {})
-    #   # => 'US' (Google DNS via range detection)
+    #   # => '**' (unknown — Otto does not guess)
     #
     # @example Using a custom resolver (MaxMind)
     #   GeoResolver.custom_resolver = ->(ip, env) {
@@ -62,7 +61,7 @@ class Otto
     #
     # @example Extending via subclass
     #   class MyGeoResolver < Otto::Privacy::GeoResolver
-    #     def self.detect_by_range(ip)
+    #     def self.check_geo_database(ip, config)
     #       # Custom logic here
     #       super  # Fall back to parent
     #     end
@@ -80,8 +79,7 @@ class Otto
     #                   └─ Invalid/Error → Continue
     #                 → Local MMDB reader configured?
     #                   ├─ Hit → Return country
-    #                   └─ Miss → Built-in range detection
-    #                             └─ Unknown ('**')
+    #                   └─ Miss → Unknown ('**')
     #
     class GeoResolver
       # Unknown country code (not ISO 3166-1 alpha-2, intentionally distinct)
@@ -143,8 +141,7 @@ class Otto
       # 2. Built-in CDN/infrastructure provider headers
       # 3. Custom resolver hook ({.custom_resolver})
       # 4. Local MMDB lookup (+config.geo_db_reader+), masked before lookup
-      # 5. Built-in IP-range detection (skipped when a database is configured)
-      # 6. '**' for unknown
+      # 5. '**' for unknown (no guessing)
       #
       # Country-level MMDB networks are almost always >= /24, so a /24-masked
       # +x.y.z.0+ resolves to the same country as the real IP. The database
@@ -161,7 +158,7 @@ class Otto
       #   masked), so a custom resolver never sees the raw IP through env either.
       # @param config [Otto::Privacy::Config, nil] privacy config supplying the
       #   configured header and MMDB reader. When nil, only the built-in provider
-      #   headers, custom resolver and range detection are used (legacy behavior).
+      #   headers and the custom resolver are consulted.
       # @param headers_trusted [Boolean] whether request geo headers may be
       #   trusted for this request (default true; the middleware computes this
       #   from the trusted-proxy decision).
@@ -169,17 +166,9 @@ class Otto
       def self.resolve(ip, env = {}, config = nil, headers_trusted: true)
         return UNKNOWN if ip.nil? || ip.empty?
 
-        country = resolve_from_sources(ip, env, config, headers_trusted)
-        return country if country
-
-        # A configured database is authoritative: a miss resolves to unknown
-        # rather than falling back to the coarse built-in range table (which
-        # could otherwise return a confident-but-wrong guess).
-        return UNKNOWN if config&.geo_db_reader
-
-        detect_by_range(ip)
-      rescue IPAddr::InvalidAddressError
-        UNKNOWN
+        # Resolution is honest: when no header, custom resolver, or database
+        # resolves a country, the answer is '**' (unknown) — never a guess.
+        resolve_from_sources(ip, env, config, headers_trusted) || UNKNOWN
       end
 
       # Walk the ordered resolution sources and return the first country found.
@@ -377,61 +366,6 @@ class Otto
         match ? match[1] : nil
       end
       private_class_method :extract_akamai_country
-
-      # Detect country by IP range (basic implementation)
-      #
-      # Detects major cloud providers and well-known IP ranges.
-      # This is intentionally limited - for comprehensive geo-location,
-      # use CDN headers or configure a custom resolver.
-      #
-      # @param ip [String] IP address
-      # @return [String] Country code or '**'
-      # @api private
-      def self.detect_by_range(ip)
-        addr = IPAddr.new(ip)
-
-        # Private/local addresses
-        return UNKNOWN if IPPrivacy.private_or_localhost?(ip)
-
-        # Check against known ranges
-        KNOWN_RANGES.each do |range, country|
-          return country if range.include?(addr)
-        end
-
-        UNKNOWN
-      end
-      private_class_method :detect_by_range
-
-      # Known IP ranges for major providers (limited set for basic detection)
-      # For comprehensive geo-location, use CDN headers or custom resolver
-      KNOWN_RANGES = {
-        # Google Public DNS
-        IPAddr.new('8.8.8.0/24') => 'US',
-        IPAddr.new('8.8.4.0/24') => 'US',
-
-        # Cloudflare DNS
-        IPAddr.new('1.1.1.0/24') => 'US',
-        IPAddr.new('1.0.0.0/24') => 'US',
-
-        # AWS US-East
-        IPAddr.new('52.0.0.0/11') => 'US',
-        IPAddr.new('54.0.0.0/8') => 'US',
-
-        # AWS EU-West
-        IPAddr.new('34.240.0.0/13') => 'IE',
-        IPAddr.new('52.16.0.0/14') => 'IE',
-
-        # AWS AP-Southeast
-        IPAddr.new('13.210.0.0/15') => 'AU',
-        IPAddr.new('52.62.0.0/15') => 'AU',
-
-        # Quad9 DNS (Switzerland)
-        IPAddr.new('9.9.9.0/24') => 'CH',
-
-        # OpenDNS
-        IPAddr.new('208.67.222.0/24') => 'US',
-        IPAddr.new('208.67.220.0/24') => 'US',
-      }.freeze
 
       # Validate country code format
       #

--- a/lib/otto/privacy/geo_resolver.rb
+++ b/lib/otto/privacy/geo_resolver.rb
@@ -18,13 +18,16 @@ class Otto
     # 1. App-configured trusted header (Config#geo_header), e.g. 'X-Client-Country'
     # 2. Built-in CDN/infrastructure provider headers (see below)
     # 3. Custom resolver hook ({.custom_resolver})
-    # 4. Local MMDB lookup of the masked IP (Config#geo_db_reader)
+    # 4. Local MMDB lookup, masked before lookup (Config#geo_db_reader)
     # 5. Built-in IP-range detection (a tiny best-effort table)
     # 6. '**' (unknown)
     #
     # Steps 1 and 2 are SKIPPED when the request's geo headers are not trusted
     # (a non-trusted-proxy request while trusted proxies are configured) — every
     # geo header is client-spoofable unless you are actually behind that CDN.
+    #
+    # When a database is configured it is authoritative: step 4 missing means
+    # step 5 is skipped and the result is '**' (no best-effort range guess).
     #
     # Supported CDN/Infrastructure Headers:
     # - Cloudflare: CF-IPCountry
@@ -139,17 +142,23 @@ class Otto
       # 1. App-configured trusted header (+config.geo_header+)
       # 2. Built-in CDN/infrastructure provider headers
       # 3. Custom resolver hook ({.custom_resolver})
-      # 4. Local MMDB lookup (+config.geo_db_reader+) — expects a MASKED IP
-      # 5. Built-in IP-range detection
+      # 4. Local MMDB lookup (+config.geo_db_reader+), masked before lookup
+      # 5. Built-in IP-range detection (skipped when a database is configured)
       # 6. '**' for unknown
       #
-      # +ip+ SHOULD be the privacy-masked address when called from the Otto
-      # middleware: country-level MMDB networks are almost always >= /24, so the
-      # /24-masked +x.y.z.0+ resolves to the same country as the real IP, and the
-      # unmasked address never reaches the resolver.
+      # Country-level MMDB networks are almost always >= /24, so a /24-masked
+      # +x.y.z.0+ resolves to the same country as the real IP. The database
+      # lookup masks internally, and the Otto middleware additionally hands this
+      # method a masked IP and a masked env, so neither the database nor a custom
+      # resolver ever sees the unmasked address.
       #
-      # @param ip [String] IP address to resolve (masked, in the framework path)
-      # @param env [Hash] Rack environment (may contain geo headers)
+      # @param ip [String] IP address to resolve. When called from the Otto
+      #   middleware this is already the masked IP; the database lookup masks
+      #   again internally, so a direct caller passing a real IP still never
+      #   exposes the unmasked address to the database.
+      # @param env [Hash] Rack environment (may contain geo headers). In the
+      #   framework path this is a masked view (REMOTE_ADDR/forwarded headers
+      #   masked), so a custom resolver never sees the raw IP through env either.
       # @param config [Otto::Privacy::Config, nil] privacy config supplying the
       #   configured header and MMDB reader. When nil, only the built-in provider
       #   headers, custom resolver and range detection are used (legacy behavior).
@@ -160,36 +169,34 @@ class Otto
       def self.resolve(ip, env = {}, config = nil, headers_trusted: true)
         return UNKNOWN if ip.nil? || ip.empty?
 
-        if headers_trusted
-          # 1. App-configured trusted header wins over provider headers.
-          country = check_configured_header(env, config)
-          return country if country
-
-          # 2. Built-in CDN/infrastructure headers, in priority order.
-          country = check_geo_headers(env)
-          return country if country
-        end
-
-        # 3. Custom resolver hook, if configured.
-        if @custom_resolver
-          begin
-            country = @custom_resolver.call(ip, env)
-            return country if country && valid_country_code?(country)
-          rescue StandardError => e
-            # Log error but don't crash - fall through to built-in detection
-            warn "GeoResolver custom resolver error: #{e.message}" if $DEBUG
-          end
-        end
-
-        # 4. Local MMDB database lookup on the (masked) IP.
-        country = check_geo_database(ip, config)
+        country = resolve_from_sources(ip, env, config, headers_trusted)
         return country if country
 
-        # 5. Fallback: Basic range detection.
+        # A configured database is authoritative: a miss resolves to unknown
+        # rather than falling back to the coarse built-in range table (which
+        # could otherwise return a confident-but-wrong guess).
+        return UNKNOWN if config&.geo_db_reader
+
         detect_by_range(ip)
       rescue IPAddr::InvalidAddressError
         UNKNOWN
       end
+
+      # Walk the ordered resolution sources and return the first country found.
+      #
+      # @return [String, nil] country code, or nil if no source resolved
+      # @api private
+      def self.resolve_from_sources(ip, env, config, headers_trusted)
+        if headers_trusted
+          # 1. Configured header wins over 2. built-in provider headers.
+          country = check_configured_header(env, config) || check_geo_headers(env)
+          return country if country
+        end
+
+        # 3. Custom resolver hook, then 4. local MMDB lookup.
+        check_custom_resolver(ip, env) || check_geo_database(ip, config)
+      end
+      private_class_method :resolve_from_sources
 
       # Check the app-configured trusted geo header, if any.
       #
@@ -206,14 +213,39 @@ class Otto
       end
       private_class_method :check_configured_header
 
+      # Invoke the configured custom resolver, guarding against errors.
+      #
+      # @param ip [String] IP address handed to the resolver (masked in the
+      #   framework path — see {.resolve})
+      # @param env [Hash] Rack environment (masked view in the framework path)
+      # @return [String, nil] a valid country code, or nil
+      # @api private
+      def self.check_custom_resolver(ip, env)
+        resolver = @custom_resolver
+        return nil unless resolver
+
+        country = resolver.call(ip, env)
+        country if country && valid_country_code?(country)
+      rescue StandardError => e
+        # A custom resolver must never crash a request; fall through.
+        warn "GeoResolver custom resolver error: #{e.message}" if $DEBUG
+        nil
+      end
+      private_class_method :check_custom_resolver
+
       # Look up the country for an IP in the configured MMDB database.
       #
-      # No-op (returns nil) when no config or reader is available. The reader is
-      # any object responding to +#get(ip)+; result shapes from both
-      # GeoLite2-Country-compatible ('country' => {'iso_code' => ...}) and flat
-      # ('country_code' => ...) mmdb builds are handled.
+      # No-op (returns nil) when no config or reader is available. The IP is
+      # masked (with the config's octet precision) before the lookup so the
+      # unmasked address never reaches the database; masking is idempotent, so
+      # an already-masked IP is unaffected. Country-level networks are >= /24,
+      # so a /24-masked address resolves to the same country as the real one.
       #
-      # @param ip [String] IP address (masked, in the framework path)
+      # The reader is any object responding to +#get(ip)+; result shapes from
+      # both GeoLite2-Country-compatible ('country' => {'iso_code' => ...}) and
+      # flat ('country_code' => ...) mmdb builds are handled.
+      #
+      # @param ip [String] IP address (masked internally before lookup)
       # @param config [Otto::Privacy::Config, nil]
       # @return [String, nil] valid country code, or nil on miss/error
       # @api private
@@ -221,10 +253,11 @@ class Otto
         reader = config&.geo_db_reader
         return nil unless reader
 
-        country = extract_db_country(reader.get(ip))
+        lookup_ip = IPPrivacy.mask_ip(ip, config.octet_precision) || ip
+        country = extract_db_country(reader.get(lookup_ip))
         valid_country_code?(country) ? country : nil
       rescue StandardError => e
-        # A DB read must never crash a request; fall through to range detection.
+        # A DB read must never crash a request; fall through.
         warn "GeoResolver database lookup error: #{e.message}" if $DEBUG
         nil
       end
@@ -256,49 +289,67 @@ class Otto
       # 6. Vercel (X-Vercel-IP-Country)
       # 7. Semi-standard headers (X-Geo-Country, X-Country-Code, Country-Code)
       #
+      # Simple provider headers whose value is the country code directly, checked
+      # ahead of Akamai (whose value is a compound Edgescape string). Cloudflare
+      # first (most widely deployed), then AWS CloudFront, then Fastly.
+      PRIMARY_COUNTRY_HEADERS = %w[
+        HTTP_CF_IPCOUNTRY
+        HTTP_CLOUDFRONT_VIEWER_COUNTRY
+        HTTP_FASTLY_CLIENT_IP_COUNTRY
+      ].freeze
+
+      # Remaining direct country-code headers, checked after Akamai: Azure Front
+      # Door, Vercel, then the least-reliable semi-standard headers.
+      SECONDARY_COUNTRY_HEADERS = %w[
+        HTTP_X_AZURE_CLIENTIP_COUNTRY
+        HTTP_X_VERCEL_IP_COUNTRY
+        HTTP_X_GEO_COUNTRY
+        HTTP_X_COUNTRY_CODE
+        HTTP_COUNTRY_CODE
+      ].freeze
+
+      # Check CDN/infrastructure provider geo headers, in priority order:
+      # Cloudflare, AWS CloudFront, Fastly, Akamai, Azure, Vercel, then the
+      # semi-standard headers.
+      #
       # @param env [Hash] Rack environment
       # @return [String, nil] ISO 3166-1 alpha-2 country code or nil
       # @api private
       def self.check_geo_headers(env)
-        # Cloudflare (most common)
-        country = env['HTTP_CF_IPCOUNTRY']
-        return country if valid_country_code?(country)
-
-        # AWS CloudFront
-        country = env['HTTP_CLOUDFRONT_VIEWER_COUNTRY']
-        return country if valid_country_code?(country)
-
-        # Fastly
-        country = env['HTTP_FASTLY_CLIENT_IP_COUNTRY']
-        return country if valid_country_code?(country)
-
-        # Akamai Edgescape (format: country_code=US,region_code=CA,...)
-        if (edgescape = env['HTTP_X_AKAMAI_EDGESCAPE'])
-          country = extract_akamai_country(edgescape)
-          return country if valid_country_code?(country)
-        end
-
-        # Azure Front Door
-        country = env['HTTP_X_AZURE_CLIENTIP_COUNTRY']
-        return country if valid_country_code?(country)
-
-        # Vercel
-        country = env['HTTP_X_VERCEL_IP_COUNTRY']
-        return country if valid_country_code?(country)
-
-        # Semi-standard headers (least reliable, check last)
-        country = env['HTTP_X_GEO_COUNTRY']
-        return country if valid_country_code?(country)
-
-        country = env['HTTP_X_COUNTRY_CODE']
-        return country if valid_country_code?(country)
-
-        country = env['HTTP_COUNTRY_CODE']
-        return country if valid_country_code?(country)
-
-        nil
+        first_valid_country(env, PRIMARY_COUNTRY_HEADERS) ||
+          akamai_country(env) ||
+          first_valid_country(env, SECONDARY_COUNTRY_HEADERS)
       end
       private_class_method :check_geo_headers
+
+      # First valid country code among the given env header keys, or nil.
+      #
+      # @param env [Hash] Rack environment
+      # @param keys [Array<String>] env keys to check in order
+      # @return [String, nil]
+      # @api private
+      def self.first_valid_country(env, keys)
+        keys.each do |key|
+          country = env[key]
+          return country if valid_country_code?(country)
+        end
+        nil
+      end
+      private_class_method :first_valid_country
+
+      # Country code from the Akamai Edgescape header, if present and valid.
+      #
+      # @param env [Hash] Rack environment
+      # @return [String, nil]
+      # @api private
+      def self.akamai_country(env)
+        edgescape = env['HTTP_X_AKAMAI_EDGESCAPE']
+        return nil unless edgescape
+
+        country = extract_akamai_country(edgescape)
+        valid_country_code?(country) ? country : nil
+      end
+      private_class_method :akamai_country
 
       # Extract country code from Akamai Edgescape header
       #

--- a/lib/otto/privacy/geo_resolver.rb
+++ b/lib/otto/privacy/geo_resolver.rb
@@ -19,9 +19,11 @@ class Otto
     # 4. Local MMDB lookup, masked before lookup (Config#geo_db_reader)
     # 5. '**' (unknown)
     #
-    # Steps 1 and 2 are SKIPPED when the request's geo headers are not trusted
-    # (a non-trusted-proxy request while trusted proxies are configured) — every
-    # geo header is client-spoofable unless you are actually behind that CDN.
+    # Steps 1 and 2 are SKIPPED when the request's geo headers are not trusted.
+    # Every geo header is client-spoofable unless you are actually behind the CDN
+    # that sets it, so the middleware trusts them only for a request that arrived
+    # via a configured trusted proxy; otherwise resolution falls straight to the
+    # custom resolver / database.
     #
     # Resolution is HONEST: when no header, custom resolver, or database resolves
     # a country, the answer is '**' (unknown). Otto does not guess from a

--- a/lib/otto/privacy/geo_resolver.rb
+++ b/lib/otto/privacy/geo_resolver.rb
@@ -8,10 +8,23 @@ class Otto
   module Privacy
     # Lightweight geo-location resolution for IP addresses
     #
-    # Provides country-level geo-location without requiring external
-    # databases or API calls. Supports headers from major CDN/infrastructure
-    # providers (Cloudflare, AWS CloudFront, Fastly, Akamai, Azure) with
-    # fallback to basic IP range detection.
+    # Provides country-level geo-location. Headers from major CDN/infrastructure
+    # providers are checked first; an optional local MaxMind-format (.mmdb)
+    # database gives an offline fallback that operates on Otto's already-MASKED
+    # IP (no external API calls, and the unmasked address never reaches the
+    # resolver).
+    #
+    # Resolution order (first hit wins), when a privacy Config is supplied:
+    # 1. App-configured trusted header (Config#geo_header), e.g. 'X-Client-Country'
+    # 2. Built-in CDN/infrastructure provider headers (see below)
+    # 3. Custom resolver hook ({.custom_resolver})
+    # 4. Local MMDB lookup of the masked IP (Config#geo_db_reader)
+    # 5. Built-in IP-range detection (a tiny best-effort table)
+    # 6. '**' (unknown)
+    #
+    # Steps 1 and 2 are SKIPPED when the request's geo headers are not trusted
+    # (a non-trusted-proxy request while trusted proxies are configured) — every
+    # geo header is client-spoofable unless you are actually behind that CDN.
     #
     # Supported CDN/Infrastructure Headers:
     # - Cloudflare: CF-IPCountry
@@ -19,6 +32,7 @@ class Otto
     # - Fastly: Fastly-Client-IP-Country
     # - Akamai: X-Akamai-Edgescape (country_code=XX format)
     # - Azure Front Door: X-Azure-ClientIP-Country
+    # - Vercel: X-Vercel-IP-Country
     # - Semi-standard: X-Geo-Country, X-Country-Code, Country-Code
     #
     # @example Resolve country from Cloudflare header
@@ -54,14 +68,17 @@ class Otto
     #
     # Resolution flow
     #
-    #    Request → Has familiar HTTP Header?
-    #              ├─ Yes → Return country (Cloudflare, AWS, etc.)
-    #              └─ No → Custom Resolver?
-    #                      ├─ Configured → Call & validate
-    #                      │               ├─ Valid → Return country
-    #                      │               └─ Invalid/Error → Continue
-    #                      └─ Not configured → Built-in range detection
-    #                                          └─ Unknown ('**')
+    #    Request → Headers trusted?
+    #              ├─ Yes → Config#geo_header set & valid? → Return country
+    #              │        └─ Provider header present & valid? → Return country
+    #              └─ (headers skipped when not trusted)
+    #                 → Custom Resolver configured?
+    #                   ├─ Valid → Return country
+    #                   └─ Invalid/Error → Continue
+    #                 → Local MMDB reader configured?
+    #                   ├─ Hit → Return country
+    #                   └─ Miss → Built-in range detection
+    #                             └─ Unknown ('**')
     #
     class GeoResolver
       # Unknown country code (not ISO 3166-1 alpha-2, intentionally distinct)
@@ -114,25 +131,46 @@ class Otto
         end
       end
 
-      # Resolve country code for an IP address
+      # Resolve country code for an IP address.
       #
-      # Resolution priority:
-      # 1. CDN/infrastructure provider headers (Cloudflare, AWS, Fastly, etc.)
-      # 2. Basic IP range detection for major countries/providers
-      # 3. Return '**' for unknown
+      # Resolution order (first hit wins). Header steps (1–2) are skipped when
+      # +headers_trusted+ is false, since geo headers are client-spoofable
+      # unless the request actually arrived through the trusted CDN/proxy:
+      # 1. App-configured trusted header (+config.geo_header+)
+      # 2. Built-in CDN/infrastructure provider headers
+      # 3. Custom resolver hook ({.custom_resolver})
+      # 4. Local MMDB lookup (+config.geo_db_reader+) — expects a MASKED IP
+      # 5. Built-in IP-range detection
+      # 6. '**' for unknown
       #
-      # @param ip [String] IP address to resolve
+      # +ip+ SHOULD be the privacy-masked address when called from the Otto
+      # middleware: country-level MMDB networks are almost always >= /24, so the
+      # /24-masked +x.y.z.0+ resolves to the same country as the real IP, and the
+      # unmasked address never reaches the resolver.
+      #
+      # @param ip [String] IP address to resolve (masked, in the framework path)
       # @param env [Hash] Rack environment (may contain geo headers)
+      # @param config [Otto::Privacy::Config, nil] privacy config supplying the
+      #   configured header and MMDB reader. When nil, only the built-in provider
+      #   headers, custom resolver and range detection are used (legacy behavior).
+      # @param headers_trusted [Boolean] whether request geo headers may be
+      #   trusted for this request (default true; the middleware computes this
+      #   from the trusted-proxy decision).
       # @return [String] ISO 3166-1 alpha-2 country code or '**'
-      def self.resolve(ip, env = {})
+      def self.resolve(ip, env = {}, config = nil, headers_trusted: true)
         return UNKNOWN if ip.nil? || ip.empty?
 
-        # Check CDN/infrastructure headers in priority order
-        # Priority based on reliability and deployment frequency
-        country = check_geo_headers(env)
-        return country if country
+        if headers_trusted
+          # 1. App-configured trusted header wins over provider headers.
+          country = check_configured_header(env, config)
+          return country if country
 
-        # Try custom resolver if configured
+          # 2. Built-in CDN/infrastructure headers, in priority order.
+          country = check_geo_headers(env)
+          return country if country
+        end
+
+        # 3. Custom resolver hook, if configured.
         if @custom_resolver
           begin
             country = @custom_resolver.call(ip, env)
@@ -143,11 +181,69 @@ class Otto
           end
         end
 
-        # Fallback: Basic range detection
+        # 4. Local MMDB database lookup on the (masked) IP.
+        country = check_geo_database(ip, config)
+        return country if country
+
+        # 5. Fallback: Basic range detection.
         detect_by_range(ip)
       rescue IPAddr::InvalidAddressError
         UNKNOWN
       end
+
+      # Check the app-configured trusted geo header, if any.
+      #
+      # @param env [Hash] Rack environment
+      # @param config [Otto::Privacy::Config, nil]
+      # @return [String, nil] valid country code from the configured header, or nil
+      # @api private
+      def self.check_configured_header(env, config)
+        header = config&.geo_header
+        return nil unless header
+
+        country = env[header]
+        valid_country_code?(country) ? country : nil
+      end
+      private_class_method :check_configured_header
+
+      # Look up the country for an IP in the configured MMDB database.
+      #
+      # No-op (returns nil) when no config or reader is available. The reader is
+      # any object responding to +#get(ip)+; result shapes from both
+      # GeoLite2-Country-compatible ('country' => {'iso_code' => ...}) and flat
+      # ('country_code' => ...) mmdb builds are handled.
+      #
+      # @param ip [String] IP address (masked, in the framework path)
+      # @param config [Otto::Privacy::Config, nil]
+      # @return [String, nil] valid country code, or nil on miss/error
+      # @api private
+      def self.check_geo_database(ip, config)
+        reader = config&.geo_db_reader
+        return nil unless reader
+
+        country = extract_db_country(reader.get(ip))
+        valid_country_code?(country) ? country : nil
+      rescue StandardError => e
+        # A DB read must never crash a request; fall through to range detection.
+        warn "GeoResolver database lookup error: #{e.message}" if $DEBUG
+        nil
+      end
+      private_class_method :check_geo_database
+
+      # Extract an ISO country code from an MMDB lookup result.
+      #
+      # @param result [Object] whatever the reader returned for the IP
+      # @return [String, nil] country code string, or nil
+      # @api private
+      def self.extract_db_country(result)
+        return nil unless result.is_a?(Hash)
+
+        code = result.dig('country', 'iso_code') ||
+               result['country_code'] ||
+               result['country']
+        code.is_a?(String) ? code : nil
+      end
+      private_class_method :extract_db_country
 
       # Check CDN/infrastructure provider geo headers
       #
@@ -157,7 +253,8 @@ class Otto
       # 3. Fastly (Fastly-Client-IP-Country)
       # 4. Akamai (X-Akamai-Edgescape) - Complex format, extract country
       # 5. Azure Front Door (X-Azure-ClientIP-Country)
-      # 6. Semi-standard headers (X-Geo-Country, X-Country-Code, Country-Code)
+      # 6. Vercel (X-Vercel-IP-Country)
+      # 7. Semi-standard headers (X-Geo-Country, X-Country-Code, Country-Code)
       #
       # @param env [Hash] Rack environment
       # @return [String, nil] ISO 3166-1 alpha-2 country code or nil
@@ -183,6 +280,10 @@ class Otto
 
         # Azure Front Door
         country = env['HTTP_X_AZURE_CLIENTIP_COUNTRY']
+        return country if valid_country_code?(country)
+
+        # Vercel
+        country = env['HTTP_X_VERCEL_IP_COUNTRY']
         return country if valid_country_code?(country)
 
         # Semi-standard headers (least reliable, check last)

--- a/lib/otto/privacy/ip_privacy.rb
+++ b/lib/otto/privacy/ip_privacy.rb
@@ -119,6 +119,24 @@ class Otto
         false
       end
 
+      # Build an RFC 7239 Forwarded header value carrying only the masked IP.
+      #
+      # The Forwarded header (unlike X-Forwarded-For) is structured, so it can't
+      # be swapped wholesale for a bare IP without producing invalid syntax.
+      # This collapses it to a single, syntactically valid `for=` element with
+      # the masked address — the same "discard the chain, keep the masked IP"
+      # treatment the middleware applies to X-Forwarded-For. IPv6 is bracketed
+      # and quoted as the RFC requires.
+      #
+      # @param masked_ip [String, nil] the masked client IP
+      # @return [String, nil] e.g. 'for=192.0.2.0' or 'for="[2001:db8::]"', or
+      #   nil when there is no masked IP
+      def self.forwarded_header_for(masked_ip)
+        return nil if masked_ip.nil? || masked_ip.empty?
+
+        masked_ip.include?(':') ? %(for="[#{masked_ip}]") : "for=#{masked_ip}"
+      end
+
       # Mask IPv4 address
       #
       # @param addr [IPAddr] IPAddr object (must be IPv4)

--- a/lib/otto/privacy/ip_privacy.rb
+++ b/lib/otto/privacy/ip_privacy.rb
@@ -119,22 +119,28 @@ class Otto
         false
       end
 
-      # Build an RFC 7239 Forwarded header value carrying only the masked IP.
+      # Redact the client identifier(s) in an RFC 7239 Forwarded header value.
       #
-      # The Forwarded header (unlike X-Forwarded-For) is structured, so it can't
-      # be swapped wholesale for a bare IP without producing invalid syntax.
-      # This collapses it to a single, syntactically valid `for=` element with
-      # the masked address — the same "discard the chain, keep the masked IP"
-      # treatment the middleware applies to X-Forwarded-For. IPv6 is bracketed
-      # and quoted as the RFC requires.
+      # Only the `for=` node value is replaced with the masked IP; `proto=`,
+      # `host=`, `by=` and the overall structure are preserved so downstream
+      # scheme/host/proxy decisions (absolute URLs, redirects, secure cookies)
+      # still work. Every `for=` element in the chain is redacted. IPv6 is
+      # bracketed and quoted as the RFC requires. This is the structured-header
+      # counterpart to the wholesale X-Forwarded-For swap.
       #
+      # @param value [String, nil] the Forwarded header value
       # @param masked_ip [String, nil] the masked client IP
-      # @return [String, nil] e.g. 'for=192.0.2.0' or 'for="[2001:db8::]"', or
-      #   nil when there is no masked IP
-      def self.forwarded_header_for(masked_ip)
-        return nil if masked_ip.nil? || masked_ip.empty?
+      # @return [String, nil] the header with every `for=` value redacted, or
+      #   the value unchanged when there is nothing to mask
+      def self.mask_forwarded_for(value, masked_ip)
+        return value if value.nil? || masked_ip.nil? || masked_ip.empty?
 
-        masked_ip.include?(':') ? %(for="[#{masked_ip}]") : "for=#{masked_ip}"
+        replacement = masked_ip.include?(':') ? %("[#{masked_ip}]") : masked_ip
+        # Match `for=` only at an element/pair boundary (start, comma, or
+        # semicolon) so a parameter merely ending in "for" is never touched.
+        value.gsub(/(\A|[,;]\s*)for\s*=\s*("[^"]*"|[^;,]+)/i) do
+          "#{Regexp.last_match(1)}for=#{replacement}"
+        end
       end
 
       # Mask IPv4 address

--- a/lib/otto/privacy/redacted_fingerprint.rb
+++ b/lib/otto/privacy/redacted_fingerprint.rb
@@ -25,6 +25,16 @@ class Otto
                   :country, :anonymized_ua, :request_path,
                   :request_method, :referer
 
+      # IP-bearing forwarded headers to mask in the geo-resolution env view.
+      # Mirrors the set IPPrivacyMiddleware#mask_forwarded_headers rewrites, so a
+      # custom resolver reading env sees masked values everywhere the middleware
+      # would otherwise have masked them.
+      GEO_MASKED_FORWARDED_HEADERS = %w[
+        HTTP_X_FORWARDED_FOR
+        HTTP_X_REAL_IP
+        HTTP_X_CLIENT_IP
+      ].freeze
+
       # Create a new RedactedFingerprint from a Rack environment
       #
       # @param env [Hash] Rack environment hash
@@ -40,11 +50,13 @@ class Otto
         @timestamp = Time.now.utc
         @masked_ip = IPPrivacy.mask_ip(remote_ip, config.octet_precision)
         @hashed_ip = IPPrivacy.hash_ip(remote_ip, config.rotation_key)
-        # Geo resolves on the MASKED IP so the unmasked address never reaches the
-        # resolver (custom resolver / MMDB). Country-level networks are >= /24,
-        # so a /24-masked address resolves to the same country as the real one.
+        # hashed_ip is computed above from the real IP; geo resolution then runs
+        # against a MASKED view — the masked IP AND an env with the IP-bearing
+        # headers masked — so neither a custom resolver nor the database can see
+        # the unmasked address, via the argument or via env. Country-level
+        # networks are >= /24, so the /24-masked IP resolves to the same country.
         @country = if config.geo_enabled
-                     GeoResolver.resolve(@masked_ip, env, config, headers_trusted: geo_headers_trusted)
+                     GeoResolver.resolve(@masked_ip, geo_env(env), config, headers_trusted: geo_headers_trusted)
                    end
         @anonymized_ua = anonymize_user_agent(env['HTTP_USER_AGENT'])
         @request_path = env['PATH_INFO']
@@ -98,6 +110,28 @@ class Otto
       end
 
       private
+
+      # A shallow copy of env with the client-IP fields masked, for geo
+      # resolution. Country-level geo needs nothing finer than the masked /24,
+      # so a custom resolver (arbitrary app code that might log or forward what
+      # it receives) is handed only the masked address here — never the raw host
+      # IP that env['REMOTE_ADDR'] and the forwarded headers still carry at this
+      # point in the middleware. Non-IP keys (including geo headers like
+      # CF-IPCountry) are preserved. Returns env unchanged when there is no
+      # masked IP (nothing to hide, and geo resolution short-circuits anyway).
+      #
+      # @param env [Hash] Rack environment
+      # @return [Hash] masked env view
+      def geo_env(env)
+        return env if @masked_ip.nil?
+
+        masked = env.dup
+        masked['REMOTE_ADDR'] = @masked_ip
+        GEO_MASKED_FORWARDED_HEADERS.each do |key|
+          masked[key] = @masked_ip if masked.key?(key)
+        end
+        masked
+      end
 
       # Anonymize user agent string by removing version numbers and build identifiers
       #

--- a/lib/otto/privacy/redacted_fingerprint.rb
+++ b/lib/otto/privacy/redacted_fingerprint.rb
@@ -25,10 +25,12 @@ class Otto
                   :country, :anonymized_ua, :request_path,
                   :request_method, :referer
 
-      # IP-bearing forwarded headers to mask in the geo-resolution env view.
-      # Mirrors the set IPPrivacyMiddleware#mask_forwarded_headers rewrites, so a
-      # custom resolver reading env sees masked values everywhere the middleware
-      # would otherwise have masked them.
+      # IP-bearing forwarded headers overwritten with the masked IP in the
+      # geo-resolution env view. Mirrors the set
+      # IPPrivacyMiddleware#mask_forwarded_headers rewrites, so a custom resolver
+      # reading env sees masked values everywhere the middleware would. The
+      # structured RFC 7239 Forwarded header (HTTP_FORWARDED) is handled
+      # separately in {#geo_env} (dropped, not swapped, to keep valid syntax).
       GEO_MASKED_FORWARDED_HEADERS = %w[
         HTTP_X_FORWARDED_FOR
         HTTP_X_REAL_IP
@@ -130,6 +132,13 @@ class Otto
         GEO_MASKED_FORWARDED_HEADERS.each do |key|
           masked[key] = @masked_ip if masked.key?(key)
         end
+        # HTTP_FORWARDED (RFC 7239) carries the client IP in a structured `for=`
+        # token — and Otto reads it as an authoritative client-IP source in
+        # depth mode with trusted_proxy_header 'Forwarded'/'Both'. A wholesale
+        # swap would produce invalid Forwarded syntax, and geo resolution needs
+        # nothing from it, so drop it from the geo view entirely rather than
+        # leak the raw address to a custom resolver.
+        masked.delete('HTTP_FORWARDED')
         masked
       end
 

--- a/lib/otto/privacy/redacted_fingerprint.rb
+++ b/lib/otto/privacy/redacted_fingerprint.rb
@@ -29,14 +29,23 @@ class Otto
       #
       # @param env [Hash] Rack environment hash
       # @param config [Otto::Privacy::Config] Privacy configuration
-      def initialize(env, config)
+      # @param geo_headers_trusted [Boolean] whether request geo headers may be
+      #   trusted for this request. The middleware passes false for a
+      #   non-trusted-proxy request when trusted proxies are configured, so
+      #   spoofed geo headers are ignored. Defaults to true for standalone use.
+      def initialize(env, config, geo_headers_trusted: true)
         remote_ip = env['REMOTE_ADDR']
 
         @session_id = SecureRandom.uuid
         @timestamp = Time.now.utc
         @masked_ip = IPPrivacy.mask_ip(remote_ip, config.octet_precision)
         @hashed_ip = IPPrivacy.hash_ip(remote_ip, config.rotation_key)
-        @country = config.geo_enabled ? GeoResolver.resolve(remote_ip, env) : nil
+        # Geo resolves on the MASKED IP so the unmasked address never reaches the
+        # resolver (custom resolver / MMDB). Country-level networks are >= /24,
+        # so a /24-masked address resolves to the same country as the real one.
+        @country = if config.geo_enabled
+                     GeoResolver.resolve(@masked_ip, env, config, headers_trusted: geo_headers_trusted)
+                   end
         @anonymized_ua = anonymize_user_agent(env['HTTP_USER_AGENT'])
         @request_path = env['PATH_INFO']
         @request_method = env['REQUEST_METHOD']

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -217,6 +217,20 @@ class Otto
         end
       end
 
+      # Whether any trusted-proxy IP/CIDR/Regexp matchers are configured.
+      #
+      # This mirrors {#trusted_proxy?}, which consults the same matcher list, so
+      # the two answers stay consistent: a request can only be "via a trusted
+      # proxy" when matchers exist. It deliberately EXCLUDES count-based depth
+      # mode — depth resolves the client IP but never confers proxy identity
+      # trust (the same decoupling {Otto::Request#forwarded_by_trusted_proxy?}
+      # applies to X-Forwarded-Proto). Used to gate geo-header trust.
+      #
+      # @return [Boolean] true when at least one trusted-proxy matcher exists
+      def trusted_proxies_configured?
+        @trusted_proxy_matchers.any?
+      end
+
       # Whether count-based ("trust the last N hops") proxy resolution is active.
       #
       # When true, Otto::Utils.resolve_client_ip ignores trusted-proxy CIDRs and

--- a/lib/otto/security/middleware/ip_privacy_middleware.rb
+++ b/lib/otto/security/middleware/ip_privacy_middleware.rb
@@ -313,29 +313,28 @@ class Otto
         #
         # Geo headers (CF-IPCountry and friends, plus any app-configured header)
         # are client-spoofable unless the request actually arrived through the
-        # CDN/proxy that sets them. Trust mirrors Otto's proxy model, per mode:
+        # CDN/proxy that sets them. So Otto trusts them ONLY when it can verify
+        # that origin: a request that arrived via a configured CIDR trusted
+        # proxy (identity checked against REMOTE_ADDR).
         #
-        # - CIDR trusted-proxy mode: trust only a request that arrived via a
-        #   trusted proxy (identity verified against REMOTE_ADDR).
-        # - Count-based depth mode: NOT trusted. Depth resolves the client IP by
-        #   peeling a fixed number of hops but cannot verify that the hop setting
-        #   a geo header is a real geo-CDN (depth proxies are often plain load
-        #   balancers that pass a spoofed header straight through). Geo then
-        #   falls to the local database / range detection.
-        # - No trusted-proxy configuration: Otto cannot tell a real CDN from a
-        #   spoofer, so it preserves legacy behavior and trusts geo headers.
-        #   Deployments exposed to spoofing should configure trusted_proxies or
-        #   rely on a local database.
+        # Every other case is untrusted, and geo falls to the local database /
+        # custom resolver:
+        # - Count-based depth mode: the hop setting the header can't be verified
+        #   as a geo-CDN (depth proxies are often plain load balancers), and
+        #   depth configures no CIDR matchers, so trusted_proxies_configured? is
+        #   false here too.
+        # - No trusted-proxy configuration: the header is client-supplied and
+        #   unverifiable. Deployments behind a real CDN should configure
+        #   trusted_proxies (or a local database) to get header-based geo.
         #
         # @param env [Hash] Rack environment
         # @return [Boolean]
         def geo_headers_trusted?(env)
           sc = @security_config
-          return true unless sc.respond_to?(:trusted_proxies_configured?)
-          return false if sc.respond_to?(:trusted_proxy_depth_mode?) && sc.trusted_proxy_depth_mode?
-          return env['otto.via_trusted_proxy'] == true if sc.trusted_proxies_configured?
+          return false unless sc.respond_to?(:trusted_proxies_configured?)
+          return false unless sc.trusted_proxies_configured?
 
-          true
+          env['otto.via_trusted_proxy'] == true
         end
 
         # Apply no-privacy settings (privacy explicitly disabled)

--- a/lib/otto/security/middleware/ip_privacy_middleware.rb
+++ b/lib/otto/security/middleware/ip_privacy_middleware.rb
@@ -96,7 +96,10 @@ class Otto
           # un-anonymized User-Agent or Referer.
           if client_ip.to_s.empty?
             Otto.logger.debug '[IPPrivacyMiddleware] No resolvable client IP; skipping IP masking' if Otto.debug
-            scrub_sensitive_headers(env, Otto::Privacy::RedactedFingerprint.new(env, @config))
+            scrub_sensitive_headers(
+              env,
+              Otto::Privacy::RedactedFingerprint.new(env, @config, geo_headers_trusted: geo_headers_trusted?(env))
+            )
             return
           end
 
@@ -128,7 +131,9 @@ class Otto
           # We temporarily set REMOTE_ADDR to the client IP for fingerprint creation
           original_remote_addr = env['REMOTE_ADDR']
           env['REMOTE_ADDR'] = client_ip
-          fingerprint = Otto::Privacy::RedactedFingerprint.new(env, @config)
+          fingerprint = Otto::Privacy::RedactedFingerprint.new(
+            env, @config, geo_headers_trusted: geo_headers_trusted?(env)
+          )
           env['REMOTE_ADDR'] = original_remote_addr
 
           # Set privacy-safe values in environment
@@ -272,6 +277,26 @@ class Otto
           return false unless @security_config
 
           @security_config.trusted_proxy?(ip)
+        end
+
+        # Whether request geo headers may be trusted for this request.
+        #
+        # Geo headers (CF-IPCountry and friends, plus any app-configured header)
+        # are client-spoofable unless the request actually arrived through the
+        # CDN/proxy that sets them. So:
+        # - When trusted proxies ARE configured, trust geo headers only if this
+        #   request came via one (env['otto.via_trusted_proxy']).
+        # - When NO trusted proxies are configured, Otto cannot tell a real CDN
+        #   from a spoofer, so it preserves the legacy behavior and trusts them.
+        #   (This keeps existing header-only deployments working unchanged.)
+        #
+        # @param env [Hash] Rack environment
+        # @return [Boolean]
+        def geo_headers_trusted?(env)
+          return true unless @security_config.respond_to?(:trusted_proxies_configured?)
+          return true unless @security_config.trusted_proxies_configured?
+
+          env['otto.via_trusted_proxy'] == true
         end
 
         # Apply no-privacy settings (privacy explicitly disabled)

--- a/lib/otto/security/middleware/ip_privacy_middleware.rb
+++ b/lib/otto/security/middleware/ip_privacy_middleware.rb
@@ -283,20 +283,29 @@ class Otto
         #
         # Geo headers (CF-IPCountry and friends, plus any app-configured header)
         # are client-spoofable unless the request actually arrived through the
-        # CDN/proxy that sets them. So:
-        # - When trusted proxies ARE configured, trust geo headers only if this
-        #   request came via one (env['otto.via_trusted_proxy']).
-        # - When NO trusted proxies are configured, Otto cannot tell a real CDN
-        #   from a spoofer, so it preserves the legacy behavior and trusts them.
-        #   (This keeps existing header-only deployments working unchanged.)
+        # CDN/proxy that sets them. Trust mirrors Otto's proxy model, per mode:
+        #
+        # - CIDR trusted-proxy mode: trust only a request that arrived via a
+        #   trusted proxy (identity verified against REMOTE_ADDR).
+        # - Count-based depth mode: NOT trusted. Depth resolves the client IP by
+        #   peeling a fixed number of hops but cannot verify that the hop setting
+        #   a geo header is a real geo-CDN (depth proxies are often plain load
+        #   balancers that pass a spoofed header straight through). Geo then
+        #   falls to the local database / range detection.
+        # - No trusted-proxy configuration: Otto cannot tell a real CDN from a
+        #   spoofer, so it preserves legacy behavior and trusts geo headers.
+        #   Deployments exposed to spoofing should configure trusted_proxies or
+        #   rely on a local database.
         #
         # @param env [Hash] Rack environment
         # @return [Boolean]
         def geo_headers_trusted?(env)
-          return true unless @security_config.respond_to?(:trusted_proxies_configured?)
-          return true unless @security_config.trusted_proxies_configured?
+          sc = @security_config
+          return true unless sc.respond_to?(:trusted_proxies_configured?)
+          return false if sc.respond_to?(:trusted_proxy_depth_mode?) && sc.trusted_proxy_depth_mode?
+          return env['otto.via_trusted_proxy'] == true if sc.trusted_proxies_configured?
 
-          env['otto.via_trusted_proxy'] == true
+          true
         end
 
         # Apply no-privacy settings (privacy explicitly disabled)

--- a/lib/otto/security/middleware/ip_privacy_middleware.rb
+++ b/lib/otto/security/middleware/ip_privacy_middleware.rb
@@ -266,6 +266,13 @@ class Otto
           env['HTTP_X_REAL_IP'] = masked_ip if env['HTTP_X_REAL_IP']
           env['HTTP_X_CLIENT_IP'] = masked_ip if env['HTTP_X_CLIENT_IP']
 
+          # RFC 7239 Forwarded carries the client IP in a structured `for=`
+          # token, and Otto reads it as an authoritative client-IP source in
+          # count-based depth mode (trusted_proxy_header 'Forwarded'/'Both').
+          # Left as-is it would leak the real IP to downstream code, so rewrite
+          # it to a valid Forwarded value holding only the masked IP.
+          env['HTTP_FORWARDED'] = Otto::Privacy::IPPrivacy.forwarded_header_for(masked_ip) if env['HTTP_FORWARDED']
+
           Otto.logger.debug "[IPPrivacyMiddleware] Masked forwarded headers" if Otto.debug
         end
 

--- a/lib/otto/security/middleware/ip_privacy_middleware.rb
+++ b/lib/otto/security/middleware/ip_privacy_middleware.rb
@@ -94,12 +94,18 @@ class Otto
           # original sensitive data. So still scrub those headers before
           # bailing — a request with no resolvable IP must not leak an
           # un-anonymized User-Agent or Referer.
+          #
+          # Likewise, forwarded headers may still carry raw client addresses
+          # (e.g. an X-Forwarded-For / Forwarded value with no usable REMOTE_ADDR
+          # to anchor resolution). There is no masked IP to rewrite them to, so
+          # DELETE them — leaving them would leak the raw address downstream.
           if client_ip.to_s.empty?
             Otto.logger.debug '[IPPrivacyMiddleware] No resolvable client IP; skipping IP masking' if Otto.debug
             scrub_sensitive_headers(
               env,
               Otto::Privacy::RedactedFingerprint.new(env, @config, geo_headers_trusted: geo_headers_trusted?(env))
             )
+            scrub_forwarded_headers(env)
             return
           end
 
@@ -244,6 +250,21 @@ class Otto
           Otto::Utils.resolve_client_ip(env, @security_config)
         end
 
+        # Delete forwarded IP headers outright.
+        #
+        # Used on the no-resolvable-client-IP path, where there is no masked IP
+        # to rewrite these to. Leaving them would leak a raw client address (in
+        # X-Forwarded-For / X-Real-IP / X-Client-IP / RFC 7239 Forwarded)
+        # downstream. Deleting is Rack-SPEC-safe: an absent CGI key is valid.
+        #
+        # @param env [Hash] Rack environment
+        def scrub_forwarded_headers(env)
+          env.delete('HTTP_X_FORWARDED_FOR')
+          env.delete('HTTP_X_REAL_IP')
+          env.delete('HTTP_X_CLIENT_IP')
+          env.delete('HTTP_FORWARDED')
+        end
+
         # Mask X-Forwarded-For and related proxy headers
         #
         # Replaces forwarded IP headers with the masked IP to prevent leakage
@@ -269,9 +290,11 @@ class Otto
           # RFC 7239 Forwarded carries the client IP in a structured `for=`
           # token, and Otto reads it as an authoritative client-IP source in
           # count-based depth mode (trusted_proxy_header 'Forwarded'/'Both').
-          # Left as-is it would leak the real IP to downstream code, so rewrite
-          # it to a valid Forwarded value holding only the masked IP.
-          env['HTTP_FORWARDED'] = Otto::Privacy::IPPrivacy.forwarded_header_for(masked_ip) if env['HTTP_FORWARDED']
+          # Left as-is it would leak the real IP to downstream code. Redact only
+          # the `for=` value(s) so proto=/host=/by= metadata survives.
+          if env['HTTP_FORWARDED']
+            env['HTTP_FORWARDED'] = Otto::Privacy::IPPrivacy.mask_forwarded_for(env['HTTP_FORWARDED'], masked_ip)
+          end
 
           Otto.logger.debug "[IPPrivacyMiddleware] Masked forwarded headers" if Otto.debug
         end

--- a/spec/otto/geo_resolver_config_spec.rb
+++ b/spec/otto/geo_resolver_config_spec.rb
@@ -114,8 +114,8 @@ RSpec.describe 'Configurable geo resolution' do
         expect(described_class.resolve('9.9.9.0', env, config)).to eq('US')
       end
 
-      it 'falls through to range detection when no header matches' do
-        expect(described_class.resolve('8.8.8.0', {}, config)).to eq('US')
+      it 'returns ** when no header matches and nothing else resolves' do
+        expect(described_class.resolve('8.8.8.0', {}, config)).to eq('**')
       end
     end
 
@@ -130,10 +130,12 @@ RSpec.describe 'Configurable geo resolution' do
       let(:config) { Otto::Privacy::Config.new(geo_header: 'X-Client-Country') }
 
       it 'skips both configured and provider headers when headers are untrusted' do
+        # A database gives a definitive non-header answer, proving neither
+        # spoofable header (JP / GB) was consulted.
+        reader = recording_reader('9.9.9.0' => { 'country' => { 'iso_code' => 'CH' } })
+        cfg = Otto::Privacy::Config.new(geo_header: 'X-Client-Country', geo_db_reader: reader)
         env = { 'HTTP_X_CLIENT_COUNTRY' => 'JP', 'HTTP_CF_IPCOUNTRY' => 'GB' }
-        # 9.9.9.0 (Quad9) resolves to CH by range detection, proving neither
-        # spoofable header was consulted.
-        expect(described_class.resolve('9.9.9.0', env, config, headers_trusted: false)).to eq('CH')
+        expect(described_class.resolve('9.9.9.0', env, cfg, headers_trusted: false)).to eq('CH')
       end
 
       it 'still consults the database when headers are untrusted' do
@@ -210,10 +212,10 @@ RSpec.describe 'Configurable geo resolution' do
       end
     end
 
-    describe '.resolve backward compatibility' do
-      it 'behaves as before when no config is supplied' do
+    describe '.resolve with no config supplied' do
+      it 'uses provider headers and otherwise returns unknown' do
         expect(described_class.resolve('8.8.8.8', { 'HTTP_CF_IPCOUNTRY' => 'GB' })).to eq('GB')
-        expect(described_class.resolve('8.8.8.8', {})).to eq('US')
+        expect(described_class.resolve('8.8.8.8', {})).to eq('**')
         expect(described_class.resolve('240.0.0.1', {})).to eq('**')
       end
     end
@@ -265,12 +267,14 @@ RSpec.describe 'Configurable geo resolution' do
       it 'ignores a spoofed provider header from a non-trusted-proxy request' do
         sc = Otto::Security::Config.new
         sc.add_trusted_proxy('10.0.0.1')
+        # A database gives the true country; the forged CF-IPCountry: GB is a lie.
+        sc.ip_privacy_config.geo_db_reader = recording_reader('8.8.8.0' => { 'country' => { 'iso_code' => 'US' } })
+        sc.ip_privacy_config.load_geo_database!
 
-        # Direct connection from 8.8.8.8 with a forged CF-IPCountry: GB is a lie.
         env = run(sc, { 'REMOTE_ADDR' => '8.8.8.8', 'HTTP_CF_IPCOUNTRY' => 'GB' })
 
         expect(env['otto.via_trusted_proxy']).to be false
-        # Header ignored; masked 8.8.8.0 resolves to US by range detection.
+        # Spoofed header ignored; the DB (masked 8.8.8.0) answers US, not GB.
         expect(env['otto.privacy.geo_country']).to eq('US')
       end
 
@@ -282,9 +286,11 @@ RSpec.describe 'Configurable geo resolution' do
       it 'ignores geo headers in count-based depth mode (edge unverifiable)' do
         sc = Otto::Security::Config.new
         sc.trusted_proxy_depth = 1
-
         # Depth mode can't verify the hop that set CF-IPCountry is a geo-CDN, so
-        # the forged GB header is ignored; masked 8.8.8.0 resolves to US.
+        # the forged GB header is ignored; the DB answers the true country.
+        sc.ip_privacy_config.geo_db_reader = recording_reader('8.8.8.0' => { 'country' => { 'iso_code' => 'US' } })
+        sc.ip_privacy_config.load_geo_database!
+
         env = run(sc, {
                     'REMOTE_ADDR' => '10.0.0.1',
                     'HTTP_X_FORWARDED_FOR' => '8.8.8.8',

--- a/spec/otto/geo_resolver_config_spec.rb
+++ b/spec/otto/geo_resolver_config_spec.rb
@@ -157,6 +157,13 @@ RSpec.describe 'Configurable geo resolution' do
         expect(described_class.resolve('5.5.5.0', {}, config)).to eq('FR')
       end
 
+      it 'reads a bare country-string result without raising' do
+        # A reader returning {'country' => 'US'} must not trip String#dig.
+        reader = recording_reader('5.5.5.0' => { 'country' => 'US' })
+        config = Otto::Privacy::Config.new(geo_db_reader: reader)
+        expect(described_class.resolve('5.5.5.0', {}, config)).to eq('US')
+      end
+
       it 'treats an invalid database code as unknown (authoritative DB)' do
         reader = recording_reader('8.8.8.0' => { 'country' => { 'iso_code' => 'ZZZ' } })
         config = Otto::Privacy::Config.new(geo_db_reader: reader)
@@ -350,6 +357,28 @@ RSpec.describe 'Configurable geo resolution' do
 
         # geo_env hands the resolver a dup, so the request env is untouched.
         expect(env['REMOTE_ADDR']).to eq('8.8.8.8')
+      end
+
+      it 'strips the RFC 7239 Forwarded header from the resolver env view' do
+        captured = {}
+        Otto::Privacy::GeoResolver.custom_resolver = lambda do |ip, resolver_env|
+          captured[:ip] = ip
+          captured[:has_forwarded] = resolver_env.key?('HTTP_FORWARDED')
+          captured[:values] = resolver_env.values
+          'PT'
+        end
+
+        # HTTP_FORWARDED carries the real client IP in its `for=` token; Otto
+        # reads it as authoritative in depth mode. It must not reach the resolver.
+        env = { 'REMOTE_ADDR' => '203.0.113.77', 'HTTP_FORWARDED' => 'for=203.0.113.77;proto=https' }
+        Otto::Privacy::RedactedFingerprint.new(env, Otto::Privacy::Config.new)
+
+        expect(captured[:ip]).to eq('203.0.113.0')
+        expect(captured[:has_forwarded]).to be false
+        leaked = captured[:values].any? { |v| v.is_a?(String) && v.include?('203.0.113.77') }
+        expect(leaked).to be false
+        # The real request env is untouched (the resolver saw a masked dup).
+        expect(env['HTTP_FORWARDED']).to eq('for=203.0.113.77;proto=https')
       end
     end
   end

--- a/spec/otto/geo_resolver_config_spec.rb
+++ b/spec/otto/geo_resolver_config_spec.rb
@@ -1,0 +1,334 @@
+# spec/otto/geo_resolver_config_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Coverage for the configurable geo-header source and the local IP->country
+# database fallback added on top of the built-in CDN-header resolution.
+RSpec.describe 'Configurable geo resolution' do
+  # A minimal MMDB-style reader: any object responding to #get(ip). Records the
+  # exact IP it was asked about so we can prove the resolver only ever sees the
+  # MASKED address.
+  def recording_reader(mapping)
+    Class.new do
+      attr_reader :seen
+
+      def initialize(mapping)
+        @mapping = mapping
+        @seen = []
+      end
+
+      def get(ip)
+        @seen << ip
+        @mapping[ip]
+      end
+    end.new(mapping)
+  end
+
+  describe Otto::Privacy::Config do
+    describe '#geo_header=' do
+      it 'canonicalizes an HTTP-form header to an env key' do
+        config = described_class.new(geo_header: 'X-Client-Country')
+        expect(config.geo_header).to eq('HTTP_X_CLIENT_COUNTRY')
+      end
+
+      it 'accepts the CGI/env form unchanged' do
+        config = described_class.new(geo_header: 'HTTP_X_CLIENT_COUNTRY')
+        expect(config.geo_header).to eq('HTTP_X_CLIENT_COUNTRY')
+      end
+
+      it 'lower-cases and dash-normalizes input' do
+        config = described_class.new(geo_header: 'x-client-country')
+        expect(config.geo_header).to eq('HTTP_X_CLIENT_COUNTRY')
+      end
+
+      it 'treats nil and blank as no header' do
+        expect(described_class.new(geo_header: nil).geo_header).to be_nil
+        expect(described_class.new(geo_header: '   ').geo_header).to be_nil
+      end
+    end
+
+    describe '#geo_db_reader' do
+      it 'returns an injected reader' do
+        reader = recording_reader({})
+        config = described_class.new(geo_db_reader: reader)
+        expect(config.geo_db_reader).to equal(reader)
+      end
+
+      it 'rejects a reader that does not respond to :get' do
+        expect { described_class.new(geo_db_reader: Object.new) }
+          .to raise_error(ArgumentError, /must respond to :get/)
+      end
+
+      it 'returns nil when geo is disabled (no DB consulted)' do
+        reader = recording_reader({})
+        config = described_class.new(geo_enabled: false, geo_db_reader: reader)
+        expect(config.geo_db_reader).to be_nil
+      end
+
+      it 'survives deep_freeze! and stays usable (reader held at class level)' do
+        reader = recording_reader('1.2.3.0' => { 'country' => { 'iso_code' => 'US' } })
+        config = described_class.new(geo_db_reader: reader)
+        config.deep_freeze!
+
+        expect(config).to be_frozen
+        expect(config.geo_db_reader).to equal(reader)
+      end
+    end
+
+    describe '#geo_db_path (boot-time loading)' do
+      it 'raises at boot for an unreadable path (not per-request)' do
+        expect { described_class.new(geo_db_path: '/no/such/geo.mmdb') }
+          .to raise_error(ArgumentError, /not readable/)
+      end
+
+      it 'does not load a database when geo is disabled' do
+        # geo disabled short-circuits: the (bad) path is never opened, so no
+        # boot error and no reader in memory.
+        expect { described_class.new(geo_enabled: false, geo_db_path: '/no/such/geo.mmdb') }
+          .not_to raise_error
+      end
+    end
+
+    describe '.canonicalize_geo_header' do
+      it 'maps equivalent forms to the same env key' do
+        %w[X-Vercel-IP-Country HTTP_X_VERCEL_IP_COUNTRY x-vercel-ip-country].each do |form|
+          expect(described_class.canonicalize_geo_header(form)).to eq('HTTP_X_VERCEL_IP_COUNTRY')
+        end
+      end
+    end
+  end
+
+  describe Otto::Privacy::GeoResolver do
+    describe '.resolve with a configured header' do
+      let(:config) { Otto::Privacy::Config.new(geo_header: 'X-Client-Country') }
+
+      it 'prefers the configured header over provider headers' do
+        env = { 'HTTP_X_CLIENT_COUNTRY' => 'JP', 'HTTP_CF_IPCOUNTRY' => 'US' }
+        expect(described_class.resolve('9.9.9.0', env, config)).to eq('JP')
+      end
+
+      it 'ignores an invalid configured code and falls through to providers' do
+        env = { 'HTTP_X_CLIENT_COUNTRY' => 'invalid', 'HTTP_CF_IPCOUNTRY' => 'US' }
+        expect(described_class.resolve('9.9.9.0', env, config)).to eq('US')
+      end
+
+      it 'falls through to range detection when no header matches' do
+        expect(described_class.resolve('8.8.8.0', {}, config)).to eq('US')
+      end
+    end
+
+    describe '.resolve with the Vercel provider header' do
+      it 'reads X-Vercel-IP-Country' do
+        env = { 'HTTP_X_VERCEL_IP_COUNTRY' => 'DE' }
+        expect(described_class.resolve('1.2.3.4', env)).to eq('DE')
+      end
+    end
+
+    describe '.resolve header trust gate' do
+      let(:config) { Otto::Privacy::Config.new(geo_header: 'X-Client-Country') }
+
+      it 'skips both configured and provider headers when headers are untrusted' do
+        env = { 'HTTP_X_CLIENT_COUNTRY' => 'JP', 'HTTP_CF_IPCOUNTRY' => 'GB' }
+        # 9.9.9.0 (Quad9) resolves to CH by range detection, proving neither
+        # spoofable header was consulted.
+        expect(described_class.resolve('9.9.9.0', env, config, headers_trusted: false)).to eq('CH')
+      end
+
+      it 'still consults the database when headers are untrusted' do
+        reader = recording_reader('9.9.9.0' => { 'country' => { 'iso_code' => 'NL' } })
+        cfg = Otto::Privacy::Config.new(geo_header: 'X-Client-Country', geo_db_reader: reader)
+        env = { 'HTTP_X_CLIENT_COUNTRY' => 'JP' }
+        expect(described_class.resolve('9.9.9.0', env, cfg, headers_trusted: false)).to eq('NL')
+      end
+    end
+
+    describe '.resolve with a database reader' do
+      it 'reads GeoLite2-compatible nested results' do
+        reader = recording_reader('8.8.8.0' => { 'country' => { 'iso_code' => 'US' } })
+        config = Otto::Privacy::Config.new(geo_db_reader: reader)
+        expect(described_class.resolve('8.8.8.0', {}, config)).to eq('US')
+      end
+
+      it 'reads flat country_code results' do
+        reader = recording_reader('5.5.5.0' => { 'country_code' => 'FR' })
+        config = Otto::Privacy::Config.new(geo_db_reader: reader)
+        expect(described_class.resolve('5.5.5.0', {}, config)).to eq('FR')
+      end
+
+      it 'ignores an invalid database code and falls through to range detection' do
+        reader = recording_reader('8.8.8.0' => { 'country' => { 'iso_code' => 'ZZZ' } })
+        config = Otto::Privacy::Config.new(geo_db_reader: reader)
+        # ZZZ is not a valid 2-letter code -> range detection (8.8.8.0/24 -> US)
+        expect(described_class.resolve('8.8.8.0', {}, config)).to eq('US')
+      end
+
+      it 'returns ** on a database miss for an otherwise unknown IP' do
+        reader = recording_reader({}) # every lookup misses
+        config = Otto::Privacy::Config.new(geo_db_reader: reader)
+        expect(described_class.resolve('203.0.113.0', {}, config)).to eq('**')
+      end
+
+      it 'never crashes a request when the reader raises' do
+        exploding = Class.new do
+          def get(_ip)
+            raise 'db exploded'
+          end
+        end.new
+        config = Otto::Privacy::Config.new(geo_db_reader: exploding)
+        # Falls through to range detection (8.8.8.0/24 -> US)
+        expect(described_class.resolve('8.8.8.0', {}, config)).to eq('US')
+      end
+    end
+
+    describe '.resolve IPv6 handling' do
+      it 'returns ** for an unknown IPv6 address' do
+        expect(described_class.resolve('2001:db8::', {})).to eq('**')
+      end
+
+      it 'reads a configured header for an IPv6 request' do
+        config = Otto::Privacy::Config.new(geo_header: 'X-Client-Country')
+        env = { 'HTTP_X_CLIENT_COUNTRY' => 'SE' }
+        expect(described_class.resolve('2001:db8::', env, config)).to eq('SE')
+      end
+
+      it 'looks up an IPv6 address in the database' do
+        reader = recording_reader('2001:db8::' => { 'country' => { 'iso_code' => 'SE' } })
+        config = Otto::Privacy::Config.new(geo_db_reader: reader)
+        expect(described_class.resolve('2001:db8::', {}, config)).to eq('SE')
+      end
+    end
+
+    describe '.resolve backward compatibility' do
+      it 'behaves as before when no config is supplied' do
+        expect(described_class.resolve('8.8.8.8', { 'HTTP_CF_IPCOUNTRY' => 'GB' })).to eq('GB')
+        expect(described_class.resolve('8.8.8.8', {})).to eq('US')
+        expect(described_class.resolve('240.0.0.1', {})).to eq('**')
+      end
+    end
+  end
+
+  describe Otto::Security::Config do
+    describe '#trusted_proxies_configured?' do
+      it 'is false with no matchers configured' do
+        expect(described_class.new.trusted_proxies_configured?).to be false
+      end
+
+      it 'is true once a trusted proxy is added' do
+        config = described_class.new
+        config.add_trusted_proxy('10.0.0.1')
+        expect(config.trusted_proxies_configured?).to be true
+      end
+
+      it 'is false in count-based depth mode (no identity matchers)' do
+        config = described_class.new
+        config.trusted_proxy_depth = 2
+        expect(config.trusted_proxies_configured?).to be false
+      end
+    end
+  end
+
+  describe 'IPPrivacyMiddleware geo integration' do
+    let(:app) { ->(_env) { [200, {}, ['OK']] } }
+
+    def run(security_config, env)
+      Otto::Security::Middleware::IPPrivacyMiddleware.new(app, security_config).call(env)
+      env
+    end
+
+    context 'header trust gate' do
+      it 'honors a provider header for a request that arrived via a trusted proxy' do
+        sc = Otto::Security::Config.new
+        sc.add_trusted_proxy('10.0.0.1')
+
+        env = run(sc, {
+                    'REMOTE_ADDR' => '10.0.0.1',
+                    'HTTP_X_FORWARDED_FOR' => '8.8.8.8',
+                    'HTTP_CF_IPCOUNTRY' => 'GB',
+                  })
+
+        expect(env['otto.via_trusted_proxy']).to be true
+        expect(env['otto.privacy.geo_country']).to eq('GB')
+      end
+
+      it 'ignores a spoofed provider header from a non-trusted-proxy request' do
+        sc = Otto::Security::Config.new
+        sc.add_trusted_proxy('10.0.0.1')
+
+        # Direct connection from 8.8.8.8 with a forged CF-IPCountry: GB is a lie.
+        env = run(sc, { 'REMOTE_ADDR' => '8.8.8.8', 'HTTP_CF_IPCOUNTRY' => 'GB' })
+
+        expect(env['otto.via_trusted_proxy']).to be false
+        # Header ignored; masked 8.8.8.0 resolves to US by range detection.
+        expect(env['otto.privacy.geo_country']).to eq('US')
+      end
+
+      it 'trusts provider headers when no trusted proxies are configured (legacy)' do
+        env = run(Otto::Security::Config.new, { 'REMOTE_ADDR' => '8.8.8.8', 'HTTP_CF_IPCOUNTRY' => 'GB' })
+        expect(env['otto.privacy.geo_country']).to eq('GB')
+      end
+    end
+
+    context 'database fallback' do
+      it 'looks up the MASKED IP only, never the real address' do
+        reader = recording_reader('8.8.8.0' => { 'country' => { 'iso_code' => 'NL' } })
+        sc = Otto::Security::Config.new
+        sc.ip_privacy_config.geo_db_reader = reader
+        sc.ip_privacy_config.load_geo_database!
+
+        env = run(sc, { 'REMOTE_ADDR' => '8.8.8.8' })
+
+        expect(env['otto.privacy.geo_country']).to eq('NL')
+        expect(reader.seen).to eq(['8.8.8.0'])
+        expect(reader.seen).not_to include('8.8.8.8')
+      end
+
+      it 'does not consult the database when geo is disabled' do
+        reader = recording_reader('8.8.8.0' => { 'country' => { 'iso_code' => 'NL' } })
+        sc = Otto::Security::Config.new
+        sc.ip_privacy_config.geo_db_reader = reader
+        sc.ip_privacy_config.geo_enabled = false
+        sc.ip_privacy_config.load_geo_database!
+
+        env = run(sc, { 'REMOTE_ADDR' => '8.8.8.8' })
+
+        expect(env['otto.privacy.geo_country']).to be_nil
+        expect(reader.seen).to be_empty
+      end
+    end
+  end
+
+  describe 'Otto#configure_ip_privacy geo options' do
+    it 'canonicalizes and stores a configured header' do
+      otto = create_minimal_otto(['GET / TestApp.index'])
+      otto.configure_ip_privacy(geo_header: 'X-Client-Country')
+
+      expect(otto.security_config.ip_privacy_config.geo_header).to eq('HTTP_X_CLIENT_COUNTRY')
+    end
+
+    it 'attaches an injected reader' do
+      reader = recording_reader({})
+      otto = create_minimal_otto(['GET / TestApp.index'])
+      otto.configure_ip_privacy(geo_db_reader: reader)
+
+      expect(otto.security_config.ip_privacy_config.geo_db_reader).to equal(reader)
+    end
+
+    it 'raises at configuration time for a bad database path' do
+      otto = create_minimal_otto(['GET / TestApp.index'])
+      expect { otto.configure_ip_privacy(geo_db_path: '/no/such/geo.mmdb') }
+        .to raise_error(ArgumentError, /not readable/)
+    end
+
+    it 'stops consulting the database once geo is disabled' do
+      reader = recording_reader({})
+      otto = create_minimal_otto(['GET / TestApp.index'])
+      otto.configure_ip_privacy(geo_db_reader: reader)
+      expect(otto.security_config.ip_privacy_config.geo_db_reader).to equal(reader)
+
+      otto.configure_ip_privacy(geo: false)
+      expect(otto.security_config.ip_privacy_config.geo_db_reader).to be_nil
+    end
+  end
+end

--- a/spec/otto/geo_resolver_config_spec.rb
+++ b/spec/otto/geo_resolver_config_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'Configurable geo resolution' do
         expect(config.geo_db_reader).to be_nil
       end
 
-      it 'survives deep_freeze! and stays usable (reader held at class level)' do
+      it 'survives deep_freeze! and stays usable (shallow-frozen reader)' do
         reader = recording_reader('1.2.3.0' => { 'country' => { 'iso_code' => 'US' } })
         config = described_class.new(geo_db_reader: reader)
         config.deep_freeze!
@@ -157,11 +157,13 @@ RSpec.describe 'Configurable geo resolution' do
         expect(described_class.resolve('5.5.5.0', {}, config)).to eq('FR')
       end
 
-      it 'ignores an invalid database code and falls through to range detection' do
+      it 'treats an invalid database code as unknown (authoritative DB)' do
         reader = recording_reader('8.8.8.0' => { 'country' => { 'iso_code' => 'ZZZ' } })
         config = Otto::Privacy::Config.new(geo_db_reader: reader)
-        # ZZZ is not a valid 2-letter code -> range detection (8.8.8.0/24 -> US)
-        expect(described_class.resolve('8.8.8.0', {}, config)).to eq('US')
+        # ZZZ is not a valid 2-letter code. With a database configured, the DB is
+        # authoritative: an unusable result is '**', not a range-table guess
+        # (8.8.8.0/24 would otherwise be coerced to US).
+        expect(described_class.resolve('8.8.8.0', {}, config)).to eq('**')
       end
 
       it 'returns ** on a database miss for an otherwise unknown IP' do
@@ -170,15 +172,16 @@ RSpec.describe 'Configurable geo resolution' do
         expect(described_class.resolve('203.0.113.0', {}, config)).to eq('**')
       end
 
-      it 'never crashes a request when the reader raises' do
+      it 'returns ** (not a range guess) when the reader raises' do
         exploding = Class.new do
           def get(_ip)
             raise 'db exploded'
           end
         end.new
         config = Otto::Privacy::Config.new(geo_db_reader: exploding)
-        # Falls through to range detection (8.8.8.0/24 -> US)
-        expect(described_class.resolve('8.8.8.0', {}, config)).to eq('US')
+        # The lookup error is swallowed (no crash); with an authoritative DB
+        # configured, the honest answer is '**' rather than a toy-table guess.
+        expect(described_class.resolve('8.8.8.0', {}, config)).to eq('**')
       end
     end
 
@@ -268,6 +271,21 @@ RSpec.describe 'Configurable geo resolution' do
         env = run(Otto::Security::Config.new, { 'REMOTE_ADDR' => '8.8.8.8', 'HTTP_CF_IPCOUNTRY' => 'GB' })
         expect(env['otto.privacy.geo_country']).to eq('GB')
       end
+
+      it 'ignores geo headers in count-based depth mode (edge unverifiable)' do
+        sc = Otto::Security::Config.new
+        sc.trusted_proxy_depth = 1
+
+        # Depth mode can't verify the hop that set CF-IPCountry is a geo-CDN, so
+        # the forged GB header is ignored; masked 8.8.8.0 resolves to US.
+        env = run(sc, {
+                    'REMOTE_ADDR' => '10.0.0.1',
+                    'HTTP_X_FORWARDED_FOR' => '8.8.8.8',
+                    'HTTP_CF_IPCOUNTRY' => 'GB',
+                  })
+
+        expect(env['otto.privacy.geo_country']).to eq('US')
+      end
     end
 
     context 'database fallback' do
@@ -295,6 +313,43 @@ RSpec.describe 'Configurable geo resolution' do
 
         expect(env['otto.privacy.geo_country']).to be_nil
         expect(reader.seen).to be_empty
+      end
+    end
+
+    context 'custom resolver sealing' do
+      after { Otto::Privacy::GeoResolver.custom_resolver = nil }
+
+      it 'hands the custom resolver the masked IP in both the argument and env' do
+        seen = {}
+        Otto::Privacy::GeoResolver.custom_resolver = lambda do |ip, resolver_env|
+          seen[:ip] = ip
+          seen[:remote_addr] = resolver_env['REMOTE_ADDR']
+          seen[:xff] = resolver_env['HTTP_X_FORWARDED_FOR']
+          'PT'
+        end
+
+        env = run(Otto::Security::Config.new,
+                  { 'REMOTE_ADDR' => '8.8.8.8', 'HTTP_X_FORWARDED_FOR' => '8.8.8.8' })
+
+        expect(env['otto.privacy.geo_country']).to eq('PT')
+        # The precise host is never exposed to the resolver, by argument or env.
+        expect(seen[:ip]).to eq('8.8.8.0')
+        expect(seen[:remote_addr]).to eq('8.8.8.0')
+        expect(seen[:xff]).to eq('8.8.8.0')
+        expect(seen.values).not_to include('8.8.8.8')
+      end
+
+      it 'does not leak resolver env mutations back into the request env' do
+        Otto::Privacy::GeoResolver.custom_resolver = lambda do |_ip, resolver_env|
+          resolver_env['REMOTE_ADDR'] = 'tampered' # mutate the masked COPY
+          'PT'
+        end
+
+        env = { 'REMOTE_ADDR' => '8.8.8.8' }
+        Otto::Privacy::RedactedFingerprint.new(env, Otto::Privacy::Config.new)
+
+        # geo_env hands the resolver a dup, so the request env is untouched.
+        expect(env['REMOTE_ADDR']).to eq('8.8.8.8')
       end
     end
   end
@@ -329,6 +384,63 @@ RSpec.describe 'Configurable geo resolution' do
 
       otto.configure_ip_privacy(geo: false)
       expect(otto.security_config.ip_privacy_config.geo_db_reader).to be_nil
+    end
+  end
+
+  # Exercises the real MaxMind::DB reader against a generated fixture (see
+  # spec/support/mmdb_fixture.rb), so the geo_db_path -> reader -> get path is
+  # verified against the genuine library, not only a duck-typed fake. Skipped
+  # when the optional maxmind-db gem is unavailable.
+  describe 'real maxmind-db reader integration', :maxmind do
+    before(:all) do
+      require 'maxmind/db'
+    rescue LoadError
+      skip 'maxmind-db gem not installed'
+    end
+
+    let(:db_path) do
+      MmdbFixture.country_db_file([
+                                    ['1.2.3.0', 24, 'US'],
+                                    ['5.5.5.0', 24, 'FR'],
+                                    ['2.0.0.0', 8, 'GB'],
+                                  ])
+    end
+
+    it 'opens a database by path and resolves via the real reader' do
+      config = Otto::Privacy::Config.new(geo_db_path: db_path)
+
+      expect(config.geo_db_reader).to be_a(MaxMind::DB)
+      expect(Otto::Privacy::GeoResolver.resolve('1.2.3.4', {}, config)).to eq('US')
+      expect(Otto::Privacy::GeoResolver.resolve('5.5.5.9', {}, config)).to eq('FR')
+      expect(Otto::Privacy::GeoResolver.resolve('2.9.9.9', {}, config)).to eq('GB')
+    end
+
+    it 'returns ** for an address absent from the real database (authoritative)' do
+      config = Otto::Privacy::Config.new(geo_db_path: db_path)
+      expect(Otto::Privacy::GeoResolver.resolve('9.9.9.9', {}, config)).to eq('**')
+    end
+
+    it 'keeps the real reader usable after the config is deep-frozen' do
+      config = Otto::Privacy::Config.new(geo_db_path: db_path)
+      config.deep_freeze!
+
+      expect(config).to be_frozen
+      expect(config.geo_db_reader).to be_frozen
+      expect(Otto::Privacy::GeoResolver.resolve('1.2.3.4', {}, config)).to eq('US')
+    end
+
+    it 'resolves the masked /24 identically to the real host address' do
+      config = Otto::Privacy::Config.new(geo_db_path: db_path)
+      # The middleware would pass 1.2.3.0; a direct real IP masks to the same.
+      expect(Otto::Privacy::GeoResolver.resolve('1.2.3.255', {}, config)).to eq('US')
+      expect(Otto::Privacy::GeoResolver.resolve('1.2.3.0', {}, config)).to eq('US')
+    end
+
+    it 'raises a clear error at boot for a non-mmdb file' do
+      not_mmdb = MmdbFixture.country_db_file([]) # will be truncated below
+      File.write(not_mmdb, 'this is not an mmdb')
+      expect { Otto::Privacy::Config.new(geo_db_path: not_mmdb) }
+        .to raise_error(ArgumentError, /Failed to open geo_db_path/)
     end
   end
 end

--- a/spec/otto/geo_resolver_config_spec.rb
+++ b/spec/otto/geo_resolver_config_spec.rb
@@ -278,18 +278,20 @@ RSpec.describe 'Configurable geo resolution' do
         expect(env['otto.privacy.geo_country']).to eq('US')
       end
 
-      it 'trusts provider headers when no trusted proxies are configured (legacy)' do
+      it 'does NOT trust provider headers when no trusted proxies are configured' do
+        # Strict default: without a verified proxy origin the header is
+        # client-supplied and unverifiable, so the spoofable GB is ignored.
         env = run(Otto::Security::Config.new, { 'REMOTE_ADDR' => '8.8.8.8', 'HTTP_CF_IPCOUNTRY' => 'GB' })
-        expect(env['otto.privacy.geo_country']).to eq('GB')
+        expect(env['otto.privacy.geo_country']).to eq('**')
       end
 
-      it 'trusts geo headers when the security config lacks trusted_proxies_configured?' do
-        # Safe legacy default: a config object that does not implement the
-        # trusted-proxy introspection method falls through to trusting headers.
+      it 'does NOT trust geo headers when the security config lacks trusted_proxies_configured?' do
+        # Strict safe default: a config object that cannot report its
+        # trusted-proxy state is treated as unverifiable, so headers are ignored.
         middleware = Otto::Security::Middleware::IPPrivacyMiddleware.new(app, nil)
         middleware.instance_variable_set(:@security_config, Object.new)
 
-        expect(middleware.send(:geo_headers_trusted?, {})).to be true
+        expect(middleware.send(:geo_headers_trusted?, {})).to be false
       end
 
       it 'ignores geo headers in count-based depth mode (edge unverifiable)' do

--- a/spec/otto/geo_resolver_config_spec.rb
+++ b/spec/otto/geo_resolver_config_spec.rb
@@ -283,6 +283,15 @@ RSpec.describe 'Configurable geo resolution' do
         expect(env['otto.privacy.geo_country']).to eq('GB')
       end
 
+      it 'trusts geo headers when the security config lacks trusted_proxies_configured?' do
+        # Safe legacy default: a config object that does not implement the
+        # trusted-proxy introspection method falls through to trusting headers.
+        middleware = Otto::Security::Middleware::IPPrivacyMiddleware.new(app, nil)
+        middleware.instance_variable_set(:@security_config, Object.new)
+
+        expect(middleware.send(:geo_headers_trusted?, {})).to be true
+      end
+
       it 'ignores geo headers in count-based depth mode (edge unverifiable)' do
         sc = Otto::Security::Config.new
         sc.trusted_proxy_depth = 1

--- a/spec/otto/geo_resolver_config_spec.rb
+++ b/spec/otto/geo_resolver_config_spec.rb
@@ -429,6 +429,17 @@ RSpec.describe 'Configurable geo resolution' do
       otto.configure_ip_privacy(geo: false)
       expect(otto.security_config.ip_privacy_config.geo_db_reader).to be_nil
     end
+
+    it 'lets a later geo_db_path replace an injected reader' do
+      reader = recording_reader({})
+      otto = create_minimal_otto(['GET / TestApp.index'])
+      otto.configure_ip_privacy(geo_db_reader: reader)
+
+      # The new path must actually take effect — a bad one now raises at boot
+      # instead of being silently shadowed by the stale reader override.
+      expect { otto.configure_ip_privacy(geo_db_path: '/no/such/geo.mmdb') }
+        .to raise_error(ArgumentError, /not readable/)
+    end
   end
 
   # Exercises the real MaxMind::DB reader against a generated fixture (see

--- a/spec/otto/ip_harmonization_spec.rb
+++ b/spec/otto/ip_harmonization_spec.rb
@@ -365,12 +365,13 @@ RSpec.describe 'IP resolution harmonization (otto#58 / OTS#3436)' do
       end
 
       it 'populates redacted_fingerprint, masked_ip, hashed_ip and geo_country' do
-        req = run_privacy('8.8.8.8') # public IP; geo range -> US
+        req = run_privacy('8.8.8.8') # public IP; no geo source configured
 
         expect(req.redacted_fingerprint).to be_a(Otto::Privacy::RedactedFingerprint)
         expect(req.masked_ip).to eq('8.8.8.0')
         expect(req.hashed_ip).to match(/\A[0-9a-f]{64}\z/)
-        expect(req.geo_country).to eq('US')
+        # No header/resolver/db configured -> honest unknown (not a range guess).
+        expect(req.geo_country).to eq('**')
       end
 
       it 'returns nil from redacted_fingerprint/hashed_ip when privacy is disabled' do

--- a/spec/otto/ip_privacy_spec.rb
+++ b/spec/otto/ip_privacy_spec.rb
@@ -108,6 +108,21 @@ RSpec.describe 'IP Privacy Features' do
         expect(Otto::Privacy::IPPrivacy.valid_ip?(nil)).to be false
       end
     end
+
+    describe '.forwarded_header_for' do
+      it 'builds an unquoted for= element for IPv4' do
+        expect(Otto::Privacy::IPPrivacy.forwarded_header_for('192.0.2.0')).to eq('for=192.0.2.0')
+      end
+
+      it 'brackets and quotes IPv6 per RFC 7239' do
+        expect(Otto::Privacy::IPPrivacy.forwarded_header_for('2001:db8::')).to eq('for="[2001:db8::]"')
+      end
+
+      it 'returns nil for nil/empty input' do
+        expect(Otto::Privacy::IPPrivacy.forwarded_header_for(nil)).to be_nil
+        expect(Otto::Privacy::IPPrivacy.forwarded_header_for('')).to be_nil
+      end
+    end
   end
 
   describe Otto::Privacy::GeoResolver do
@@ -488,6 +503,32 @@ RSpec.describe 'IP Privacy Features' do
           middleware.call(env)
 
           expect(env['otto.original_ip']).to be_nil
+        end
+      end
+
+      context 'RFC 7239 Forwarded header masking' do
+        it 'rewrites HTTP_FORWARDED to hold only the masked IP' do
+          env = { 'REMOTE_ADDR' => '203.0.113.77', 'HTTP_FORWARDED' => 'for=203.0.113.77;proto=https;by=10.0.0.1' }
+          middleware.call(env)
+
+          expect(env['HTTP_FORWARDED']).to eq('for=203.0.113.0')
+          expect(env['HTTP_FORWARDED']).not_to include('203.0.113.77')
+        end
+
+        it 'brackets and quotes a masked IPv6 for= value (valid RFC 7239)' do
+          env = { 'REMOTE_ADDR' => '2001:db8:85a3::8a2e:370:7334', 'HTTP_FORWARDED' => 'for="[2001:db8:85a3::8a2e:370:7334]"' }
+          middleware.call(env)
+
+          # /48-masked (octet_precision 1 -> last 80 bits) IPv6, bracketed+quoted
+          expect(env['HTTP_FORWARDED']).to match(/\Afor="\[2001:db8:85a3:[0:]*\]"\z/)
+          expect(env['HTTP_FORWARDED']).not_to include('8a2e')
+        end
+
+        it 'leaves HTTP_FORWARDED untouched for exempt private IPs' do
+          env = { 'REMOTE_ADDR' => '192.168.1.100', 'HTTP_FORWARDED' => 'for=192.168.1.100' }
+          middleware.call(env)
+
+          expect(env['HTTP_FORWARDED']).to eq('for=192.168.1.100')
         end
       end
 

--- a/spec/otto/ip_privacy_spec.rb
+++ b/spec/otto/ip_privacy_spec.rb
@@ -137,11 +137,11 @@ RSpec.describe 'IP Privacy Features' do
           expect(result).to eq('**')
         end
 
-        it 'falls back to range detection when custom resolver returns nil' do
+        it 'returns ** when custom resolver returns nil and nothing else resolves' do
           Otto::Privacy::GeoResolver.custom_resolver = ->(ip, _env) { nil }
 
           result = Otto::Privacy::GeoResolver.resolve('8.8.8.8', {})
-          expect(result).to eq('US')  # From range detection
+          expect(result).to eq('**')  # Honest unknown; no guessing
         end
 
         it 'handles custom resolver errors gracefully' do
@@ -150,8 +150,8 @@ RSpec.describe 'IP Privacy Features' do
           }
 
           result = Otto::Privacy::GeoResolver.resolve('8.8.8.8', {})
-          # Falls back to range detection
-          expect(result).to eq('US')
+          # Error is swallowed; no other source resolves -> unknown
+          expect(result).to eq('**')
         end
 
         it 'prefers CDN headers over custom resolver' do
@@ -185,7 +185,7 @@ RSpec.describe 'IP Privacy Features' do
           Otto::Privacy::GeoResolver.custom_resolver = nil
 
           result = Otto::Privacy::GeoResolver.resolve('8.8.8.8', {})
-          expect(result).to eq('US')  # Uses range detection
+          expect(result).to eq('**')  # No resolver, header, or db -> unknown
         end
       end
 
@@ -305,16 +305,16 @@ RSpec.describe 'IP Privacy Features' do
           env = { 'HTTP_X_AKAMAI_EDGESCAPE' => 'invalid_format' }
           result = Otto::Privacy::GeoResolver.resolve('8.8.8.8', env)
 
-          # Falls back to range detection (Google DNS -> US)
-          expect(result).to eq('US')
+          # Unparseable header is ignored; nothing else resolves -> unknown
+          expect(result).to eq('**')
         end
 
         it 'handles Edgescape with invalid country code' do
           env = { 'HTTP_X_AKAMAI_EDGESCAPE' => 'country_code=INVALID' }
           result = Otto::Privacy::GeoResolver.resolve('8.8.8.8', env)
 
-          # Falls back to range detection
-          expect(result).to eq('US')
+          # Invalid code is ignored -> unknown
+          expect(result).to eq('**')
         end
 
         it 'handles trailing comma edge cases' do
@@ -338,53 +338,48 @@ RSpec.describe 'IP Privacy Features' do
       end
 
       context 'header validation' do
-        it 'ignores invalid Cloudflare header and falls back to range detection' do
+        it 'ignores an invalid Cloudflare header' do
           env = { 'HTTP_CF_IPCOUNTRY' => 'invalid' }
           result = Otto::Privacy::GeoResolver.resolve('8.8.8.8', env)
 
-          # Should ignore invalid CF header and fall back to range detection
-          expect(result).to eq('US')
+          # Invalid CF header is ignored; nothing else resolves -> unknown
+          expect(result).to eq('**')
         end
 
         it 'ignores lowercase country codes' do
           env = { 'HTTP_CF_IPCOUNTRY' => 'us' }
           result = Otto::Privacy::GeoResolver.resolve('8.8.8.8', env)
 
-          # Falls back to range detection
-          expect(result).to eq('US')
+          expect(result).to eq('**')
         end
 
         it 'ignores 3-letter codes' do
           env = { 'HTTP_CF_IPCOUNTRY' => 'USA' }
           result = Otto::Privacy::GeoResolver.resolve('8.8.8.8', env)
 
-          # Falls back to range detection
-          expect(result).to eq('US')
+          expect(result).to eq('**')
         end
 
         it 'ignores single-letter codes' do
           env = { 'HTTP_CF_IPCOUNTRY' => 'U' }
           result = Otto::Privacy::GeoResolver.resolve('8.8.8.8', env)
 
-          # Falls back to range detection
-          expect(result).to eq('US')
+          expect(result).to eq('**')
         end
 
         it 'ignores non-string values' do
           env = { 'HTTP_CF_IPCOUNTRY' => 123 }
           result = Otto::Privacy::GeoResolver.resolve('8.8.8.8', env)
 
-          # Falls back to range detection
-          expect(result).to eq('US')
+          expect(result).to eq('**')
         end
       end
 
-      it 'resolves country using IP range detection' do
-        # Test with Google DNS (8.8.8.8) which should resolve to US
+      it 'returns ** when no header, resolver, or database resolves' do
+        # No hardcoded IP-range guessing: an unrecognized address is unknown.
         result = Otto::Privacy::GeoResolver.resolve('8.8.8.8', {})
 
-        # Should resolve to US via range detection
-        expect(result).to eq('US')
+        expect(result).to eq('**')
       end
 
       it 'falls back to ** for truly unknown IPs' do

--- a/spec/otto/ip_privacy_spec.rb
+++ b/spec/otto/ip_privacy_spec.rb
@@ -109,18 +109,34 @@ RSpec.describe 'IP Privacy Features' do
       end
     end
 
-    describe '.forwarded_header_for' do
-      it 'builds an unquoted for= element for IPv4' do
-        expect(Otto::Privacy::IPPrivacy.forwarded_header_for('192.0.2.0')).to eq('for=192.0.2.0')
+    describe '.mask_forwarded_for' do
+      it 'redacts for= while preserving proto/host/by metadata' do
+        value = 'for=203.0.113.77;proto=https;host=example.com;by=10.0.0.1'
+        expect(Otto::Privacy::IPPrivacy.mask_forwarded_for(value, '203.0.113.0'))
+          .to eq('for=203.0.113.0;proto=https;host=example.com;by=10.0.0.1')
       end
 
-      it 'brackets and quotes IPv6 per RFC 7239' do
-        expect(Otto::Privacy::IPPrivacy.forwarded_header_for('2001:db8::')).to eq('for="[2001:db8::]"')
+      it 'redacts every for= element in a chain' do
+        value = 'for=203.0.113.77, for=198.51.100.9;proto=https'
+        expect(Otto::Privacy::IPPrivacy.mask_forwarded_for(value, '203.0.113.0'))
+          .to eq('for=203.0.113.0, for=203.0.113.0;proto=https')
       end
 
-      it 'returns nil for nil/empty input' do
-        expect(Otto::Privacy::IPPrivacy.forwarded_header_for(nil)).to be_nil
-        expect(Otto::Privacy::IPPrivacy.forwarded_header_for('')).to be_nil
+      it 'brackets and quotes a masked IPv6 for= value' do
+        value = 'for="[2001:db8:85a3::8a2e:370:7334]";proto=https'
+        expect(Otto::Privacy::IPPrivacy.mask_forwarded_for(value, '2001:db8::'))
+          .to eq('for="[2001:db8::]";proto=https')
+      end
+
+      it 'does not touch a parameter merely ending in "for"' do
+        value = 'secret_for=203.0.113.77;proto=https'
+        expect(Otto::Privacy::IPPrivacy.mask_forwarded_for(value, '203.0.113.0'))
+          .to eq('secret_for=203.0.113.77;proto=https')
+      end
+
+      it 'returns the value unchanged when there is nothing to mask' do
+        expect(Otto::Privacy::IPPrivacy.mask_forwarded_for('for=1.2.3.4', nil)).to eq('for=1.2.3.4')
+        expect(Otto::Privacy::IPPrivacy.mask_forwarded_for(nil, '1.2.3.0')).to be_nil
       end
     end
   end
@@ -507,20 +523,23 @@ RSpec.describe 'IP Privacy Features' do
       end
 
       context 'RFC 7239 Forwarded header masking' do
-        it 'rewrites HTTP_FORWARDED to hold only the masked IP' do
-          env = { 'REMOTE_ADDR' => '203.0.113.77', 'HTTP_FORWARDED' => 'for=203.0.113.77;proto=https;by=10.0.0.1' }
+        it 'redacts for= but preserves proto/host/by metadata' do
+          env = { 'REMOTE_ADDR' => '203.0.113.77',
+                  'HTTP_FORWARDED' => 'for=203.0.113.77;proto=https;host=example.com;by=10.0.0.1' }
           middleware.call(env)
 
-          expect(env['HTTP_FORWARDED']).to eq('for=203.0.113.0')
+          expect(env['HTTP_FORWARDED']).to eq('for=203.0.113.0;proto=https;host=example.com;by=10.0.0.1')
           expect(env['HTTP_FORWARDED']).not_to include('203.0.113.77')
         end
 
         it 'brackets and quotes a masked IPv6 for= value (valid RFC 7239)' do
-          env = { 'REMOTE_ADDR' => '2001:db8:85a3::8a2e:370:7334', 'HTTP_FORWARDED' => 'for="[2001:db8:85a3::8a2e:370:7334]"' }
+          env = { 'REMOTE_ADDR' => '2001:db8:85a3::8a2e:370:7334',
+                  'HTTP_FORWARDED' => 'for="[2001:db8:85a3::8a2e:370:7334]";proto=https' }
           middleware.call(env)
 
-          # /48-masked (octet_precision 1 -> last 80 bits) IPv6, bracketed+quoted
-          expect(env['HTTP_FORWARDED']).to match(/\Afor="\[2001:db8:85a3:[0:]*\]"\z/)
+          # /48-masked (octet_precision 1 -> last 80 bits) IPv6, bracketed+quoted,
+          # with proto= preserved.
+          expect(env['HTTP_FORWARDED']).to match(%r{\Afor="\[2001:db8:85a3:[0:]*\]";proto=https\z})
           expect(env['HTTP_FORWARDED']).not_to include('8a2e')
         end
 
@@ -529,6 +548,17 @@ RSpec.describe 'IP Privacy Features' do
           middleware.call(env)
 
           expect(env['HTTP_FORWARDED']).to eq('for=192.168.1.100')
+        end
+
+        it 'deletes forwarded headers when there is no resolvable client IP' do
+          # No REMOTE_ADDR to anchor resolution, but forwarded headers carry a
+          # raw client address. With no masked IP to rewrite them to, they must
+          # be dropped, not left to leak downstream.
+          env = { 'HTTP_X_FORWARDED_FOR' => '203.0.113.99', 'HTTP_FORWARDED' => 'for=203.0.113.99' }
+          middleware.call(env)
+
+          expect(env).not_to have_key('HTTP_X_FORWARDED_FOR')
+          expect(env).not_to have_key('HTTP_FORWARDED')
         end
       end
 

--- a/spec/support/mmdb_fixture.rb
+++ b/spec/support/mmdb_fixture.rb
@@ -1,0 +1,171 @@
+# spec/support/mmdb_fixture.rb
+#
+# frozen_string_literal: true
+
+require 'ipaddr'
+
+# Minimal MaxMind DB (.mmdb) encoder for test fixtures.
+#
+# Produces a valid IPv4 country database (record_size 24, ip_version 4) that the
+# real MaxMind::DB reader opens in MODE_MEMORY. This lets the geo specs exercise
+# the genuine reader path (open + get + result shape) without vendoring a binary
+# or depending on an external database.
+#
+# Format reference: https://maxmind.github.io/MaxMind-DB/
+module MmdbFixture
+  MARKER = "\xAB\xCD\xEFMaxMind.com".b
+  DATA_SEPARATOR = ("\x00".b * 16)
+
+  module_function
+
+  # Build an IPv4 country database.
+  #
+  # @param networks [Array<Array(String, Integer, String)>] [ip, prefix, iso_code]
+  # @return [String] mmdb bytes (ASCII-8BIT)
+  def country_db(networks, database_type: 'Test-Country', build_epoch: 1_600_000_000)
+    nodes = [new_node]
+    data_bytes = []
+    data_index = {}
+
+    networks.each do |ip, prefix, iso|
+      idx = (data_index[iso] ||= begin
+        data_bytes << country_value(iso)
+        data_bytes.length - 1
+      end)
+      insert(nodes, IPAddr.new(ip).to_i, prefix, idx)
+    end
+
+    node_count = nodes.length
+    data_section = +''.b
+    data_offsets = data_bytes.map do |bytes|
+      offset = data_section.bytesize
+      data_section << bytes
+      offset
+    end
+
+    tree = +''.b
+    nodes.each do |node|
+      tree << record(node[:left], node_count, data_offsets)
+      tree << record(node[:right], node_count, data_offsets)
+    end
+
+    tree + DATA_SEPARATOR + data_section + MARKER +
+      metadata(node_count, database_type, build_epoch)
+  end
+
+  # Write a database to a temp file and return its path. The Tempfile is kept
+  # alive on the returned path's singleton so it is not GC'd mid-test.
+  #
+  # @return [String] filesystem path to the .mmdb file
+  def country_db_file(networks, **opts)
+    require 'tempfile'
+    file = Tempfile.new(['otto-geo', '.mmdb'])
+    file.binmode
+    file.write(country_db(networks, **opts))
+    file.close
+    path = file.path
+    path.define_singleton_method(:__tempfile) { file } # retain
+    path
+  end
+
+  # --- data-type encoders (return ASCII-8BIT byte strings) ---
+
+  def str(value)
+    bytes = value.b
+    raise ArgumentError, 'fixture strings must be < 29 bytes' if bytes.bytesize >= 29
+
+    [(0x40 | bytes.bytesize)].pack('C') + bytes # type 2 (UTF-8 string)
+  end
+
+  def uint(number, type_num)
+    bytes = int_bytes(number)
+    if type_num <= 7 # non-extended (uint16=5, uint32=6)
+      [((type_num << 5) | bytes.bytesize)].pack('C') + bytes
+    else # extended (uint64=9)
+      [bytes.bytesize].pack('C') + [type_num - 7].pack('C') + bytes
+    end
+  end
+
+  def u16(number) = uint(number, 5)
+  def u32(number) = uint(number, 6)
+  def u64(number) = uint(number, 9)
+
+  def int_bytes(number)
+    return ''.b if number.zero?
+
+    bytes = +''.b
+    while number.positive?
+      bytes.prepend((number & 0xff).chr)
+      number >>= 8
+    end
+    bytes
+  end
+
+  def arr(elements)
+    [elements.length].pack('C') + [11 - 7].pack('C') + elements.join # type 11 (array), extended
+  end
+
+  def map(pairs)
+    body = pairs.map { |key, value| str(key) + value }.join
+    [(0xE0 | pairs.length)].pack('C') + body # type 7 (map)
+  end
+
+  def country_value(iso)
+    map([['country', map([['iso_code', str(iso)]])]])
+  end
+
+  def metadata(node_count, database_type, build_epoch)
+    map([
+          ['node_count', u32(node_count)],
+          ['record_size', u16(24)],
+          ['ip_version', u16(4)],
+          ['database_type', str(database_type)],
+          ['languages', arr([str('en')])],
+          ['binary_format_major_version', u16(2)],
+          ['binary_format_minor_version', u16(0)],
+          ['build_epoch', u64(build_epoch)],
+          ['description', map([['en', str('Otto test country db')]])],
+        ])
+  end
+
+  # --- search-tree construction ---
+
+  def new_node = { left: :empty, right: :empty }
+
+  def insert(nodes, ip_int, prefix, data_idx)
+    node_i = 0
+    prefix.times do |depth|
+      bit = (ip_int >> (31 - depth)) & 1
+      key = bit.zero? ? :left : :right
+      if depth == prefix - 1
+        nodes[node_i][key] = [:data, data_idx]
+      else
+        node_i = descend(nodes, node_i, key)
+      end
+    end
+  end
+
+  def descend(nodes, node_i, key)
+    rec = nodes[node_i][key]
+    case rec
+    when :empty
+      nodes << new_node
+      child = nodes.length - 1
+      nodes[node_i][key] = [:node, child]
+      child
+    when Array
+      raise ArgumentError, 'overlapping fixture networks unsupported' unless rec[0] == :node
+
+      rec[1]
+    end
+  end
+
+  def record(rec, node_count, data_offsets)
+    value =
+      case rec
+      when :empty then node_count
+      when Array then rec[0] == :node ? rec[1] : node_count + 16 + data_offsets[rec[1]]
+      end
+    [value].pack('N')[1, 3] # 24-bit big-endian
+  end
+end


### PR DESCRIPTION
## Summary

This PR adds configurable geo-location resolution to Otto's IP privacy system, enabling apps to specify a trusted request header and/or a local MaxMind-format database as fallback sources for country-code resolution. The implementation ensures the unmasked IP address never reaches custom resolvers or databases by operating on an already-masked view.

## Key Changes

- **Configurable geo header**: Added `geo_header` parameter to `configure_ip_privacy()` to specify a trusted, app-configured request header (e.g., `'X-Client-Country'`) that is checked *before* built-in CDN headers. Accepts both HTTP form (`'X-Client-Country'`) and CGI form (`'HTTP_X_CLIENT_COUNTRY'`), canonicalizing to the env key.

- **Local MMDB database support**: Added `geo_db_path` and `geo_db_reader` parameters to enable offline IP→country lookups using MaxMind-format databases. The `geo_db_path` parameter loads a `.mmdb` file at boot (failing fast on bad paths), while `geo_db_reader` allows injecting any object responding to `#get()`, keeping the reader choice independent of Otto.

- **Masked IP resolution**: Geo resolution now operates on a masked view—the masked IP and an env with IP-bearing headers masked—so the unmasked address never reaches custom resolvers or databases by argument or via env. Country networks are ≥ /24, so /24-masked results are identical at the default masking level.

- **Header trust gating**: Geo headers (both configured and built-in CDN headers) are now ignored unless the request arrived via a configured trusted proxy. Non-trusted-proxy requests fall back to the custom resolver and database, preventing header spoofing. Count-based depth mode never trusts headers (edge unverifiable).

- **Honest resolution**: Removed the built-in `KNOWN_RANGES` IP-range guess table. Geo resolution is now honest: when no header, custom resolver, or database resolves a country, the result is `'**'` (unknown) rather than a guess from a hardcoded table.

- **Vercel header support**: Added `X-Vercel-IP-Country` to the list of recognized built-in CDN/provider headers.

- **Resolution order**: Implemented a clear, documented resolution order:
  1. App-configured trusted header (if headers trusted)
  2. Built-in CDN/provider headers (if headers trusted)
  3. Custom resolver hook
  4. Local MMDB database lookup (on masked IP)
  5. `'**'` (unknown)

## Implementation Details

- **Config changes**: `Otto::Privacy::Config` now validates and stores `geo_header`, `geo_db_path`, and `geo_db_reader`. The `geo_header` setter canonicalizes header names to Rack CGI form. The `geo_db_reader` setter validates that the object responds to `:get`.

- **GeoResolver refactoring**: Split the resolution logic into focused private methods (`check_configured_header`, `check_geo_headers`, `check_custom_resolver`, `check_geo_database`) for clarity and testability. The public `resolve()` method now accepts a `config` parameter and a `headers_trusted` flag.

- **Middleware integration**: `IPPrivacyMiddleware` now computes `geo_headers_trusted?` based on the trusted-proxy decision and passes it to `RedactedFingerprint`, which creates a masked env view for geo resolution via `geo_env()`.

- **Database result handling**: Supports both GeoLite2-compatible nested results (`{'country' => {'iso_code' => 'US'}}`) and flat results (`{'country_code' => 'US'}`), with graceful error handling for invalid codes or reader exceptions.

- **Test fixtures**: Added `MmdbFixture` module to generate valid IPv4 country databases for testing, enabling the geo specs to exercise the genuine MaxMind::DB reader path without vendoring binaries.

## Security Implications

- Geo headers are now properly gated by trusted-proxy verification, preventing spoofing on untrusted requests.
- The unmasked IP never reaches resolvers or databases, maintaining privacy guarantees.

https://claude.ai/code/session_01MPVQ5qk148iQ4GninyJJfD