### PR TITLE
feat: add IP precision capability and privacy profiles

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,13 +95,30 @@ repos:
   #         - rubocop-rspec
 
   # Commit message issue tracking integration
-  - repo: https://github.com/avilaton/add-msg-issue-prefix-hook
-    rev: v0.0.13
+  - repo: https://github.com/delano/add-msg-issue-prefix-hook
+    rev: v0.1.1-fork
     hooks:
       - id: add-msg-issue-prefix
         stages: [prepare-commit-msg]
         description: Automatically prefix commits with issue numbers
         args:
-          - "--default="
-          - "--pattern=(i18n(?=/)|([a-zA-Z0-9]{0,10}-?[0-9]{1,5}))"
-          - "--template=[#{}]"
+          - '--default='
+          - '--exclude-pattern=^(dependabot|renovate)/'
+          # Extract the issue ID from the branch name, anchored at the start or a
+          # `/` boundary, so version/encoding tokens like v4, utf8, sha256 and
+          # 0.26.2 never match. Two shapes yield an ID: a bare number
+          # (feature/3840-x) or an explicit word prefix (claude/fix-3499-x,
+          # fix/issue-1234), where `(?P<id>...)` emits the bare number.
+          # `i18n(?=/)` emits the whole match as [#I18N].
+          #
+          # NOT JIRA-compatible: there is deliberately no generic `WORD-NNN` arm,
+          # so `feature/ENG-123` yields no prefix. GitHub issue numbers are the
+          # only ticket scheme here, and a generic arm matched dependency and
+          # date tokens instead (deps/postgres-17, security/audit-2026-07-06).
+          # Re-add that arm if this repo ever adopts JIRA-style keys. (#3891)
+          - '--pattern=(?:^|(?<=/))(?:i18n(?=/)|(?:issue|fix|bug|feat|feature)-(?P<id>[0-9]{1,5})|[0-9]{2,5})(?![0-9])'
+          # Separate pattern for has_tag(): detects an already-present [#TAG] in
+          # the subject on reword so the hook does not double-prefix. Matches the
+          # upcased emitted form, incl. [#I18N] which the branch pattern cannot.
+          - '--tag-pattern=[A-Za-z0-9][A-Za-z0-9._-]*'
+          - '--template=[#{}]'

--- a/changelog.d/20260725_ip_precision_and_privacy_profiles.rst
+++ b/changelog.d/20260725_ip_precision_and_privacy_profiles.rst
@@ -58,6 +58,20 @@ Fixed
   request, so a post-construction ``configure_ip_privacy(profile: :audit)``
   was silently ignored and the middleware kept masking.
 
+- ``IPPrivacyMiddleware`` no longer interpolates the resolved, unmasked client
+  IP into its debug log. Both masking paths logged the raw address when
+  ``Otto.debug`` was on — the pre-mask resolution line under ``:masked`` and
+  ``:anonymous``, and the private/localhost exemption line under ``:masked`` —
+  handing back through the log exactly what the profile withholds from env, and
+  to a destination that typically travels further than the process. The masked
+  value is still logged after masking. ``:audit`` is unaffected: it keeps the
+  raw IP in env by design and takes a path that never logged it.
+
+- ``Otto::Privacy::Config.profile_presets`` raises ``ArgumentError`` for a
+  profile that is not a Symbol or String. ``profile: 123`` or an explicit
+  ``profile: nil`` previously raised ``NoMethodError`` on ``#to_sym``,
+  inconsistent with the rest of the class's input validation.
+
 - ``IPPrivacyMiddleware``'s idempotency guard installs a fail-closed
   ``otto.ip_match`` when ``otto.client_ip`` was set outside the middleware
   (out of contract, but previously left the advertised capability ``nil`` and

--- a/changelog.d/20260725_ip_precision_and_privacy_profiles.rst
+++ b/changelog.d/20260725_ip_precision_and_privacy_profiles.rst
@@ -44,8 +44,13 @@ Fixed
   trusted-proxy entries, where an unmatched proxy silently withheld
   ``otto.via_trusted_proxy`` and with it ``Request#secure?`` and geo-header
   trust. Behavior change for anyone who configured a mapped-IPv6 range: it
-  now matches the IPv4 clients it names. Plain IPv4 and IPv6 ranges are
-  unaffected, and pre-parsed ``IPAddr`` entries are not mutated.
+  now matches the IPv4 clients it names — including ``::ffff:0:0/96``, which
+  is the whole mapped space and so matches every IPv4 address. Deprecated
+  IPv4-compatible notation (``::a.b.c.d``) folds on the same terms. The
+  prefix must cover the mapped marker (``/96`` or longer); a shorter one
+  such as ``::ffff:10.0.0.0/64`` masks the marker away and still matches
+  neither form. Plain IPv4 and IPv6 ranges are unaffected, and pre-parsed
+  ``IPAddr`` entries are not mutated (frozen ones included).
 
 - ``IPPrivacyMiddleware`` reads the privacy setting per request instead of
   caching it at construction. Otto builds its middleware stack at the end of

--- a/changelog.d/20260725_ip_precision_and_privacy_profiles.rst
+++ b/changelog.d/20260725_ip_precision_and_privacy_profiles.rst
@@ -59,18 +59,26 @@ Fixed
   was silently ignored and the middleware kept masking.
 
 - ``IPPrivacyMiddleware`` no longer interpolates the resolved, unmasked client
-  IP into its debug log. Both masking paths logged the raw address when
-  ``Otto.debug`` was on — the pre-mask resolution line under ``:masked`` and
-  ``:anonymous``, and the private/localhost exemption line under ``:masked`` —
-  handing back through the log exactly what the profile withholds from env, and
-  to a destination that typically travels further than the process. The masked
-  value is still logged after masking. ``:audit`` is unaffected: it keeps the
-  raw IP in env by design and takes a path that never logged it.
+  IP into its debug log. Two lines logged the raw address when ``Otto.debug``
+  was on — the pre-mask resolution line (``:masked`` and ``:anonymous``) and
+  the private/localhost exemption line (``:masked``) — handing back through the
+  log exactly what the profile withholds from env, and to a destination that
+  typically travels further than the process. The resolution line is gone
+  entirely; the masking path still logs the masked IP once masking has
+  happened, and the exemption line now records only that the exemption fired
+  (that path masks nothing, so it has no derived value to log — but it also
+  leaves the address in ``REMOTE_ADDR`` and ``otto.client_ip``, where request
+  logging can still reach it). ``:audit`` is unaffected: it keeps the raw IP in
+  env by design and takes a path that logs nothing at all.
 
-- ``Otto::Privacy::Config.profile_presets`` raises ``ArgumentError`` for a
-  profile that is not a Symbol or String. ``profile: 123`` or an explicit
-  ``profile: nil`` previously raised ``NoMethodError`` on ``#to_sym``,
-  inconsistent with the rest of the class's input validation.
+- ``Otto::Privacy::Config#profile=`` raises ``ArgumentError`` for a value that
+  cannot name a profile, where ``config.profile = 123`` and
+  ``config.profile = nil`` previously raised ``NoMethodError`` on ``#to_sym``,
+  inconsistent with the rest of the class's input validation. The ``profile:``
+  option form (``Config.new`` / ``configure_ip_privacy``) is unchanged for
+  ``nil``, which has always meant "leave unchanged" and is skipped before it
+  reaches validation; a non-nameable value such as ``profile: 123`` now raises
+  there too, before any other option in the same call is applied.
 
 - ``IPPrivacyMiddleware``'s idempotency guard installs a fail-closed
   ``otto.ip_match`` when ``otto.client_ip`` was set outside the middleware

--- a/changelog.d/20260725_ip_precision_and_privacy_profiles.rst
+++ b/changelog.d/20260725_ip_precision_and_privacy_profiles.rst
@@ -32,3 +32,30 @@ Added
   malformed → ``false``); configuration ``cidrs`` entries fail fast (invalid
   → raise). Accepts pre-parsed ``IPAddr`` entries to skip re-parsing on hot
   paths.
+
+Fixed
+-----
+
+- IPv4-mapped IPv6 CIDR *ranges* are now folded through ``IPAddr#native``, so
+  the fold is symmetric with the client address. Previously only the client
+  was folded, so a mapped range (``::ffff:10.0.0.0/104``) failed the
+  address-family check and was silently skipped — a wrong verdict rather than
+  an error. Affects both ``Otto::Utils.ip_in_cidrs?`` / ``otto.ip_match`` and
+  trusted-proxy entries, where an unmatched proxy silently withheld
+  ``otto.via_trusted_proxy`` and with it ``Request#secure?`` and geo-header
+  trust. Behavior change for anyone who configured a mapped-IPv6 range: it
+  now matches the IPv4 clients it names. Plain IPv4 and IPv6 ranges are
+  unaffected, and pre-parsed ``IPAddr`` entries are not mutated.
+
+- ``IPPrivacyMiddleware`` reads the privacy setting per request instead of
+  caching it at construction. Otto builds its middleware stack at the end of
+  ``Otto.new`` while ``configure_ip_privacy`` stays legal until the first
+  request, so a post-construction ``configure_ip_privacy(profile: :audit)``
+  was silently ignored and the middleware kept masking.
+
+- ``IPPrivacyMiddleware``'s idempotency guard installs a fail-closed
+  ``otto.ip_match`` when ``otto.client_ip`` was set outside the middleware
+  (out of contract, but previously left the advertised capability ``nil`` and
+  raised ``NoMethodError`` downstream). It deliberately does not rebuild the
+  check from ``otto.client_ip``, which may be masked — matching a masked
+  address against a narrow CIDR yields false allows. The deny is logged.

--- a/changelog.d/20260725_ip_precision_and_privacy_profiles.rst
+++ b/changelog.d/20260725_ip_precision_and_privacy_profiles.rst
@@ -1,0 +1,34 @@
+Added
+-----
+
+- Named privacy profiles: ``configure_ip_privacy(profile: :anonymous | :masked
+  | :audit)`` (also accepted by ``Otto::Privacy::Config.new``). A profile is a
+  validated preset over the existing knobs — ``:masked`` is the default
+  posture (public IPs masked, private exempt), ``:anonymous`` masks every IP
+  including private/localhost, and ``:audit`` disables IP privacy for
+  private/compliance environments where granular attributability supersedes
+  (retention responsibility transfers to the operator). The profile declares a
+  deployment's observability posture in one reviewable word;
+  ``Config#profile`` derives the label from live knob state so it can never go
+  stale. Unknown names raise ``ArgumentError``.
+
+- ``env['otto.ip_match']``: a verdict-only CIDR membership check over the
+  resolved, UNMASKED client IP, installed by ``IPPrivacyMiddleware`` on every
+  path that resolves an IP, under every profile. Call it with an array of
+  CIDR strings (or ``IPAddr`` objects) and get ``true``/``false`` back. This
+  decouples policy precision from observability posture: downstream access
+  control (e.g. a per-tenant IP allowlist) can match at full /32–/128
+  precision while ``otto.client_ip``, ``REMOTE_ADDR``, logs, and fingerprints
+  stay masked. The unmasked address never lands in env — only the closure
+  does, and a Proc serializes to nothing useful, so env dumps and loggers
+  cannot leak it accidentally. Returns ``false`` when the request has no
+  resolvable client IP (fail-closed for allowlist callers); invalid CIDR
+  entries raise ``IPAddr::InvalidAddressError`` (configuration error).
+
+- ``Otto::Utils.ip_in_cidrs?(ip, cidrs)``: the general-purpose CIDR-set
+  matcher behind ``otto.ip_match``, sharing the trusted-proxy matcher's
+  semantics — port stripping, ``IPAddr#native`` folding of IPv4-mapped IPv6,
+  family-aware range skipping. Runtime ``ip`` input fails closed (nil/blank/
+  malformed → ``false``); configuration ``cidrs`` entries fail fast (invalid
+  → raise). Accepts pre-parsed ``IPAddr`` entries to skip re-parsing on hot
+  paths.

--- a/lib/otto/env_keys.rb
+++ b/lib/otto/env_keys.rb
@@ -149,6 +149,10 @@ class Otto
     #       no resolvable client IP (fail-closed for allowlist callers);
     #       raises IPAddr::InvalidAddressError for invalid CIDR entries
     #       (configuration error). See Otto::Utils.ip_in_cidrs?.
+    # Note: setting CLIENT_IP yourself is out of contract — it trips the
+    #       middleware's idempotency guard, so the unmasked address is never
+    #       captured and this capability degrades to a logged fail-closed
+    #       check that denies every range.
     IP_MATCH = 'otto.ip_match'
 
     # Privacy-safe masked IP address

--- a/lib/otto/env_keys.rb
+++ b/lib/otto/env_keys.rb
@@ -134,6 +134,23 @@ class Otto
     # Note: presence also acts as the idempotency guard for the middleware
     CLIENT_IP = 'otto.client_ip'
 
+    # Verdict-only CIDR membership check over the resolved, UNMASKED client IP
+    # Type: Proc — call with an Enumerable of CIDR strings or IPAddr objects,
+    #       returns true/false
+    # Set by: IPPrivacyMiddleware (every path that resolves an IP, all
+    #         privacy profiles)
+    # Used by: Downstream IP policy code (allowlists, denylists, network
+    #          zones) that needs full /32-/128 precision without changing the
+    #          observability posture — CLIENT_IP is masked under the default
+    #          profile, so it cannot express a single host
+    # Note: the unmasked IP never lands in env; only this closure does, and a
+    #       Proc serializes to nothing useful, so env dumps and loggers cannot
+    #       leak the address accidentally. Returns false when the request had
+    #       no resolvable client IP (fail-closed for allowlist callers);
+    #       raises IPAddr::InvalidAddressError for invalid CIDR entries
+    #       (configuration error). See Otto::Utils.ip_in_cidrs?.
+    IP_MATCH = 'otto.ip_match'
+
     # Privacy-safe masked IP address
     # Type: String (e.g., '192.168.1.0')
     # Set by: IPPrivacyMiddleware

--- a/lib/otto/privacy/config.rb
+++ b/lib/otto/privacy/config.rb
@@ -228,8 +228,17 @@ class Otto
       #
       # @param profile [Symbol, String] one of the {PROFILES} keys
       # @return [Hash] frozen preset hash
-      # @raise [ArgumentError] for an unknown profile name
+      # @raise [ArgumentError] for an unknown profile name or an un-nameable type
       def self.profile_presets(profile)
+        # Neither Integer nor NilClass responds to #to_sym, so an unguarded
+        # conversion raises NoMethodError for `profile: 123` or an explicit
+        # `profile: nil` — an opaque failure inconsistent with the ArgumentError
+        # the rest of this class raises for bad input (cf. correlation_secret=).
+        unless profile.respond_to?(:to_sym)
+          raise ArgumentError,
+                "Privacy profile must be a Symbol or String, got: #{profile.class}"
+        end
+
         PROFILES.fetch(profile.to_sym) do
           raise ArgumentError,
                 "Unknown privacy profile: #{profile.inspect} (valid: #{PROFILES.keys.join(', ')})"
@@ -240,6 +249,14 @@ class Otto
       #
       # Sets only the knobs the profile names (see {PROFILES}); other settings
       # (octet_precision, geo, correlation_secret, ...) are untouched.
+      #
+      # Presets are applied, not reset: a knob a profile does not name keeps its
+      # previous value. Switching :anonymous -> :audit therefore leaves
+      # mask_private_ips true, because :audit names only `disabled`. That is
+      # inert rather than wrong — `disabled` short-circuits privacy_enabled?
+      # before mask_private_ips is ever read, and #profile below tests @disabled
+      # first, so the derived label stays accurate. Switching on to :masked
+      # re-sets both knobs explicitly. Only surprising if you read the raw ivars.
       #
       # @param profile [Symbol, String] :anonymous, :masked, or :audit
       # @raise [ArgumentError] for an unknown profile name

--- a/lib/otto/privacy/config.rb
+++ b/lib/otto/privacy/config.rb
@@ -357,9 +357,13 @@ class Otto
         raise ArgumentError, "octet_precision must be 1 or 2, got: #{@octet_precision}" unless [1,
                                                                                                 2].include?(@octet_precision)
 
-        return unless @hash_rotation_period < 60
+        # Type check before the numeric comparison: a non-Numeric value (false,
+        # a String from unparsed config, ...) would otherwise surface as
+        # NoMethodError/ArgumentError from #<, not a clear configuration error.
+        return if @hash_rotation_period.is_a?(Numeric) && @hash_rotation_period >= 60
 
-        raise ArgumentError, 'hash_rotation_period must be at least 60 seconds'
+        raise ArgumentError,
+              "hash_rotation_period must be at least 60 seconds, got: #{@hash_rotation_period.inspect}"
       end
 
       private

--- a/lib/otto/privacy/config.rb
+++ b/lib/otto/privacy/config.rb
@@ -27,6 +27,28 @@ class Otto
     class Config
       include Otto::Core::Freezable
 
+      # Named privacy profiles: validated presets over the individual knobs,
+      # so a deployment's observability posture is declared in one reviewable
+      # word instead of inferred from knob combinations.
+      #
+      # - :anonymous — mask every IP, including private/localhost. For
+      #   deployments where even internal addresses are treated as PII.
+      # - :masked    — the default posture: public IPs masked, private and
+      #   localhost exempt (development-friendly privacy-by-default).
+      # - :audit     — privacy disabled: real IPs flow to env and logs. For
+      #   private/compliance environments where granular attributability
+      #   supersedes IP privacy; retention responsibility transfers to the
+      #   operator.
+      #
+      # Note the axis this controls: what PERSISTS observably (env keys, logs,
+      # fingerprints). Precise ephemeral matching against the unmasked IP does
+      # not require :audit — see EnvKeys::IP_MATCH, available in every profile.
+      PROFILES = {
+        anonymous: { disabled: false, mask_private_ips: true }.freeze,
+           masked: { disabled: false, mask_private_ips: false }.freeze,
+            audit: { disabled: true }.freeze,
+      }.freeze
+
       attr_accessor :octet_precision, :hash_rotation_period, :geo_enabled, :mask_private_ips
       attr_reader :disabled, :correlation_secret, :geo_header, :geo_db_path
 
@@ -79,7 +101,11 @@ class Otto
       #   string is rejected, because an empty secret would let anyone reverse the
       #   fingerprint back to an IP.
       # @option options [Redis] :redis Optional Redis connection for multi-server environments
+      # @option options [Symbol] :profile Named privacy profile (:anonymous,
+      #   :masked, or :audit) applied as a preset; any other explicitly passed
+      #   option overrides the preset. See {PROFILES}.
       def initialize(options = {})
+        options = self.class.profile_presets(options[:profile]).merge(options) if options[:profile]
         @octet_precision = options.fetch(:octet_precision, 1)
         @hash_rotation_period = options.fetch(:hash_rotation_period, 86_400) # 24 hours
         @geo_enabled = options.fetch(:geo_enabled, true)
@@ -196,6 +222,45 @@ class Otto
           elsif @geo_db_path
             build_maxmind_reader(@geo_db_path)
           end
+      end
+
+      # Look up the preset hash for a named profile, failing fast on typos.
+      #
+      # @param profile [Symbol, String] one of the {PROFILES} keys
+      # @return [Hash] frozen preset hash
+      # @raise [ArgumentError] for an unknown profile name
+      def self.profile_presets(profile)
+        PROFILES.fetch(profile.to_sym) do
+          raise ArgumentError,
+                "Unknown privacy profile: #{profile.inspect} (valid: #{PROFILES.keys.join(', ')})"
+        end
+      end
+
+      # Apply a named privacy profile's presets to this config.
+      #
+      # Sets only the knobs the profile names (see {PROFILES}); other settings
+      # (octet_precision, geo, correlation_secret, ...) are untouched.
+      #
+      # @param profile [Symbol, String] :anonymous, :masked, or :audit
+      # @raise [ArgumentError] for an unknown profile name
+      def profile=(profile)
+        presets = self.class.profile_presets(profile)
+        @disabled = presets[:disabled] if presets.key?(:disabled)
+        @mask_private_ips = presets[:mask_private_ips] if presets.key?(:mask_private_ips)
+      end
+
+      # The profile the current knob state corresponds to.
+      #
+      # Derived from the live settings rather than remembering the last
+      # `profile=` call, so manual knob changes can never leave a stale label:
+      # what this returns is always what the config actually does.
+      #
+      # @return [Symbol] :audit, :anonymous, or :masked
+      def profile
+        return :audit if @disabled
+        return :anonymous if @mask_private_ips
+
+        :masked
       end
 
       # Canonicalize a geo header name to a Rack CGI env key ('HTTP_*').

--- a/lib/otto/privacy/config.rb
+++ b/lib/otto/privacy/config.rb
@@ -101,11 +101,11 @@ class Otto
       #   string is rejected, because an empty secret would let anyone reverse the
       #   fingerprint back to an IP.
       # @option options [Redis] :redis Optional Redis connection for multi-server environments
-      # @option options [Symbol] :profile Named privacy profile (:anonymous,
+      # @option options [Symbol, String] :profile Named privacy profile (:anonymous,
       #   :masked, or :audit) applied as a preset; any other explicitly passed
       #   option overrides the preset. See {PROFILES}.
       def initialize(options = {})
-        options = self.class.profile_presets(options[:profile]).merge(options) if options[:profile]
+        options = self.class.profile_presets(options[:profile]).merge(options) unless options[:profile].nil?
         @octet_precision = options.fetch(:octet_precision, 1)
         @hash_rotation_period = options.fetch(:hash_rotation_period, 86_400) # 24 hours
         @geo_enabled = options.fetch(:geo_enabled, true)

--- a/lib/otto/privacy/core.rb
+++ b/lib/otto/privacy/core.rb
@@ -107,7 +107,7 @@ class Otto
         ensure_not_frozen!
         config = @security_config.ip_privacy_config
 
-        config.profile = profile if profile
+        config.profile = profile unless profile.nil?
         config.octet_precision = octet_precision if octet_precision
         config.hash_rotation_period = hash_rotation if hash_rotation
         config.geo_enabled = geo unless geo.nil?

--- a/lib/otto/privacy/core.rb
+++ b/lib/otto/privacy/core.rb
@@ -88,16 +88,26 @@ class Otto
       #   redis = Redis.new(url: ENV['REDIS_URL'])
       #   otto.configure_ip_privacy(redis: redis)
       #
+      # @example Declare the observability posture for a compliance deployment
+      #   otto.configure_ip_privacy(profile: :audit)
+      #
+      # @param profile [Symbol] Named privacy profile (:anonymous, :masked, or
+      #   :audit) applied FIRST as a preset over disabled/mask_private_ips, so
+      #   any other option in the same call overrides it. This declares the
+      #   deployment's observability posture in one reviewable word; see
+      #   Otto::Privacy::Config::PROFILES.
+      #
       # rubocop:disable Metrics/ParameterLists -- a keyword-only configuration
       # method; the options are self-documenting at the call site and grouping
       # them into a hash would only obscure the supported settings.
       def configure_ip_privacy(octet_precision: nil, hash_rotation: nil, geo: nil, redis: nil,
                                correlation_secret: nil, geo_header: nil, geo_db_path: nil,
-                               geo_db_reader: nil)
+                               geo_db_reader: nil, profile: nil)
         # rubocop:enable Metrics/ParameterLists
         ensure_not_frozen!
         config = @security_config.ip_privacy_config
 
+        config.profile = profile if profile
         config.octet_precision = octet_precision if octet_precision
         config.hash_rotation_period = hash_rotation if hash_rotation
         config.geo_enabled = geo unless geo.nil?

--- a/lib/otto/privacy/core.rb
+++ b/lib/otto/privacy/core.rb
@@ -107,17 +107,17 @@ class Otto
         ensure_not_frozen!
         config = @security_config.ip_privacy_config
 
+        # Every kwarg uses a nil guard: nil means "leave unchanged", any other
+        # value — including false or "" — is a real assignment that must either
+        # take effect or fail validation loudly. A truthiness guard would
+        # silently drop false (and, for correlation_secret, the explicit ""
+        # that disables the correlation hash).
         config.profile = profile unless profile.nil?
-        config.octet_precision = octet_precision if octet_precision
-        config.hash_rotation_period = hash_rotation if hash_rotation
+        config.octet_precision = octet_precision unless octet_precision.nil?
+        config.hash_rotation_period = hash_rotation unless hash_rotation.nil?
         config.geo_enabled = geo unless geo.nil?
-        # Mirror geo's `unless nil?` guard: nil means "leave unchanged", while an
-        # explicit "" is a real value that disables the correlation hash. (A
-        # plain `if correlation_secret` would also assign "" since "" is truthy
-        # in Ruby, but stating the nil intent explicitly keeps this consistent
-        # with the other nilable kwargs.)
         config.correlation_secret = correlation_secret unless correlation_secret.nil?
-        config.instance_variable_set(:@redis, redis) if redis
+        config.instance_variable_set(:@redis, redis) unless redis.nil?
 
         # Validate configuration
         config.validate!

--- a/lib/otto/privacy/core.rb
+++ b/lib/otto/privacy/core.rb
@@ -106,27 +106,44 @@ class Otto
         # rubocop:enable Metrics/ParameterLists
         ensure_not_frozen!
         config = @security_config.ip_privacy_config
+        knobs = { profile: profile, octet_precision: octet_precision,
+                  hash_rotation: hash_rotation, geo: geo,
+                  correlation_secret: correlation_secret, redis: redis }
 
-        # Every kwarg uses a nil guard: nil means "leave unchanged", any other
-        # value — including false or "" — is a real assignment that must either
-        # take effect or fail validation loudly. A truthiness guard would
-        # silently drop false (and, for correlation_secret, the explicit ""
-        # that disables the correlation hash).
-        config.profile = profile unless profile.nil?
-        config.octet_precision = octet_precision unless octet_precision.nil?
-        config.hash_rotation_period = hash_rotation unless hash_rotation.nil?
-        config.geo_enabled = geo unless geo.nil?
-        config.correlation_secret = correlation_secret unless correlation_secret.nil?
-        config.instance_variable_set(:@redis, redis) unless redis.nil?
-
-        # Validate configuration
-        config.validate!
+        # Dry-run the assignments on a throwaway copy and validate the combined
+        # result there, so a rejected knob (octet_precision: 7 after a profile
+        # preset, say) raises before the live config has been touched — the
+        # call is all-or-nothing, never half-applied.
+        apply_privacy_knobs(config.dup, knobs).validate!
+        apply_privacy_knobs(config, knobs)
 
         apply_geo_config(config, geo: geo, geo_header: geo_header,
                                  geo_db_path: geo_db_path, geo_db_reader: geo_db_reader)
       end
 
       private
+
+      # Assign the non-geo privacy knobs onto a config.
+      #
+      # Every kwarg uses a nil guard: nil means "leave unchanged", any other
+      # value — including false or "" — is a real assignment that must either
+      # take effect or fail validation loudly. A truthiness guard would
+      # silently drop false (and, for correlation_secret, the explicit ""
+      # that disables the correlation hash).
+      #
+      # @param config [Otto::Privacy::Config] the config to mutate
+      # @param knobs [Hash] the non-geo keyword arguments from configure_ip_privacy
+      # @return [Otto::Privacy::Config] the same config, for chaining
+      # @api private
+      def apply_privacy_knobs(config, knobs)
+        config.profile = knobs[:profile] unless knobs[:profile].nil?
+        config.octet_precision = knobs[:octet_precision] unless knobs[:octet_precision].nil?
+        config.hash_rotation_period = knobs[:hash_rotation] unless knobs[:hash_rotation].nil?
+        config.geo_enabled = knobs[:geo] unless knobs[:geo].nil?
+        config.correlation_secret = knobs[:correlation_secret] unless knobs[:correlation_secret].nil?
+        config.instance_variable_set(:@redis, knobs[:redis]) unless knobs[:redis].nil?
+        config
+      end
 
       # Apply the geo-fallback settings and (re)load the database when needed.
       #

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -782,12 +782,20 @@ class Otto
       # trusted_proxy? never re-parses. Non-IP strings and Regexp/other entries
       # store a nil range and fall back to prefix/regexp matching.
       #
+      # The parsed range is folded through IPAddr#native at registration, to
+      # match the fold trusted_proxy? applies to the client address. Without
+      # it a mapped-IPv6 proxy entry (::ffff:10.0.0.0/104) could never match,
+      # because ip_in_range?'s family check would reject the folded IPv4
+      # client — a proxy silently untrusted, which is what gates
+      # otto.via_trusted_proxy, secure?, and geo-header trust. #native returns
+      # self for entries that are not IPv4-mapped/compatible.
+      #
       # @param entry [String, Regexp, Object] trusted proxy entry being added
       # @return [Array(Object, IPAddr)] [raw_entry, parsed_range_or_nil]
       def register_proxy_matcher(entry)
         return [entry, nil] unless entry.is_a?(String)
 
-        range = parse_ipaddr(entry)
+        range = parse_ipaddr(entry)&.native
         warn_legacy_proxy_entry(entry) unless range
         [entry, range]
       end

--- a/lib/otto/security/middleware/ip_privacy_middleware.rb
+++ b/lib/otto/security/middleware/ip_privacy_middleware.rb
@@ -131,13 +131,14 @@ class Otto
           # material is gone (REMOTE_ADDR and forwarded headers rewritten).
           install_ip_match(env, client_ip)
 
-          # Deliberately does not interpolate client_ip. This method only runs on
-          # the masking profiles (:masked / :anonymous), so echoing the resolved
-          # address here would hand back exactly what the profile just promised
-          # to withhold — and logs travel further than env does. The masked value
-          # is logged after masking instead; :audit keeps the raw IP in env by
-          # design and takes apply_no_privacy, which never reaches this line.
-          Otto.logger.debug '[IPPrivacyMiddleware] Resolved client IP (pre-mask)' if Otto.debug
+          # There is deliberately no debug line for the resolution itself. It
+          # used to interpolate client_ip, which handed back through the log
+          # exactly what these profiles withhold from env — and logs travel
+          # further than a process does. Stripped of the address it carried no
+          # information worth a line: this method only runs on the masking
+          # profiles (:masked / :anonymous), and every branch below already logs
+          # its own outcome. To trace resolution here, log a derived value (the
+          # masked IP, the family, the trusted-proxy verdict) — never the address.
 
           # No resolvable client IP (REMOTE_ADDR absent or blank, and no trusted
           # forwarded value). There is nothing to mask, and masking would derive
@@ -188,10 +189,12 @@ class Otto
               # localhost / RFC-1918 addresses (the default dev path) even when a
               # correlation_secret is configured. Set mask_private_ips to treat
               # private IPs as public and run them through the full path below.
-              # No address interpolated here either (see the pre-mask note
-              # above). Exempt IPs skip fingerprinting entirely, so there is no
-              # derived value to log — the line records only that the exemption
-              # fired.
+              # No address interpolated (see the resolution note at the top of
+              # this method). Exempt IPs skip fingerprinting entirely, so there
+              # is no derived value to log either — the line records only that
+              # the exemption fired. The address is not lost to debugging: this
+              # path leaves REMOTE_ADDR unmasked and sets otto.client_ip to the
+              # same value, so downstream request logs still carry it.
               Otto.logger.debug '[IPPrivacyMiddleware] Private/localhost IP exempted from masking' if Otto.debug
               return
             end

--- a/lib/otto/security/middleware/ip_privacy_middleware.rb
+++ b/lib/otto/security/middleware/ip_privacy_middleware.rb
@@ -113,9 +113,10 @@ class Otto
         # Every path in this middleware that sets otto.client_ip installs the
         # capability first, so a second IPPrivacyMiddleware pass that reaches
         # this guard finds both keys and leaves the precise closure in place.
-        # (The no-resolvable-IP path sets neither key, so a second pass simply
-        # re-runs apply_privacy — idempotent, since there is nothing to
-        # double-mask.) The gap is out-of-contract writes: otto.client_ip is
+        # (The no-resolvable-IP path installs the capability but never sets
+        # otto.client_ip, so a second pass re-runs apply_privacy and reinstalls
+        # an equivalent fail-closed closure — idempotent, since there is nothing
+        # to double-mask.) The gap is out-of-contract writes: otto.client_ip is
         # documented as "Set by: IPPrivacyMiddleware" (see Otto::EnvKeys), but
         # an app or test harness that sets it directly trips the idempotency
         # guard and leaves the advertised capability nil — downstream policy

--- a/lib/otto/security/middleware/ip_privacy_middleware.rb
+++ b/lib/otto/security/middleware/ip_privacy_middleware.rb
@@ -32,9 +32,6 @@ class Otto
           @app = app
           @security_config = security_config
           @config = security_config&.ip_privacy_config || Otto::Privacy::Config.new
-
-          # Privacy is enabled by default unless explicitly disabled
-          @privacy_enabled = @config.enabled?
         end
 
         # Process request with IP privacy
@@ -46,7 +43,10 @@ class Otto
           # canonical client IP for this request, do not re-resolve or re-mask.
           # This makes stacking two instances (e.g. an app-level mount plus
           # Otto's built-in router mount) order-safe instead of double-masking.
-          return @app.call(env) if env.key?('otto.client_ip')
+          if env.key?('otto.client_ip')
+            ensure_ip_match_present(env)
+            return @app.call(env)
+          end
 
           # Record the connecting peer's trust decision BEFORE any masking, so
           # secure? can authorize X-Forwarded-Proto canonically even after
@@ -58,7 +58,7 @@ class Otto
           # downstream OneTimeSecret behavior).
           env['otto.via_trusted_proxy'] = trusted_proxy?(env['REMOTE_ADDR'])
 
-          if @privacy_enabled
+          if privacy_enabled?
             apply_privacy(env)
           else
             apply_no_privacy(env)
@@ -68,6 +68,52 @@ class Otto
         end
 
         private
+
+        # Whether IP privacy is on for this request.
+        #
+        # Read live from the config rather than cached at construction. Otto
+        # builds its middleware stack at the end of Otto.new, but
+        # configure_ip_privacy stays legal until the first request (the
+        # configuration freeze is deferred — see Otto#initialize). A flag
+        # captured in #initialize would therefore ignore a post-construction
+        # `configure_ip_privacy(profile: :audit)` and keep masking under a
+        # profile the operator explicitly turned off. One predicate call per
+        # request buys that correctness.
+        #
+        # @return [Boolean]
+        def privacy_enabled?
+          @config.enabled?
+        end
+
+        # Guarantee env['otto.ip_match'] exists on the idempotent-return path.
+        #
+        # Every path in this middleware that sets otto.client_ip installs the
+        # capability first, so a second IPPrivacyMiddleware pass always finds
+        # both keys. The gap is out-of-contract writes: otto.client_ip is
+        # documented as "Set by: IPPrivacyMiddleware" (see Otto::EnvKeys), but
+        # an app or test harness that sets it directly trips the idempotency
+        # guard and leaves the advertised capability nil — downstream policy
+        # code then raises NoMethodError on nil.
+        #
+        # The repair installs a fail-closed check, NOT one derived from
+        # env['otto.client_ip']. That value may already be masked, and matching
+        # a masked address against a narrow CIDR produces false ALLOWs (masked
+        # 192.168.1.0 falls inside 192.168.1.0/28 when the real client was
+        # .200). A universal deny is the safe verdict; the warning below is
+        # what makes it diagnosable instead of a silent lockout.
+        #
+        # @param env [Hash] Rack environment
+        def ensure_ip_match_present(env)
+          return if env.key?('otto.ip_match')
+
+          Otto.logger.warn(
+            '[IPPrivacyMiddleware] otto.client_ip was set outside this ' \
+            'middleware, so otto.ip_match could not be built from the ' \
+            'unmasked address; installing a fail-closed check (every CIDR ' \
+            'test returns false). Let IPPrivacyMiddleware resolve the client IP.'
+          )
+          env['otto.ip_match'] = ->(_cidrs) { false }
+        end
 
         # Apply privacy settings to environment
         #

--- a/lib/otto/security/middleware/ip_privacy_middleware.rb
+++ b/lib/otto/security/middleware/ip_privacy_middleware.rb
@@ -131,7 +131,13 @@ class Otto
           # material is gone (REMOTE_ADDR and forwarded headers rewritten).
           install_ip_match(env, client_ip)
 
-          Otto.logger.debug "[IPPrivacyMiddleware] Resolved client IP: #{client_ip}" if Otto.debug
+          # Deliberately does not interpolate client_ip. This method only runs on
+          # the masking profiles (:masked / :anonymous), so echoing the resolved
+          # address here would hand back exactly what the profile just promised
+          # to withhold — and logs travel further than env does. The masked value
+          # is logged after masking instead; :audit keeps the raw IP in env by
+          # design and takes apply_no_privacy, which never reaches this line.
+          Otto.logger.debug '[IPPrivacyMiddleware] Resolved client IP (pre-mask)' if Otto.debug
 
           # No resolvable client IP (REMOTE_ADDR absent or blank, and no trusted
           # forwarded value). There is nothing to mask, and masking would derive
@@ -182,7 +188,11 @@ class Otto
               # localhost / RFC-1918 addresses (the default dev path) even when a
               # correlation_secret is configured. Set mask_private_ips to treat
               # private IPs as public and run them through the full path below.
-              Otto.logger.debug "[IPPrivacyMiddleware] Private/localhost IP exempted: #{client_ip}" if Otto.debug
+              # No address interpolated here either (see the pre-mask note
+              # above). Exempt IPs skip fingerprinting entirely, so there is no
+              # derived value to log — the line records only that the exemption
+              # fired.
+              Otto.logger.debug '[IPPrivacyMiddleware] Private/localhost IP exempted from masking' if Otto.debug
               return
             end
           end

--- a/lib/otto/security/middleware/ip_privacy_middleware.rb
+++ b/lib/otto/security/middleware/ip_privacy_middleware.rb
@@ -77,6 +77,11 @@ class Otto
           # canonical resolution step; masking below operates on this value.
           client_ip = resolve_client_ip(env)
 
+          # Install the verdict-only precision capability while client_ip is
+          # still the real address — after this method returns, the raw
+          # material is gone (REMOTE_ADDR and forwarded headers rewritten).
+          install_ip_match(env, client_ip)
+
           Otto.logger.debug "[IPPrivacyMiddleware] Resolved client IP: #{client_ip}" if Otto.debug
 
           # No resolvable client IP (REMOTE_ADDR absent or blank, and no trusted
@@ -250,6 +255,36 @@ class Otto
           Otto::Utils.resolve_client_ip(env, @security_config)
         end
 
+        # Install env['otto.ip_match']: a verdict-only CIDR membership check
+        # over the resolved, UNMASKED client IP.
+        #
+        # This is the precision axis of the privacy design, decoupled from the
+        # observability axis (the privacy profile): policy code downstream —
+        # e.g. a per-tenant IP allowlist — can ask "is this client inside
+        # these ranges?" at full /32-/128 precision under ANY profile,
+        # including full masking. The unmasked address itself never lands in
+        # env; only this closure does, and a closure serializes to nothing
+        # useful, so env dumps, loggers, and error reporters that walk env
+        # cannot leak the IP accidentally.
+        #
+        # Threat model: the capability is a membership oracle, so deliberate
+        # in-process code could reconstruct the address via adaptive queries —
+        # but in-process code is already trusted (it could monkeypatch this
+        # middleware). The invariant defended is accidental persistence and
+        # serialization, and a Proc preserves it where a raw string could not.
+        #
+        # The closure is installed on every path that resolves an IP (masked,
+        # private-exempt, and privacy-disabled). When the request has no
+        # resolvable client IP the check returns false — fail-closed for
+        # allowlist callers. Invalid CIDR entries raise (configuration error);
+        # see Otto::Utils.ip_in_cidrs?.
+        #
+        # @param env [Hash] Rack environment
+        # @param client_ip [String, nil] resolved, unmasked client IP
+        def install_ip_match(env, client_ip)
+          env['otto.ip_match'] = ->(cidrs) { Otto::Utils.ip_in_cidrs?(client_ip, cidrs) }
+        end
+
         # Delete forwarded IP headers outright.
         #
         # Used on the no-resolvable-client-IP path, where there is no masked IP
@@ -347,7 +382,12 @@ class Otto
           # Resolve the canonical client IP once, even with privacy disabled, so
           # downstream code can read env['otto.client_ip'] instead of re-deriving
           # it from REMOTE_ADDR / forwarded headers.
-          env['otto.client_ip'] = resolve_client_ip(env)
+          client_ip = resolve_client_ip(env)
+          env['otto.client_ip'] = client_ip
+
+          # Same precision capability as the privacy-enabled paths, so policy
+          # code has one interface regardless of profile.
+          install_ip_match(env, client_ip)
 
           # Store original values for explicit access when privacy is disabled
           if env['REMOTE_ADDR']

--- a/lib/otto/security/middleware/ip_privacy_middleware.rb
+++ b/lib/otto/security/middleware/ip_privacy_middleware.rb
@@ -88,8 +88,11 @@ class Otto
         # Guarantee env['otto.ip_match'] exists on the idempotent-return path.
         #
         # Every path in this middleware that sets otto.client_ip installs the
-        # capability first, so a second IPPrivacyMiddleware pass always finds
-        # both keys. The gap is out-of-contract writes: otto.client_ip is
+        # capability first, so a second IPPrivacyMiddleware pass that reaches
+        # this guard finds both keys and leaves the precise closure in place.
+        # (The no-resolvable-IP path sets neither key, so a second pass simply
+        # re-runs apply_privacy — idempotent, since there is nothing to
+        # double-mask.) The gap is out-of-contract writes: otto.client_ip is
         # documented as "Set by: IPPrivacyMiddleware" (see Otto::EnvKeys), but
         # an app or test harness that sets it directly trips the idempotency
         # guard and leaves the advertised capability nil — downstream policy

--- a/lib/otto/utils.rb
+++ b/lib/otto/utils.rb
@@ -339,6 +339,14 @@ class Otto
     # untouched, and it returns a new IPAddr rather than mutating, so
     # pre-parsed entries in a caller's configuration array stay intact.
     #
+    # The fold needs the prefix to cover the mapped marker — /96 or longer.
+    # ::ffff:10.0.0.0/104 folds to 10.0.0.0/8; ::ffff:10.0.0.0/64 does not
+    # fold at all, because masking zeroes the ffff marker, and so matches
+    # neither an IPv4 client nor a mapped one. Write mapped ranges at /96+,
+    # or just write the IPv4 CIDR. ::ffff:0:0/96 is the whole mapped space
+    # and therefore matches every IPv4 address. Deprecated IPv4-compatible
+    # notation (::a.b.c.d) folds on the same terms, on both sides.
+    #
     # Asymmetric strictness, on purpose:
     # - `ip` is runtime data — nil, blank, or malformed input returns false
     #   (fail-closed for allowlist callers).
@@ -367,7 +375,13 @@ class Otto
         end
 
       cidrs.any? do |entry|
-        range = (entry.is_a?(IPAddr) ? entry : IPAddr.new(entry.to_s)).native
+        range = entry.is_a?(IPAddr) ? entry : IPAddr.new(entry.to_s)
+        # IPAddr#native builds its result with #clone, which carries frozen
+        # state over and then fails to mutate it. Callers who freeze their
+        # range configuration (or pass it through Ractor.make_shareable) would
+        # hit FrozenError, so unfreeze the one case that actually folds.
+        range = range.dup if range.frozen? && (range.ipv4_mapped? || range.ipv4_compat?)
+        range = range.native
         range.family == client.family && range.include?(client)
       end
     end

--- a/lib/otto/utils.rb
+++ b/lib/otto/utils.rb
@@ -320,5 +320,47 @@ class Otto
     rescue IPAddr::InvalidAddressError, IPAddr::AddressFamilyError
       false
     end
+
+    # Whether an address falls inside any of the given CIDR ranges.
+    #
+    # The general-purpose CIDR-set matcher (allowlists, denylists, network
+    # zones), sharing the semantics of the trusted-proxy matcher: the client
+    # address is normalized (port stripped, validated) and folded via
+    # IPAddr#native so an IPv4-mapped IPv6 peer (::ffff:203.0.113.7) matches
+    # an IPv4 range; ranges of the other address family are skipped rather
+    # than raising.
+    #
+    # Asymmetric strictness, on purpose:
+    # - `ip` is runtime data — nil, blank, or malformed input returns false
+    #   (fail-closed for allowlist callers).
+    # - `cidrs` entries are configuration — an invalid CIDR string raises
+    #   IPAddr::InvalidAddressError, because silently skipping an entry
+    #   narrows an allowlist or widens a denylist. Validate entries at
+    #   write/boot time; pre-parsed IPAddr entries skip re-parsing here.
+    #
+    # @param ip [String, IPAddr, nil] address to test (runtime data)
+    # @param cidrs [Enumerable<String, IPAddr>, nil] CIDR ranges or host
+    #   addresses (configuration)
+    # @return [Boolean] true when ip is inside at least one range
+    # @raise [IPAddr::InvalidAddressError] if a cidrs entry is not a valid
+    #   IP or CIDR string
+    def ip_in_cidrs?(ip, cidrs)
+      return false if cidrs.nil?
+
+      client =
+        if ip.is_a?(IPAddr)
+          ip.native
+        else
+          candidate = normalize_ip(ip&.to_s)
+          return false unless candidate
+
+          IPAddr.new(candidate).native
+        end
+
+      cidrs.any? do |entry|
+        range = entry.is_a?(IPAddr) ? entry : IPAddr.new(entry.to_s)
+        range.family == client.family && range.include?(client)
+      end
+    end
   end
 end

--- a/lib/otto/utils.rb
+++ b/lib/otto/utils.rb
@@ -330,6 +330,15 @@ class Otto
     # an IPv4 range; ranges of the other address family are skipped rather
     # than raising.
     #
+    # Ranges are folded through #native too, so the fold is symmetric: a
+    # mapped-IPv6 CIDR (::ffff:10.0.0.0/104) matches a plain IPv4 client just
+    # as a mapped client matches a plain IPv4 range. Folding only one side
+    # made the family check reject the pair and silently drop the entry —
+    # wrong verdict, not a raise. #native returns self for ranges that are
+    # not IPv4-mapped/compatible, so ordinary IPv4 and IPv6 CIDRs are
+    # untouched, and it returns a new IPAddr rather than mutating, so
+    # pre-parsed entries in a caller's configuration array stay intact.
+    #
     # Asymmetric strictness, on purpose:
     # - `ip` is runtime data — nil, blank, or malformed input returns false
     #   (fail-closed for allowlist callers).
@@ -358,7 +367,7 @@ class Otto
         end
 
       cidrs.any? do |entry|
-        range = entry.is_a?(IPAddr) ? entry : IPAddr.new(entry.to_s)
+        range = (entry.is_a?(IPAddr) ? entry : IPAddr.new(entry.to_s)).native
         range.family == client.family && range.include?(client)
       end
     end

--- a/lib/otto/utils.rb
+++ b/lib/otto/utils.rb
@@ -379,8 +379,11 @@ class Otto
         # IPAddr#native builds its result with #clone, which carries frozen
         # state over and then fails to mutate it. Callers who freeze their
         # range configuration (or pass it through Ractor.make_shareable) would
-        # hit FrozenError, so unfreeze the one case that actually folds.
-        range = range.dup if range.frozen? && (range.ipv4_mapped? || range.ipv4_compat?)
+        # hit FrozenError, so hand #native an unfrozen receiver. Gating the dup
+        # on a foldable-range predicate would cost more than it saves:
+        # #ipv4_compat? is deprecated and warns under -w, and #native already
+        # short-circuits to self for anything that does not fold.
+        range = range.dup if range.frozen?
         range = range.native
         range.family == client.family && range.include?(client)
       end

--- a/spec/otto/ip_precision_capability_spec.rb
+++ b/spec/otto/ip_precision_capability_spec.rb
@@ -162,11 +162,19 @@ RSpec.describe 'IP precision capability and privacy profiles' do
       end
 
       it 'raises ArgumentError, not NoMethodError, for a profile that cannot be a name' do
-        # Neither responds to #to_sym.
+        # Neither Integer nor NilClass responds to #to_sym.
         expect { described_class.new.profile = 123 }
           .to raise_error(ArgumentError, /must be a Symbol or String, got: Integer/)
         expect { described_class.new.profile = nil }
           .to raise_error(ArgumentError, /must be a Symbol or String, got: NilClass/)
+        expect { described_class.new(profile: 123) }
+          .to raise_error(ArgumentError, /must be a Symbol or String, got: Integer/)
+      end
+
+      it 'treats profile: nil at construction as "leave unchanged", not an error' do
+        # The truthiness guard at the option site skips the preset entirely, so
+        # the nil never reaches profile_presets. Only the setter rejects nil.
+        expect(described_class.new(profile: nil).profile).to eq(:masked)
       end
 
       it 'derives the profile from live knob state, never a stale label' do
@@ -208,6 +216,14 @@ RSpec.describe 'IP precision capability and privacy profiles' do
         config = otto.security_config.ip_privacy_config
         expect(config.profile).to eq(:masked)
         expect(config.octet_precision).to eq(2)
+      end
+
+      it 'raises on a profile that cannot be a name' do
+        otto = Otto.new
+        expect { otto.configure_ip_privacy(profile: 123) }
+          .to raise_error(ArgumentError, /must be a Symbol or String, got: Integer/)
+        # Rejected before any other option is applied.
+        expect(otto.security_config.ip_privacy_config.profile).to eq(:masked)
       end
 
       it 'raises on an unknown profile' do
@@ -360,14 +376,19 @@ RSpec.describe 'IP precision capability and privacy profiles' do
         env = { 'REMOTE_ADDR' => '192.168.1.50' }
         middleware.call(env)
 
-        expect(lines.join("\n")).not_to include('192.168.1.50')
+        log = lines.join("\n")
+        expect(log).not_to be_empty # guards against a vacuous pass
+        expect(log).not_to include('192.168.1.50')
       end
 
-      it 'still logs the resolved address under :audit, which keeps it in env by design' do
+      it 'emits nothing at all under :audit, which keeps the raw IP in env by design' do
         security_config.ip_privacy_config.profile = :audit
         env = { 'REMOTE_ADDR' => '203.0.113.7' }
         middleware.call(env)
 
+        # apply_no_privacy has no logging statements; the raw address stays in
+        # env, so there is nothing for a log line to disclose that env does not.
+        expect(lines).to be_empty
         expect(env['otto.client_ip']).to eq('203.0.113.7')
       end
     end

--- a/spec/otto/ip_precision_capability_spec.rb
+++ b/spec/otto/ip_precision_capability_spec.rb
@@ -1,0 +1,246 @@
+# spec/otto/ip_precision_capability_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# The two-axis privacy design:
+# - Observability posture (what persists in env/logs) — named profiles.
+# - Policy precision (what a decision may examine, ephemerally) — the
+#   verdict-only env['otto.ip_match'] capability and its Utils primitive.
+RSpec.describe 'IP precision capability and privacy profiles' do
+  describe 'Otto::Utils.ip_in_cidrs?' do
+    it 'matches an IPv4 host inside a CIDR range' do
+      expect(Otto::Utils.ip_in_cidrs?('203.0.113.7', ['203.0.113.0/24'])).to be true
+    end
+
+    it 'matches a full /32 host entry' do
+      expect(Otto::Utils.ip_in_cidrs?('203.0.113.7', ['203.0.113.7/32'])).to be true
+      expect(Otto::Utils.ip_in_cidrs?('203.0.113.8', ['203.0.113.7/32'])).to be false
+    end
+
+    it 'matches IPv6 ranges' do
+      expect(Otto::Utils.ip_in_cidrs?('2001:db8:85a3::1', ['2001:db8::/32'])).to be true
+      expect(Otto::Utils.ip_in_cidrs?('2001:db9::1', ['2001:db8::/32'])).to be false
+    end
+
+    it 'folds IPv4-mapped IPv6 clients onto IPv4 ranges' do
+      expect(Otto::Utils.ip_in_cidrs?('::ffff:203.0.113.7', ['203.0.113.0/24'])).to be true
+    end
+
+    it 'skips ranges of the other address family instead of raising' do
+      expect(Otto::Utils.ip_in_cidrs?('203.0.113.7', ['2001:db8::/32'])).to be false
+      expect(Otto::Utils.ip_in_cidrs?('2001:db8::1', ['203.0.113.0/24'])).to be false
+    end
+
+    it 'accepts pre-parsed IPAddr entries' do
+      ranges = [IPAddr.new('203.0.113.0/24'), IPAddr.new('2001:db8::/32')]
+      expect(Otto::Utils.ip_in_cidrs?('203.0.113.7', ranges)).to be true
+      expect(Otto::Utils.ip_in_cidrs?('2001:db8::1', ranges)).to be true
+    end
+
+    it 'accepts an IPAddr as the client address' do
+      expect(Otto::Utils.ip_in_cidrs?(IPAddr.new('203.0.113.7'), ['203.0.113.0/24'])).to be true
+    end
+
+    it 'strips a port from the client address' do
+      expect(Otto::Utils.ip_in_cidrs?('203.0.113.7:443', ['203.0.113.0/24'])).to be true
+      expect(Otto::Utils.ip_in_cidrs?('[2001:db8::1]:443', ['2001:db8::/32'])).to be true
+    end
+
+    it 'fails closed on nil, blank, or malformed client input' do
+      expect(Otto::Utils.ip_in_cidrs?(nil, ['203.0.113.0/24'])).to be false
+      expect(Otto::Utils.ip_in_cidrs?('', ['203.0.113.0/24'])).to be false
+      expect(Otto::Utils.ip_in_cidrs?('not-an-ip', ['203.0.113.0/24'])).to be false
+    end
+
+    it 'returns false for nil or empty range lists' do
+      expect(Otto::Utils.ip_in_cidrs?('203.0.113.7', nil)).to be false
+      expect(Otto::Utils.ip_in_cidrs?('203.0.113.7', [])).to be false
+    end
+
+    it 'raises for an invalid CIDR entry (configuration error, not runtime data)' do
+      expect do
+        Otto::Utils.ip_in_cidrs?('203.0.113.7', ['not-a-cidr'])
+      end.to raise_error(IPAddr::InvalidAddressError)
+    end
+  end
+
+  describe 'privacy profiles' do
+    describe Otto::Privacy::Config do
+      it 'defaults to the :masked profile' do
+        expect(described_class.new.profile).to eq(:masked)
+      end
+
+      it 'applies :anonymous presets' do
+        config = described_class.new
+        config.profile = :anonymous
+        expect(config.enabled?).to be true
+        expect(config.mask_private_ips).to be true
+        expect(config.profile).to eq(:anonymous)
+      end
+
+      it 'applies :audit presets' do
+        config = described_class.new
+        config.profile = :audit
+        expect(config.disabled?).to be true
+        expect(config.profile).to eq(:audit)
+      end
+
+      it 'returns to :masked when re-applied' do
+        config = described_class.new
+        config.profile = :audit
+        config.profile = :masked
+        expect(config.enabled?).to be true
+        expect(config.mask_private_ips).to be false
+        expect(config.profile).to eq(:masked)
+      end
+
+      it 'derives the profile from live knob state, never a stale label' do
+        config = described_class.new
+        config.profile = :masked
+        config.mask_private_ips = true
+        expect(config.profile).to eq(:anonymous)
+      end
+
+      it 'raises on an unknown profile name' do
+        expect { described_class.new.profile = :stealth }
+          .to raise_error(ArgumentError, /Unknown privacy profile/)
+      end
+
+      it 'accepts profile: at construction, with explicit options overriding the preset' do
+        config = described_class.new(profile: :anonymous, mask_private_ips: false)
+        expect(config.mask_private_ips).to be false
+        expect(config.enabled?).to be true
+      end
+
+      it 'leaves non-profile knobs untouched when a profile is applied' do
+        config = described_class.new(octet_precision: 2)
+        config.profile = :audit
+        expect(config.octet_precision).to eq(2)
+      end
+    end
+
+    describe 'Otto#configure_ip_privacy(profile:)' do
+      it 'applies the profile to the security config' do
+        otto = Otto.new
+        otto.configure_ip_privacy(profile: :audit)
+        expect(otto.security_config.ip_privacy_config.profile).to eq(:audit)
+      end
+
+      it 'lets explicit options in the same call override the preset' do
+        otto = Otto.new
+        otto.configure_ip_privacy(profile: :audit)
+        otto.configure_ip_privacy(profile: :masked, octet_precision: 2)
+        config = otto.security_config.ip_privacy_config
+        expect(config.profile).to eq(:masked)
+        expect(config.octet_precision).to eq(2)
+      end
+
+      it 'raises on an unknown profile' do
+        otto = Otto.new
+        expect { otto.configure_ip_privacy(profile: :bogus) }
+          .to raise_error(ArgumentError, /Unknown privacy profile/)
+      end
+    end
+  end
+
+  describe "env['otto.ip_match'] capability" do
+    let(:app) { ->(env) { [200, {}, ['OK']] } }
+    let(:security_config) { Otto::Security::Config.new }
+    let(:middleware) { Otto::Security::Middleware::IPPrivacyMiddleware.new(app, security_config) }
+
+    context 'masked path (public IP, privacy enabled)' do
+      it 'matches the full unmasked address while otto.client_ip is masked' do
+        env = { 'REMOTE_ADDR' => '203.0.113.7' }
+        middleware.call(env)
+
+        expect(env['otto.client_ip']).to eq('203.0.113.0')
+        expect(env['otto.ip_match'].call(['203.0.113.7/32'])).to be true
+        expect(env['otto.ip_match'].call(['203.0.113.8/32'])).to be false
+      end
+
+      it 'gives /32 precision the masked client_ip cannot express' do
+        env = { 'REMOTE_ADDR' => '203.0.113.7' }
+        middleware.call(env)
+
+        # The masked IP would wrongly match a sibling host's /32; the
+        # capability does not.
+        expect(Otto::Utils.ip_in_cidrs?(env['otto.client_ip'], ['203.0.113.0/32'])).to be true
+        expect(env['otto.ip_match'].call(['203.0.113.0/32'])).to be false
+      end
+
+      it 'does not place the unmasked address anywhere in env' do
+        env = { 'REMOTE_ADDR' => '203.0.113.7' }
+        middleware.call(env)
+
+        serializable = env.reject { |_k, v| v.is_a?(Proc) || v.is_a?(Otto::Privacy::RedactedFingerprint) }
+        expect(serializable.inspect).not_to include('203.0.113.7')
+      end
+
+      it 'matches IPv6 clients at full /128 precision' do
+        env = { 'REMOTE_ADDR' => '2001:db8:85a3::8a2e:370:7334' }
+        middleware.call(env)
+
+        expect(env['otto.ip_match'].call(['2001:db8:85a3::8a2e:370:7334/128'])).to be true
+        expect(env['otto.ip_match'].call(['2001:db8:85a3::8a2e:370:7335/128'])).to be false
+      end
+
+      it 'resolves through a trusted proxy before matching' do
+        security_config.add_trusted_proxy('10.0.0.0/8')
+        env = { 'REMOTE_ADDR' => '10.0.0.1', 'HTTP_X_FORWARDED_FOR' => '203.0.113.7' }
+        middleware.call(env)
+
+        expect(env['otto.ip_match'].call(['203.0.113.7/32'])).to be true
+      end
+    end
+
+    context 'private-exempt path' do
+      it 'installs the capability for exempt private IPs' do
+        env = { 'REMOTE_ADDR' => '192.168.1.50' }
+        middleware.call(env)
+
+        expect(env['otto.client_ip']).to eq('192.168.1.50')
+        expect(env['otto.ip_match'].call(['192.168.1.50/32'])).to be true
+        expect(env['otto.ip_match'].call(['192.168.2.0/24'])).to be false
+      end
+    end
+
+    context 'privacy disabled (:audit profile)' do
+      it 'installs the same capability for interface consistency' do
+        security_config.ip_privacy_config.profile = :audit
+        env = { 'REMOTE_ADDR' => '203.0.113.7' }
+        middleware.call(env)
+
+        expect(env['otto.client_ip']).to eq('203.0.113.7')
+        expect(env['otto.ip_match'].call(['203.0.113.7/32'])).to be true
+      end
+    end
+
+    context 'no resolvable client IP' do
+      it 'fails closed: the capability returns false for any range' do
+        env = {}
+        middleware.call(env)
+
+        expect(env['otto.ip_match']).to be_a(Proc)
+        expect(env['otto.ip_match'].call(['0.0.0.0/0', '::/0'])).to be false
+      end
+    end
+
+    context 'idempotency guard' do
+      it 'does not install a second capability when otto.client_ip is pre-set' do
+        env = { 'REMOTE_ADDR' => '203.0.113.7', 'otto.client_ip' => '203.0.113.0' }
+        middleware.call(env)
+
+        expect(env['otto.ip_match']).to be_nil
+      end
+    end
+
+    it 'raises for invalid CIDR entries (configuration error surfaces to the caller)' do
+      env = { 'REMOTE_ADDR' => '203.0.113.7' }
+      middleware.call(env)
+
+      expect { env['otto.ip_match'].call(['bogus']) }.to raise_error(IPAddr::InvalidAddressError)
+    end
+  end
+end

--- a/spec/otto/ip_precision_capability_spec.rb
+++ b/spec/otto/ip_precision_capability_spec.rb
@@ -52,6 +52,30 @@ RSpec.describe 'IP precision capability and privacy profiles' do
       expect(Otto::Utils.ip_in_cidrs?('2001:db8::1', ranges)).to be true
     end
 
+    it 'folds frozen pre-parsed entries without raising' do
+      # IPAddr#native builds its result with #clone, which carries frozen state
+      # over; a caller freezing their range config must not hit FrozenError.
+      frozen_mapped = IPAddr.new('::ffff:10.0.0.0/104').freeze
+      frozen_plain = IPAddr.new('10.0.0.0/8').freeze
+
+      expect(Otto::Utils.ip_in_cidrs?('10.1.2.3', [frozen_mapped])).to be true
+      expect(Otto::Utils.ip_in_cidrs?('11.1.2.3', [frozen_mapped])).to be false
+      expect(Otto::Utils.ip_in_cidrs?('10.1.2.3', [frozen_plain])).to be true
+    end
+
+    it 'needs /96 or longer for a mapped range to fold' do
+      # Masking at /64 zeroes the ffff marker, so the entry is no longer
+      # recognizable as mapped and stays IPv6 — matching neither form.
+      expect(Otto::Utils.ip_in_cidrs?('10.1.2.3', ['::ffff:10.0.0.0/64'])).to be false
+      expect(Otto::Utils.ip_in_cidrs?('::ffff:10.1.2.3', ['::ffff:10.0.0.0/64'])).to be false
+    end
+
+    it 'treats ::ffff:0:0/96 as the whole IPv4 space' do
+      expect(Otto::Utils.ip_in_cidrs?('10.1.2.3', ['::ffff:0:0/96'])).to be true
+      expect(Otto::Utils.ip_in_cidrs?('203.0.113.7', ['::ffff:0:0/96'])).to be true
+      expect(Otto::Utils.ip_in_cidrs?('2001:db8::1', ['::ffff:0:0/96'])).to be false
+    end
+
     it 'does not mutate pre-parsed IPAddr entries while folding' do
       mapped = IPAddr.new('::ffff:10.0.0.0/104')
       ranges = [mapped]
@@ -304,6 +328,7 @@ RSpec.describe 'IP precision capability and privacy profiles' do
       end
 
       it 'preserves the capability a prior middleware pass installed' do
+        allow(Otto.logger).to receive(:warn)
         env = { 'REMOTE_ADDR' => '203.0.113.7' }
         middleware.call(env)
         first = env['otto.ip_match']
@@ -312,6 +337,8 @@ RSpec.describe 'IP precision capability and privacy profiles' do
         middleware.call(env)
         expect(env['otto.ip_match']).to equal(first)
         expect(env['otto.ip_match'].call(['203.0.113.7/32'])).to be true
+        # The normal path must never reach the fail-closed repair branch.
+        expect(Otto.logger).not_to have_received(:warn)
       end
 
       it 'installs a fail-closed capability when otto.client_ip was set out-of-contract' do

--- a/spec/otto/ip_precision_capability_spec.rb
+++ b/spec/otto/ip_precision_capability_spec.rb
@@ -147,6 +147,28 @@ RSpec.describe 'IP precision capability and privacy profiles' do
         expect(config.profile).to eq(:masked)
       end
 
+      it 'round-trips through all three profiles' do
+        # :audit names only `disabled`, so it leaves mask_private_ips set from
+        # the :anonymous pass. :masked must re-set both knobs to land clean.
+        config = described_class.new
+        config.profile = :anonymous
+        config.profile = :audit
+        expect(config.profile).to eq(:audit)
+
+        config.profile = :masked
+        expect(config.enabled?).to be true
+        expect(config.mask_private_ips).to be false
+        expect(config.profile).to eq(:masked)
+      end
+
+      it 'raises ArgumentError, not NoMethodError, for a profile that cannot be a name' do
+        # Neither responds to #to_sym.
+        expect { described_class.new.profile = 123 }
+          .to raise_error(ArgumentError, /must be a Symbol or String, got: Integer/)
+        expect { described_class.new.profile = nil }
+          .to raise_error(ArgumentError, /must be a Symbol or String, got: NilClass/)
+      end
+
       it 'derives the profile from live knob state, never a stale label' do
         config = described_class.new
         config.profile = :masked
@@ -290,6 +312,63 @@ RSpec.describe 'IP precision capability and privacy profiles' do
         expect(env['otto.original_ip']).to be_nil
         expect(env['otto.ip_match'].call(['192.168.1.50/32'])).to be true
         expect(env['otto.ip_match'].call(['192.168.1.51/32'])).to be false
+      end
+    end
+
+    context 'debug logging' do
+      let(:lines) { [] }
+      let(:capturing_logger) do
+        Class.new do
+          def initialize(sink)
+            @sink = sink
+          end
+
+          def debug(message = nil)
+            @sink << (message || yield).to_s
+          end
+
+          def method_missing(_name, *_args) = nil
+
+          def respond_to_missing?(_name, _include_private = false) = true
+        end.new(lines)
+      end
+
+      # Otto.debug and Otto.logger are process globals; restore both so an
+      # enabled spec cannot bleed into the rest of the suite.
+      around do |example|
+        original_debug  = Otto.debug
+        original_logger = Otto.logger
+        Otto.debug  = true
+        Otto.logger = capturing_logger
+        example.run
+      ensure
+        Otto.debug  = original_debug
+        Otto.logger = original_logger
+      end
+
+      it 'never writes the unmasked address to the log on the masked path' do
+        env = { 'REMOTE_ADDR' => '203.0.113.7' }
+        middleware.call(env)
+
+        log = lines.join("\n")
+        expect(log).not_to be_empty
+        expect(log).not_to include('203.0.113.7')
+        expect(log).to include('203.0.113.0') # the masked value is still logged
+      end
+
+      it 'never writes the address to the log on the private-exempt path' do
+        env = { 'REMOTE_ADDR' => '192.168.1.50' }
+        middleware.call(env)
+
+        expect(lines.join("\n")).not_to include('192.168.1.50')
+      end
+
+      it 'still logs the resolved address under :audit, which keeps it in env by design' do
+        security_config.ip_privacy_config.profile = :audit
+        env = { 'REMOTE_ADDR' => '203.0.113.7' }
+        middleware.call(env)
+
+        expect(env['otto.client_ip']).to eq('203.0.113.7')
       end
     end
 

--- a/spec/otto/ip_precision_capability_spec.rb
+++ b/spec/otto/ip_precision_capability_spec.rb
@@ -114,6 +114,12 @@ RSpec.describe 'IP precision capability and privacy profiles' do
       expect do
         Otto::Utils.ip_in_cidrs?('203.0.113.7', ['not-a-cidr'])
       end.to raise_error(IPAddr::InvalidAddressError)
+      # An empty string is fail-closed false as the client IP (runtime data)
+      # but raises as a range entry — a blank line or trailing comma in a
+      # config file is a configuration error, not an empty allowlist.
+      expect do
+        Otto::Utils.ip_in_cidrs?('203.0.113.7', [''])
+      end.to raise_error(IPAddr::InvalidAddressError)
     end
   end
 
@@ -162,18 +168,21 @@ RSpec.describe 'IP precision capability and privacy profiles' do
       end
 
       it 'raises ArgumentError, not NoMethodError, for a profile that cannot be a name' do
-        # Neither Integer nor NilClass responds to #to_sym.
+        # None of Integer, NilClass, or FalseClass responds to #to_sym.
         expect { described_class.new.profile = 123 }
           .to raise_error(ArgumentError, /must be a Symbol or String, got: Integer/)
         expect { described_class.new.profile = nil }
           .to raise_error(ArgumentError, /must be a Symbol or String, got: NilClass/)
         expect { described_class.new(profile: 123) }
           .to raise_error(ArgumentError, /must be a Symbol or String, got: Integer/)
+        # false is not "no profile" — only nil means "leave unchanged".
+        expect { described_class.new(profile: false) }
+          .to raise_error(ArgumentError, /must be a Symbol or String, got: FalseClass/)
       end
 
       it 'treats profile: nil at construction as "leave unchanged", not an error' do
-        # The truthiness guard at the option site skips the preset entirely, so
-        # the nil never reaches profile_presets. Only the setter rejects nil.
+        # The nil guard at the option site skips the preset entirely, so the
+        # nil never reaches profile_presets. Only the setter rejects nil.
         expect(described_class.new(profile: nil).profile).to eq(:masked)
       end
 
@@ -193,6 +202,14 @@ RSpec.describe 'IP precision capability and privacy profiles' do
         config = described_class.new(profile: :anonymous, mask_private_ips: false)
         expect(config.mask_private_ips).to be false
         expect(config.enabled?).to be true
+      end
+
+      it 'accepts a String profile name wherever a Symbol is accepted' do
+        # env/YAML-driven configuration hands profiles over as Strings.
+        expect(described_class.new(profile: 'anonymous').profile).to eq(:anonymous)
+        config = described_class.new
+        config.profile = 'audit'
+        expect(config.profile).to eq(:audit)
       end
 
       it 'leaves non-profile knobs untouched when a profile is applied' do
@@ -218,10 +235,18 @@ RSpec.describe 'IP precision capability and privacy profiles' do
         expect(config.octet_precision).to eq(2)
       end
 
+      it 'accepts a String profile name' do
+        otto = Otto.new
+        otto.configure_ip_privacy(profile: 'audit')
+        expect(otto.security_config.ip_privacy_config.profile).to eq(:audit)
+      end
+
       it 'raises on a profile that cannot be a name' do
         otto = Otto.new
         expect { otto.configure_ip_privacy(profile: 123) }
           .to raise_error(ArgumentError, /must be a Symbol or String, got: Integer/)
+        expect { otto.configure_ip_privacy(profile: false) }
+          .to raise_error(ArgumentError, /must be a Symbol or String, got: FalseClass/)
         # Rejected before any other option is applied.
         expect(otto.security_config.ip_privacy_config.profile).to eq(:masked)
       end

--- a/spec/otto/ip_precision_capability_spec.rb
+++ b/spec/otto/ip_precision_capability_spec.rb
@@ -33,10 +33,37 @@ RSpec.describe 'IP precision capability and privacy profiles' do
       expect(Otto::Utils.ip_in_cidrs?('2001:db8::1', ['203.0.113.0/24'])).to be false
     end
 
+    it 'folds IPv4-mapped IPv6 ranges onto IPv4 clients (symmetric with the client fold)' do
+      expect(Otto::Utils.ip_in_cidrs?('10.1.2.3', ['::ffff:10.0.0.0/104'])).to be true
+      expect(Otto::Utils.ip_in_cidrs?('11.1.2.3', ['::ffff:10.0.0.0/104'])).to be false
+      # Host entry, and a mapped client against a mapped range.
+      expect(Otto::Utils.ip_in_cidrs?('203.0.113.7', ['::ffff:203.0.113.7/128'])).to be true
+      expect(Otto::Utils.ip_in_cidrs?('::ffff:10.1.2.3', ['::ffff:10.0.0.0/104'])).to be true
+    end
+
+    it 'leaves genuine IPv6 ranges unfolded' do
+      expect(Otto::Utils.ip_in_cidrs?('2001:db8::1', ['2001:db8::/32'])).to be true
+      expect(Otto::Utils.ip_in_cidrs?('10.1.2.3', ['2001:db8::/32'])).to be false
+    end
+
     it 'accepts pre-parsed IPAddr entries' do
       ranges = [IPAddr.new('203.0.113.0/24'), IPAddr.new('2001:db8::/32')]
       expect(Otto::Utils.ip_in_cidrs?('203.0.113.7', ranges)).to be true
       expect(Otto::Utils.ip_in_cidrs?('2001:db8::1', ranges)).to be true
+    end
+
+    it 'does not mutate pre-parsed IPAddr entries while folding' do
+      mapped = IPAddr.new('::ffff:10.0.0.0/104')
+      ranges = [mapped]
+
+      expect(Otto::Utils.ip_in_cidrs?('10.1.2.3', ranges)).to be true
+      expect(Otto::Utils.ip_in_cidrs?('10.1.2.3', ranges)).to be true
+
+      # The caller's configuration array is reusable across requests: still the
+      # same object, still IPv6, still mapped.
+      expect(ranges.first).to equal(mapped)
+      expect(mapped.family).to eq(Socket::AF_INET6)
+      expect(mapped.ipv4_mapped?).to be true
     end
 
     it 'accepts an IPAddr as the client address' do
@@ -215,6 +242,46 @@ RSpec.describe 'IP precision capability and privacy profiles' do
         expect(env['otto.client_ip']).to eq('203.0.113.7')
         expect(env['otto.ip_match'].call(['203.0.113.7/32'])).to be true
       end
+
+      it 'fails closed with no resolvable client IP, same as the privacy-enabled path' do
+        security_config.ip_privacy_config.profile = :audit
+        env = {}
+        middleware.call(env)
+
+        expect(env['otto.ip_match']).to be_a(Proc)
+        expect(env['otto.ip_match'].call(['0.0.0.0/0', '::/0'])).to be false
+        expect(env['REMOTE_ADDR']).to be_nil
+        expect(env['otto.original_ip']).to be_nil
+      end
+    end
+
+    context ':anonymous profile' do
+      it 'masks private IPs that the default profile exempts, without losing precision' do
+        security_config.ip_privacy_config.profile = :anonymous
+        env = { 'REMOTE_ADDR' => '192.168.1.50' }
+        middleware.call(env)
+
+        expect(env['otto.client_ip']).to eq('192.168.1.0')
+        expect(env['REMOTE_ADDR']).to eq('192.168.1.0')
+        expect(env['otto.original_ip']).to be_nil
+        expect(env['otto.ip_match'].call(['192.168.1.50/32'])).to be true
+        expect(env['otto.ip_match'].call(['192.168.1.51/32'])).to be false
+      end
+    end
+
+    context 'profile configured after the middleware stack is built' do
+      it 'honors a profile change made before the first request' do
+        # Otto builds its stack at the end of Otto.new, but configuration stays
+        # legal until the first request. A privacy flag cached at construction
+        # would keep masking here.
+        otto = Otto.new
+        otto.configure_ip_privacy(profile: :audit)
+        env = Rack::MockRequest.env_for('/', 'REMOTE_ADDR' => '203.0.113.7')
+        otto.call(env)
+
+        expect(env['otto.client_ip']).to eq('203.0.113.7')
+        expect(env['REMOTE_ADDR']).to eq('203.0.113.7')
+      end
     end
 
     context 'no resolvable client IP' do
@@ -228,11 +295,37 @@ RSpec.describe 'IP precision capability and privacy profiles' do
     end
 
     context 'idempotency guard' do
-      it 'does not install a second capability when otto.client_ip is pre-set' do
+      it 'does not re-resolve or re-mask when a prior pass already set otto.client_ip' do
         env = { 'REMOTE_ADDR' => '203.0.113.7', 'otto.client_ip' => '203.0.113.0' }
         middleware.call(env)
 
-        expect(env['otto.ip_match']).to be_nil
+        expect(env['REMOTE_ADDR']).to eq('203.0.113.7')
+        expect(env['otto.client_ip']).to eq('203.0.113.0')
+      end
+
+      it 'preserves the capability a prior middleware pass installed' do
+        env = { 'REMOTE_ADDR' => '203.0.113.7' }
+        middleware.call(env)
+        first = env['otto.ip_match']
+
+        # Second pass through a stacked instance: same closure, still precise.
+        middleware.call(env)
+        expect(env['otto.ip_match']).to equal(first)
+        expect(env['otto.ip_match'].call(['203.0.113.7/32'])).to be true
+      end
+
+      it 'installs a fail-closed capability when otto.client_ip was set out-of-contract' do
+        # An app or harness set otto.client_ip itself, so the unmasked address
+        # is unavailable. Deny rather than match against a possibly-masked
+        # value, which would produce false allows on narrow CIDRs.
+        allow(Otto.logger).to receive(:warn)
+        env = { 'REMOTE_ADDR' => '203.0.113.7', 'otto.client_ip' => '203.0.113.7' }
+        middleware.call(env)
+
+        expect(env['otto.ip_match']).to be_a(Proc)
+        expect(env['otto.ip_match'].call(['203.0.113.7/32'])).to be false
+        expect(env['otto.ip_match'].call(['0.0.0.0/0', '::/0'])).to be false
+        expect(Otto.logger).to have_received(:warn).with(/otto.client_ip was set outside/)
       end
     end
 

--- a/spec/otto/ip_precision_capability_spec.rb
+++ b/spec/otto/ip_precision_capability_spec.rb
@@ -256,6 +256,17 @@ RSpec.describe 'IP precision capability and privacy profiles' do
         expect { otto.configure_ip_privacy(profile: :bogus) }
           .to raise_error(ArgumentError, /Unknown privacy profile/)
       end
+
+      it 'is all-or-nothing: a knob rejected by validate! leaves the profile preset unapplied' do
+        otto = Otto.new
+        expect { otto.configure_ip_privacy(profile: :anonymous, octet_precision: 7) }
+          .to raise_error(ArgumentError, /octet_precision/)
+
+        config = otto.security_config.ip_privacy_config
+        expect(config.profile).to eq(:masked)
+        expect(config.mask_private_ips).to be(false)
+        expect(config.octet_precision).to eq(1)
+      end
     end
   end
 

--- a/spec/otto/ip_privacy_spec.rb
+++ b/spec/otto/ip_privacy_spec.rb
@@ -2477,4 +2477,33 @@ RSpec.describe 'IP Privacy Features' do
         .to raise_error(ArgumentError, /correlation_secret must be a String or nil/)
     end
   end
+
+  describe 'Otto#configure_ip_privacy knob guards (nil means "leave unchanged")' do
+    it 'rejects octet_precision: false instead of silently dropping it' do
+      otto = create_minimal_otto(['GET / TestApp.index'])
+
+      expect { otto.configure_ip_privacy(octet_precision: false) }
+        .to raise_error(ArgumentError, /octet_precision must be 1 or 2, got: false/)
+    end
+
+    it 'rejects hash_rotation: false with ArgumentError, not NoMethodError' do
+      otto = create_minimal_otto(['GET / TestApp.index'])
+
+      expect { otto.configure_ip_privacy(hash_rotation: false) }
+        .to raise_error(ArgumentError, /hash_rotation_period must be at least 60 seconds, got: false/)
+    end
+
+    it 'rejects a hash_rotation below the 60-second floor' do
+      otto = create_minimal_otto(['GET / TestApp.index'])
+
+      expect { otto.configure_ip_privacy(hash_rotation: 30) }
+        .to raise_error(ArgumentError, /hash_rotation_period must be at least 60 seconds, got: 30/)
+    end
+
+    it 'accepts redis: false as "no connection" (falsy, so equivalent to unset)' do
+      otto = create_minimal_otto(['GET / TestApp.index'])
+
+      expect { otto.configure_ip_privacy(redis: false) }.not_to raise_error
+    end
+  end
 end

--- a/spec/security_config_spec.rb
+++ b/spec/security_config_spec.rb
@@ -319,6 +319,17 @@ RSpec.describe Otto::Security::Config do
         config.add_trusted_proxy('10.0.0.0/8')
         expect(config.trusted_proxy?('::1')).to be false
       end
+
+      it 'matches a plain IPv4 peer against an IPv4-mapped IPv6 proxy entry' do
+        # The client address is folded via IPAddr#native, so the entry must be
+        # folded too — otherwise the family check silently untrusts the proxy,
+        # which gates otto.via_trusted_proxy, secure?, and geo-header trust.
+        # /112 in mapped space is a /16 of IPv4.
+        config.add_trusted_proxy('::ffff:172.16.0.0/112')
+        expect(config.trusted_proxy?('172.16.0.1')).to be true
+        expect(config.trusted_proxy?('::ffff:172.16.0.1')).to be true
+        expect(config.trusted_proxy?('172.17.0.1')).to be false
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

- Install `env['otto.ip_match']` — a verdict-only CIDR membership check (a Proc) over the resolved, **unmasked** client IP, on every resolution path (masked, private-exempt, and privacy-disabled). Downstream policy code (allowlists, denylists, network isolation) gets full /32–/128 precision under any privacy profile, while the raw IP never lands in env — a Proc serializes to nothing useful, so env dumps and loggers can't leak it.
- Add `Otto::Utils.ip_in_cidrs?`, the general-purpose CIDR-set matcher backing the capability: normalizes the client address, folds IPv4-mapped IPv6 via `IPAddr#native`, fails closed on malformed runtime input, and raises on invalid configured CIDR entries.
- Add named privacy profiles `:anonymous`, `:masked`, `:audit` as validated presets over `disabled`/`mask_private_ips`, settable via `configure_ip_privacy(profile:)` or `config.profile=`. `config.profile` is derived from live knob state, so the label can never go stale.

The two axes are deliberately decoupled: profiles control what *persists observably* (env keys, logs, fingerprints); `otto.ip_match` provides *ephemeral precision matching* in every profile, so precise IP policy no longer requires `:audit`.

Enables the fix for onetimesecret/onetimesecret#3912, where AdminNetworkIsolation matched allowlist CIDRs against the already-masked `otto.client_ip`, breaking /25+ IPv4 and /49+ IPv6 rules and IPv4-mapped IPv6 matching.

## Test plan

- New spec `spec/otto/ip_precision_capability_spec.rb` covers the capability across profiles, fail-closed behavior, invalid-CIDR raising, and IPv4-mapped IPv6 matching.