### PR TITLE
[#219] Run IPPrivacyMiddleware outermost so all middleware sees masked IPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ end
 2. Registers your callback, invoked once per violation with an
    `Otto::Security::CSP::Report`.
 3. Injects `Otto::Security::CSP::ReportMiddleware`, pinned **outermost** in the
-   stack, which intercepts `POST`s to the report path, parses both the legacy
+   stack (only IP masking runs ahead of it), which intercepts `POST`s to the
+   report path, parses both the legacy
    `application/csp-report` and the Reporting API `application/reports+json`
    formats, enforces a 64 KiB body cap, and always answers `204 No Content` —
    without touching your routes.

--- a/changelog.d/20260730_ipprivacy_middleware_order.rst
+++ b/changelog.d/20260730_ipprivacy_middleware_order.rst
@@ -1,0 +1,48 @@
+Added
+-----
+
+- ``MiddlewareStack#execution_order`` returns middleware classes in the order
+  they actually run (outermost first), resolving pin tiers — unlike
+  ``#middleware_list``, which reports registration order. (#219)
+
+- ``add_with_position`` accepts ``position: :innermost`` as a clearer synonym
+  for ``:first``, and a new ``position: :entrypoint`` tier that pins middleware
+  outside even ``:outermost`` entries. (#219)
+
+Security
+--------
+
+- IP masking now applies to the whole middleware stack, not just the
+  application. ``IPPrivacyMiddleware`` was registered ``position: :first``,
+  which is first-in-*array* and therefore **innermost**, so every other
+  middleware Otto mounts — plus anything added via ``Otto#use`` — received the
+  raw ``REMOTE_ADDR``, an un-anonymized User-Agent, and a nil
+  ``env['otto.client_ip']``. It is now pinned outermost and runs before
+  everything else. (#219)
+
+- Rate-limit logging no longer writes raw client IPs. The ``rack.attack``
+  subscribers in ``Otto::Security::RateLimiting`` and ``Otto::MCP::RateLimiter``
+  interpolated ``req.ip`` into a ``warn``-level line on every blocked request,
+  so deployments on the default masked profile leaked public IPs to their logs.
+  Both now log a masked address. Rack::Attack is mounted outside Otto, so this
+  is independent of middleware ordering. (#219)
+
+Changed
+-------
+
+- ``Otto::LoggingHelpers.request_context`` masks its ``:ip`` field when the
+  request never passed through ``IPPrivacyMiddleware`` (previously it fell back
+  to the raw ``REMOTE_ADDR``). New ``LoggingHelpers.privacy_safe_ip`` exposes
+  that behavior for callers outside Otto's stack. (#219)
+
+- ``Otto::CaddyTLS::LocalhostGuard`` reads the new leak-free boolean
+  ``env['otto.peer_loopback']`` — the loopback verdict ``IPPrivacyMiddleware``
+  records on the untouched socket peer before masking — falling back to
+  ``REMOTE_ADDR`` when absent. The guard still authenticates the raw peer,
+  which it can no longer read directly now that IP masking runs first. (#219)
+
+AI Assistance
+-------------
+
+- Middleware ordering audit, raw-peer record design, and regression coverage
+  developed with AI assistance. (#219)

--- a/changelog.d/20260730_ipprivacy_middleware_order.rst
+++ b/changelog.d/20260730_ipprivacy_middleware_order.rst
@@ -30,6 +30,11 @@ Security
 Changed
 -------
 
+- Middleware pins are now recorded per *entry* rather than per class. A
+  ``:outermost`` pin previously reordered every registration of that class,
+  including ones registered separately with different arguments; each
+  registration now carries its own tier. (#219)
+
 - ``Otto::LoggingHelpers.request_context`` masks its ``:ip`` field when the
   request never passed through ``IPPrivacyMiddleware`` (previously it fell back
   to the raw ``REMOTE_ADDR``). New ``LoggingHelpers.privacy_safe_ip`` exposes

--- a/docs/reverse-proxy-network-services.md
+++ b/docs/reverse-proxy-network-services.md
@@ -177,12 +177,25 @@ deny). Everything fails closed.
 This is the load-bearing decision, and it corrects the obvious-but-wrong first
 instinct (which every initial design in the panel made).
 
-`Otto::CaddyTLS::LocalhostGuard` reads the **original `env['REMOTE_ADDR']`** — the
-TCP socket peer — and runs **before** `IPPrivacyMiddleware` rewrites `REMOTE_ADDR`
-from forwarded headers. Because the guard is installed via `Otto#use` (appended,
-therefore *outermost* in Otto's `reduce`-built stack) and `IPPrivacyMiddleware` is
-pinned *innermost*, the guard provably inspects the true socket peer regardless of
-when `enable_caddy_tls!` is called.
+`Otto::CaddyTLS::LocalhostGuard` authenticates the **original TCP socket peer**,
+never the address left in `REMOTE_ADDR` after `IPPrivacyMiddleware` rewrites it
+from forwarded headers.
+
+Otto originally guaranteed that by ordering: the guard is installed via `Otto#use`
+(appended, therefore *outermost* in Otto's `reduce`-built stack) and
+`IPPrivacyMiddleware` was pinned *innermost*, so the guard ran first and read a
+pristine `REMOTE_ADDR`. Issue #219 inverted that: masking innermost meant every
+*other* middleware saw raw IPs, so `IPPrivacyMiddleware` is now pinned **outermost**
+(the `:entrypoint` tier) and runs *ahead* of the guard.
+
+The guarantee is preserved by a record rather than by order.
+`IPPrivacyMiddleware` evaluates the untouched peer before masking and stores the
+verdict as `env['otto.peer_loopback']` — a boolean, never an address, so it leaks
+nothing. The guard reads that record when present and evaluates `REMOTE_ADDR`
+itself when it is not (guard mounted outside Otto, or no privacy middleware in the
+stack). Both paths share `Otto::Utils.loopback_address?`, so they cannot drift, and
+the decision is made on the raw peer either way — regardless of when
+`enable_caddy_tls!` is called.
 
 Reading Otto's resolved `otto.client_ip` (or the rewritten `REMOTE_ADDR`) would be
 **exploitable**: `Otto::Utils.resolve_client_ip` honors `X-Forwarded-For` when the

--- a/lib/otto.rb
+++ b/lib/otto.rb
@@ -226,11 +226,19 @@ class Otto
     # before first request (before configuration freezing)
     finalize_request_response_classes
 
-    # Add IP Privacy middleware first in stack (privacy by default for public IPs)
-    # Private/localhost IPs are automatically exempted from masking
+    # IP Privacy is the ENTRY POINT of the stack: the first middleware to touch
+    # a request, so everything else — Otto's own middleware, an :outermost pin,
+    # and anything the app adds via Otto#use — observes the masked REMOTE_ADDR
+    # and the canonical env['otto.client_ip'] (privacy by default for public
+    # IPs; private/localhost IPs are automatically exempted from masking).
+    #
+    # NOT position: :first, which is first-in-ARRAY and therefore INNERMOST —
+    # it put IP masking closest to the app and left every other middleware
+    # reading the raw peer address (issue #219). See
+    # MiddlewareStack#add_with_position for the full position vocabulary.
     @middleware.add_with_position(
       Otto::Security::Middleware::IPPrivacyMiddleware,
-      position: :first
+      position: :entrypoint
     )
   end
 

--- a/lib/otto/caddy_tls/localhost_guard.rb
+++ b/lib/otto/caddy_tls/localhost_guard.rb
@@ -2,8 +2,6 @@
 #
 # frozen_string_literal: true
 
-require 'ipaddr'
-
 require_relative '../utils'
 
 class Otto
@@ -22,11 +20,15 @@ class Otto
     #
     # == Security: authenticate the RAW peer, not the resolved client IP
     #
-    # The guard reads the ORIGINAL +env['REMOTE_ADDR']+ — the TCP socket peer —
-    # and MUST run before +IPPrivacyMiddleware+ rewrites +REMOTE_ADDR+ from
-    # forwarded headers. Installed via +Otto#use+ (appended, hence outermost in
-    # the reduce-built stack) it always executes ahead of +IPPrivacyMiddleware+
-    # (which is pinned innermost), so it inspects the true socket peer.
+    # The guard authenticates the TCP socket peer as it arrived, before
+    # +IPPrivacyMiddleware+ rewrites +REMOTE_ADDR+ from forwarded headers.
+    # +IPPrivacyMiddleware+ is pinned OUTERMOST (issue #219), so it runs ahead
+    # of this guard and records its verdict on the untouched peer as
+    # +env['otto.peer_loopback']+ — a boolean, never an address. The guard reads
+    # that record when present and falls back to evaluating +REMOTE_ADDR+
+    # itself when it is not (no Otto privacy middleware in the stack, or the
+    # guard mounted outside Otto). Either way the decision is made on the raw
+    # peer.
     #
     # Reading Otto's resolved +otto.client_ip+ (or the rewritten +REMOTE_ADDR+)
     # would be exploitable: a co-located reverse proxy on loopback is itself a
@@ -92,7 +94,7 @@ class Otto
       # @param env [Hash] Rack environment
       # @return [Boolean]
       def direct_local_call?(env)
-        loopback_peer?(env['REMOTE_ADDR']) && !relayed?(env)
+        loopback_peer?(env) && !relayed?(env)
       end
 
       # Whether any forwarding header is present (request came via a proxy).
@@ -125,28 +127,27 @@ class Otto
         Otto::Utils.normalize_path(path)
       end
 
-      # Whether the connecting peer is a loopback address. Fails closed: a
-      # blank or otherwise unparseable value is treated as non-loopback
-      # (denied) rather than raising on the hot path.
+      # Whether the connecting peer is a loopback address.
       #
-      # +.native+ folds IPv4-mapped IPv6 (+::ffff:127.0.0.1+, which dual-stack
-      # servers commonly present) so it is correctly recognized as loopback;
-      # plain +IPAddr#loopback?+ returns false for the mapped form.
+      # Prefers +env['otto.peer_loopback']+ — IPPrivacyMiddleware's verdict on
+      # the ORIGINAL peer, recorded before it rewrites +REMOTE_ADDR+ (it runs
+      # outermost, so by the time this guard sees the env the address may
+      # already be the resolved-and-masked client IP). Only a real Boolean is
+      # honored; anything else falls through to evaluating +REMOTE_ADDR+, which
+      # is the correct source when no privacy middleware ran.
       #
-      # A conforming Rack server sets +REMOTE_ADDR+ to a bare IP (the peer's
-      # port lives in +REMOTE_PORT+). We deliberately do NOT strip a +:port+
-      # suffix here: an unexpected format is a signal something upstream is
-      # non-standard, so denying (fail-closed) is safer than coercing it.
+      # Both paths share +Otto::Utils.loopback_address?+, so the recorded
+      # verdict and the fallback cannot disagree. It fails closed: a blank,
+      # ported, or unparseable value is treated as non-loopback (denied) rather
+      # than raising on the hot path.
       #
-      # @param remote_addr [String, nil] the raw socket peer address
+      # @param env [Hash] Rack environment
       # @return [Boolean]
-      def loopback_peer?(remote_addr)
-        addr = remote_addr.to_s.strip
-        return false if addr.empty?
+      def loopback_peer?(env)
+        recorded = env['otto.peer_loopback']
+        return recorded if [true, false].include?(recorded)
 
-        IPAddr.new(addr).native.loopback?
-      rescue IPAddr::InvalidAddressError, IPAddr::AddressFamilyError
-        false
+        Otto::Utils.loopback_address?(env['REMOTE_ADDR'])
       end
 
       # @return [Array] 401 Rack response tuple

--- a/lib/otto/caddy_tls/localhost_guard.rb
+++ b/lib/otto/caddy_tls/localhost_guard.rb
@@ -99,6 +99,23 @@ class Otto
 
       # Whether any forwarding header is present (request came via a proxy).
       #
+      # Unlike the peer check, this reads header STATE, which IPPrivacyMiddleware
+      # has already touched by the time the guard runs. That is safe in both of
+      # its paths, but only for a reason worth writing down:
+      #
+      # - Masking REWRITES a forwarded header to the masked IP rather than
+      #   removing it, so a relayed request still looks relayed. Correct — it was.
+      # - The no-resolvable-client-IP path DELETES them, which would make a
+      #   relayed request look direct. That path is reached only when REMOTE_ADDR
+      #   is absent or blank, which forces otto.peer_loopback to false, so
+      #   #direct_local_call? denies on the peer check before this one matters.
+      #
+      # So header deletion upstream cannot turn a deny into an allow — but that
+      # rests on the peer check failing closed for a blank address. Anything that
+      # makes an unresolvable-IP request keep a loopback peer verdict would need
+      # to record the relay state pre-scrub too (an otto.peer_relayed sibling to
+      # otto.peer_loopback).
+      #
       # @param env [Hash] Rack environment
       # @return [Boolean]
       def relayed?(env)

--- a/lib/otto/core/middleware_stack.rb
+++ b/lib/otto/core/middleware_stack.rb
@@ -13,12 +13,21 @@ class Otto
       include Enumerable
       include Otto::Core::Freezable
 
+      # Pin tiers honored by #ordered_stack, outward-ascending. #wrap folds the
+      # stack with reduce, so a LATER array position is a FURTHER OUT wrapper;
+      # sorting by tier therefore sorts by how early the middleware sees the
+      # request. Unpinned entries are tier 0 and keep their insertion order.
+      PIN_TIERS = {
+         outermost: 1,
+        entrypoint: 2,
+      }.freeze
+
       def initialize
         @stack = []
         @middleware_set = Set.new
-        # Classes pinned to run OUTERMOST regardless of insertion order (see
-        # the :outermost position in #add_with_position and #ordered_stack).
-        @outermost = Set.new
+        # middleware_class => pin tier (see PIN_TIERS). Pinned classes are
+        # sorted outward at build time, regardless of insertion order.
+        @pins = {}
         @on_change_callback = nil
       end
 
@@ -52,8 +61,15 @@ class Otto
 
       # Add middleware with position hint for optimal ordering
       #
-      # Positions:
-      # - :first     — innermost (runs last, closest to the app)
+      # Positions name a place in the ARRAY; #wrap folds the array with reduce,
+      # so array order is the REVERSE of execution order — the last entry is the
+      # outermost wrapper and therefore the first to see a request.
+      #
+      # - :first/:innermost — innermost: the LAST middleware to see the request,
+      #                closest to the app. Note the trap in the older `:first`
+      #                spelling: it is first-in-array, hence last-to-execute.
+      #                `:innermost` says the same thing in execution terms and is
+      #                the preferred spelling.
       # - :last/nil  — append (outermost among currently-registered middleware,
       #                but a later append displaces it)
       # - :outermost — pin to run OUTERMOST (first to see the request) and STAY
@@ -62,10 +78,18 @@ class Otto
       #                at build time. Use for middleware that must short-circuit
       #                ahead of everything else (e.g. the CSP report receiver,
       #                which must intercept before CSRF).
+      # - :entrypoint — pin OUTSIDE even the :outermost tier: the very first
+      #                middleware to touch a request. Reserved for middleware
+      #                that must normalize the request before anything else can
+      #                observe it. Otto pins IPPrivacyMiddleware here so every
+      #                other middleware — its own, an :outermost pin, and
+      #                anything the app adds via Otto#use — reads a masked
+      #                REMOTE_ADDR and the canonical env['otto.client_ip'].
       #
       # @param middleware_class [Class] Middleware class
       # @param args [Array] Middleware arguments
-      # @param position [Symbol, nil] Position hint (:first, :last, :outermost, or nil)
+      # @param position [Symbol, nil] Position hint (:first, :innermost, :last,
+      #   :outermost, :entrypoint, or nil)
       def add_with_position(middleware_class, *args, position: nil, **options)
         raise FrozenError, 'Cannot modify frozen middleware stack' if frozen?
 
@@ -81,11 +105,11 @@ class Otto
         entry = { middleware: middleware_class, args: args, options: options }
 
         case position
-        when :first
+        when :first, :innermost
           @stack.unshift(entry)
-        when :outermost
+        when *PIN_TIERS.keys
           @stack << entry
-          @outermost.add(middleware_class)
+          @pins[middleware_class] = PIN_TIERS.fetch(position)
         else
           @stack << entry # :last / nil — default append
         end
@@ -162,7 +186,7 @@ class Otto
 
         # Rebuild the set of unique middleware classes
         @middleware_set = Set.new(@stack.map { |entry| entry[:middleware] })
-        @outermost.delete(middleware_class)
+        @pins.delete(middleware_class)
         # Notify of change
         @on_change_callback&.call
       end
@@ -179,7 +203,7 @@ class Otto
 
         @stack.clear
         @middleware_set.clear
-        @outermost.clear
+        @pins.clear
         # Notify of change
         @on_change_callback&.call
       end
@@ -192,9 +216,9 @@ class Otto
       # Build Rack application with middleware chain
       #
       # The stack folds via reduce, so the LAST entry becomes the OUTERMOST
-      # wrapper (first to see the request). #ordered_stack moves any :outermost-
-      # pinned middleware to the end so it stays outermost regardless of the
-      # order middleware was registered in.
+      # wrapper (first to see the request). #ordered_stack moves any pinned
+      # middleware (:outermost, :entrypoint) to the end so it stays outermost
+      # regardless of the order middleware was registered in.
       def wrap(base_app, security_config = nil)
         ordered_stack.reduce(base_app) do |app, entry|
           middleware = entry[:middleware]
@@ -215,9 +239,21 @@ class Otto
         end
       end
 
-      # Returns list of middleware classes in order
+      # Returns list of middleware classes in REGISTRATION order — the order
+      # they were added, which is the reverse of execution order and ignores pin
+      # tiers. Use #execution_order to see what actually runs first.
       def middleware_list
         @stack.map { |entry| entry[:middleware] }
+      end
+
+      # Returns middleware classes in EXECUTION order: the first entry is the
+      # outermost wrapper #wrap builds, i.e. the first to see a request. This is
+      # #middleware_list resolved through the pin tiers and reversed, so it
+      # answers "what does this stack actually do?" without building the app.
+      #
+      # @return [Array<Class>] outermost (first to execute) first
+      def execution_order
+        ordered_stack.reverse.map { |entry| entry[:middleware] }
       end
 
       # Detailed introspection
@@ -255,15 +291,17 @@ class Otto
       private
 
       # The stack ordered for #wrap: identical to @stack unless some middleware
-      # is pinned :outermost, in which case pinned entries are moved to the end
-      # (outermost) while preserving the relative order of both groups. Returns
-      # @stack itself (no copy) in the common no-pin case, so ordinary apps are
-      # completely unaffected.
+      # is pinned, in which case entries are sorted by pin tier (PIN_TIERS,
+      # outward-ascending) so pinned entries move to the end (outermost) while
+      # the relative order within every tier is preserved. Ruby's sort_by is not
+      # stable, hence the explicit index tiebreak. Returns @stack itself (no
+      # copy) in the common no-pin case, so ordinary apps are unaffected.
       def ordered_stack
-        return @stack if @outermost.empty?
+        return @stack if @pins.empty?
 
-        pinned, rest = @stack.partition { |entry| @outermost.include?(entry[:middleware]) }
-        rest + pinned
+        @stack.each_with_index
+              .sort_by { |entry, index| [@pins.fetch(entry[:middleware], 0), index] }
+              .map(&:first)
       end
 
       def middleware_needs_config?(middleware_class)

--- a/lib/otto/core/middleware_stack.rb
+++ b/lib/otto/core/middleware_stack.rb
@@ -220,6 +220,12 @@ class Otto
       # wrapper (first to see the request). #ordered_stack moves any pinned
       # middleware (:outermost, :entrypoint) to the end so it stays outermost
       # regardless of the order middleware was registered in.
+      #
+      # NOT a request-path method. Its only caller is Otto's build_app!, which
+      # runs at construction and again whenever the stack changes; requests are
+      # served by the chain it returns. So the ordering work here (and in
+      # #ordered_stack) is per-BUILD, not per-request — don't add caching
+      # machinery on the assumption that it is hot.
       def wrap(base_app, security_config = nil)
         ordered_stack.reduce(base_app) do |app, entry|
           middleware = entry[:middleware]
@@ -297,6 +303,8 @@ class Otto
       # the relative order within every tier is preserved. Ruby's sort_by is not
       # stable, hence the explicit index tiebreak. Returns @stack itself (no
       # copy) in the common no-pin case, so ordinary apps are unaffected.
+      #
+      # Runs per build, not per request — see #wrap.
       def ordered_stack
         return @stack if @stack.none? { |entry| entry[:pin_tier] }
 

--- a/lib/otto/core/middleware_stack.rb
+++ b/lib/otto/core/middleware_stack.rb
@@ -17,6 +17,12 @@ class Otto
       # stack with reduce, so a LATER array position is a FURTHER OUT wrapper;
       # sorting by tier therefore sorts by how early the middleware sees the
       # request. Unpinned entries are tier 0 and keep their insertion order.
+      #
+      # A tier is recorded on the ENTRY (as entry[:pin_tier]), not on the
+      # middleware class. Entries are identified by (class, args, options), so
+      # the same class can legitimately be registered more than once with
+      # different configuration; a class-wide pin would drag those other
+      # registrations into the pinned tier along with it.
       PIN_TIERS = {
          outermost: 1,
         entrypoint: 2,
@@ -25,9 +31,6 @@ class Otto
       def initialize
         @stack = []
         @middleware_set = Set.new
-        # middleware_class => pin tier (see PIN_TIERS). Pinned classes are
-        # sorted outward at build time, regardless of insertion order.
-        @pins = {}
         @on_change_callback = nil
       end
 
@@ -108,8 +111,7 @@ class Otto
         when :first, :innermost
           @stack.unshift(entry)
         when *PIN_TIERS.keys
-          @stack << entry
-          @pins[middleware_class] = PIN_TIERS.fetch(position)
+          @stack << entry.merge(pin_tier: PIN_TIERS.fetch(position))
         else
           @stack << entry # :last / nil — default append
         end
@@ -184,9 +186,9 @@ class Otto
         # Update middleware set if any matching entries were found
         return unless matches
 
-        # Rebuild the set of unique middleware classes
+        # Rebuild the set of unique middleware classes. Pins need no cleanup:
+        # each removed entry took its own tier with it.
         @middleware_set = Set.new(@stack.map { |entry| entry[:middleware] })
-        @pins.delete(middleware_class)
         # Notify of change
         @on_change_callback&.call
       end
@@ -203,7 +205,6 @@ class Otto
 
         @stack.clear
         @middleware_set.clear
-        @pins.clear
         # Notify of change
         @on_change_callback&.call
       end
@@ -290,17 +291,17 @@ class Otto
 
       private
 
-      # The stack ordered for #wrap: identical to @stack unless some middleware
-      # is pinned, in which case entries are sorted by pin tier (PIN_TIERS,
+      # The stack ordered for #wrap: identical to @stack unless some entry is
+      # pinned, in which case entries are sorted by pin tier (PIN_TIERS,
       # outward-ascending) so pinned entries move to the end (outermost) while
       # the relative order within every tier is preserved. Ruby's sort_by is not
       # stable, hence the explicit index tiebreak. Returns @stack itself (no
       # copy) in the common no-pin case, so ordinary apps are unaffected.
       def ordered_stack
-        return @stack if @pins.empty?
+        return @stack if @stack.none? { |entry| entry[:pin_tier] }
 
         @stack.each_with_index
-              .sort_by { |entry, index| [@pins.fetch(entry[:middleware], 0), index] }
+              .sort_by { |entry, index| [entry[:pin_tier] || 0, index] }
               .map(&:first)
       end
 

--- a/lib/otto/env_keys.rb
+++ b/lib/otto/env_keys.rb
@@ -82,6 +82,17 @@ class Otto
     #   without depending on the (masked) REMOTE_ADDR
     VIA_TRUSTED_PROXY = 'otto.via_trusted_proxy'
 
+    # Whether the connecting peer was the loopback interface.
+    # Type: Boolean
+    # Set by: IPPrivacyMiddleware (every request, evaluated on the ORIGINAL
+    #   socket peer BEFORE REMOTE_ADDR is masked/rewritten). A boolean, never
+    #   an address, so it carries no identifying data.
+    # Used by: Otto::CaddyTLS::LocalhostGuard to authenticate a direct local
+    #   call now that IPPrivacyMiddleware runs outermost. Deliberately the raw
+    #   peer, not the resolved client IP: forwarded headers must play no part
+    #   in a localhost trust decision.
+    PEER_LOOPBACK = 'otto.peer_loopback'
+
     # =========================================================================
     # LOCALIZATION (I18N)
     # =========================================================================

--- a/lib/otto/logging_helpers.rb
+++ b/lib/otto/logging_helpers.rb
@@ -76,10 +76,59 @@ class Otto
       {
             method: env['REQUEST_METHOD'],
               path: env['PATH_INFO'],
-                ip: env['otto.client_ip'] || env['REMOTE_ADDR'], # Canonical client IP (masked when privacy on)
+                ip: privacy_safe_ip(env), # Canonical client IP (masked when privacy on)
            country: env['otto.privacy.geo_country'],
         user_agent: env['HTTP_USER_AGENT']&.slice(0, 100), # Already anonymized by IPPrivacyMiddleware
       }.compact
+    end
+
+    # A client IP that is safe to write to a log.
+    #
+    # Prefers the canonical env['otto.client_ip'] that IPPrivacyMiddleware
+    # resolves once per request: masked when privacy is on, and deliberately
+    # the real address when the app has disabled privacy. That key is present
+    # for anything running inside Otto, since the middleware is pinned
+    # outermost.
+    #
+    # It is ABSENT for code that runs outside Otto's stack — notably
+    # Rack::Attack, which the hosting app mounts ahead of Otto (see
+    # Otto::Security::Middleware::RateLimitMiddleware), so its 'rack.attack'
+    # subscriber observes the raw peer no matter how Otto orders its own
+    # middleware. There we mask the address ourselves rather than log it whole:
+    # a public IP is reduced with the default precision (privacy config is not
+    # reachable from a global subscriber), and private/localhost addresses pass
+    # through unmasked, matching the middleware's own exemption so development
+    # logs stay readable.
+    #
+    # Never raises and never returns a raw public address: an unparseable value
+    # (a ported REMOTE_ADDR, a malformed forwarded entry) becomes '[redacted]'.
+    #
+    # @param env [Hash] Rack environment hash
+    # @param fallback_ip [String, nil] address to fall back to when the env
+    #   carries no canonical client IP — e.g. Rack::Request#ip, which factors in
+    #   forwarded headers. Defaults to REMOTE_ADDR.
+    # @return [String, nil] log-safe address, or nil when there is none
+    def self.privacy_safe_ip(env, fallback_ip = nil)
+      canonical = env['otto.client_ip']
+      return canonical unless canonical.to_s.empty?
+
+      candidate = fallback_ip.to_s.empty? ? env['REMOTE_ADDR'] : fallback_ip
+      redact_ip(candidate)
+    end
+
+    # Reduce a raw address to a log-safe form. See .privacy_safe_ip.
+    #
+    # @param ip [String, nil] raw address
+    # @return [String, nil] masked address, the address itself when
+    #   private/localhost, '[redacted]' when unparseable, nil when blank
+    def self.redact_ip(ip)
+      address = ip.to_s.strip
+      return nil if address.empty?
+      return address if Otto::Privacy::IPPrivacy.private_or_localhost?(address)
+
+      Otto::Privacy::IPPrivacy.mask_ip(address) || '[redacted]'
+    rescue ArgumentError
+      '[redacted]'
     end
 
     # Log a timed operation with consistent timing and error handling

--- a/lib/otto/mcp/rate_limiting.rb
+++ b/lib/otto/mcp/rate_limiting.rb
@@ -113,14 +113,17 @@ class Otto
       def self.configure_mcp_logging
         return unless defined?(ActiveSupport::Notifications)
 
+        # Masked address only — see the note on the sibling subscriber in
+        # Otto::Security::RateLimiting.configure_rack_attack! (issue #219).
         ActiveSupport::Notifications.subscribe('rack.attack') do |_name, _start, _finish, _request_id, payload|
           req      = payload[:request]
           endpoint = req.env['otto.mcp_http_endpoint'] || '/_mcp'
+          ip       = Otto::LoggingHelpers.privacy_safe_ip(req.env, req.ip)
 
           if req.path.start_with?(endpoint)
-            Otto.logger.warn "[MCP] Rate limit #{payload[:match_type]} for #{req.ip}: #{payload[:matched]}"
+            Otto.logger.warn "[MCP] Rate limit #{payload[:match_type]} for #{ip}: #{payload[:matched]}"
           else
-            Otto.logger.warn "[Otto] Rate limit #{payload[:match_type]} for #{req.ip}: #{payload[:matched]}"
+            Otto.logger.warn "[Otto] Rate limit #{payload[:match_type]} for #{ip}: #{payload[:matched]}"
           end
         end
       end

--- a/lib/otto/security/core.rb
+++ b/lib/otto/security/core.rb
@@ -181,7 +181,10 @@ class Otto
       # The middleware is pinned to run OUTERMOST (ahead of CSRF and every other
       # middleware), so it short-circuits report POSTs before CSRF validation —
       # browsers can post reports without a CSRF token. This holds regardless of
-      # the order in which you enable security features.
+      # the order in which you enable security features. The one thing that runs
+      # ahead of it is IPPrivacyMiddleware, pinned to the outer :entrypoint tier
+      # so nothing observes a raw client IP; being a pass-through, it cannot
+      # affect the short-circuit.
       #
       # SECURITY / DoS: running outermost also means the receiver sits ahead of
       # rate limiting (rate limiting is inner middleware). This is intentional —

--- a/lib/otto/security/csp/report_middleware.rb
+++ b/lib/otto/security/csp/report_middleware.rb
@@ -27,7 +27,9 @@ class Otto
       #   with no CSRF token: the report never reaches the CSRF middleware.
       #   {Otto::Security::Core#enable_csp_reporting!} pins this middleware
       #   OUTERMOST (via the :outermost stack position), so the guarantee holds
-      #   regardless of the order security features are enabled in. The flip side
+      #   regardless of the order security features are enabled in. Only
+      #   IPPrivacyMiddleware (pinned to the outer :entrypoint tier) runs ahead
+      #   of it, and it is a pass-through. The flip side
       #   is that reports also bypass rate limiting — see the DoS note on
       #   {Otto::Security::Core#enable_csp_reporting!}; keep callbacks cheap.
       # - Enforces a hard {MAX_BODY_BYTES} body cap. Oversized bodies are

--- a/lib/otto/security/middleware/ip_privacy_middleware.rb
+++ b/lib/otto/security/middleware/ip_privacy_middleware.rb
@@ -10,8 +10,18 @@ class Otto
       # Automatically masks IP addresses for privacy by default. Original IPs
       # are never stored unless privacy is explicitly disabled.
       #
-      # This middleware runs FIRST in the stack to ensure all downstream
-      # middleware and application code receives masked IPs by default.
+      # Otto pins this middleware to the OUTERMOST position of the stack (the
+      # :entrypoint tier — see Otto::Core::MiddlewareStack#add_with_position),
+      # so it is the first middleware to touch a request and every other
+      # middleware, plus the application, reads masked IPs by default. Before
+      # #219 it was registered `position: :first`, which is first-in-array and
+      # therefore INNERMOST: only the wrapped app saw masked values while every
+      # other middleware still saw the raw peer address.
+      #
+      # Because it now runs ahead of everything, facts about the ORIGINAL peer
+      # that downstream code can no longer derive from the (masked) REMOTE_ADDR
+      # are recorded first, as leak-free booleans — never as addresses:
+      # env['otto.via_trusted_proxy'] and env['otto.peer_loopback'].
       #
       # @example Default behavior (privacy enabled)
       #   # env['REMOTE_ADDR'] is masked to 192.168.1.0
@@ -57,6 +67,19 @@ class Otto
           # it never grants proxy trust for X-Forwarded-Proto (matching the
           # downstream OneTimeSecret behavior).
           env['otto.via_trusted_proxy'] = trusted_proxy?(env['REMOTE_ADDR'])
+
+          # Same rationale, for loopback: this middleware runs outermost, so a
+          # downstream middleware that must authenticate a DIRECT LOCAL CALL
+          # (Otto::CaddyTLS::LocalhostGuard) can no longer read the true socket
+          # peer from REMOTE_ADDR. Record the verdict here, on the untouched
+          # peer, as a boolean — the address itself is never exposed.
+          #
+          # Deliberately the raw peer, NOT the resolved client IP: resolution
+          # honors forwarded headers from trusted proxies, and a co-located
+          # reverse proxy on loopback is itself a natural trusted proxy, so
+          # resolving first would let `X-Forwarded-For: 127.0.0.1` promote a
+          # remote caller to "localhost".
+          env['otto.peer_loopback'] = Otto::Utils.loopback_address?(env['REMOTE_ADDR'])
 
           if @privacy_enabled
             apply_privacy(env)

--- a/lib/otto/security/rate_limiter.rb
+++ b/lib/otto/security/rate_limiter.rb
@@ -80,9 +80,15 @@ class Otto
         # Log blocked requests if ActiveSupport is available
         return unless defined?(ActiveSupport::Notifications)
 
+        # Rack::Attack is mounted by the hosting app AHEAD of Otto, so this
+        # subscriber sees the raw peer regardless of where IPPrivacyMiddleware
+        # sits in Otto's own stack. Log a masked address, never req.ip: a
+        # deployment on the default :masked profile must not write raw client
+        # IPs to its logs every time a limit trips (issue #219).
         ActiveSupport::Notifications.subscribe('rack.attack') do |_name, _start, _finish, _request_id, payload|
           req = payload[:request]
-          Otto.logger.warn "[Otto] Rate limit #{payload[:match_type]} for #{req.ip}: #{payload[:matched]}"
+          ip  = Otto::LoggingHelpers.privacy_safe_ip(req.env, req.ip)
+          Otto.logger.warn "[Otto] Rate limit #{payload[:match_type]} for #{ip}: #{payload[:matched]}"
         end
       end
     end

--- a/lib/otto/utils.rb
+++ b/lib/otto/utils.rb
@@ -320,5 +320,37 @@ class Otto
     rescue IPAddr::InvalidAddressError, IPAddr::AddressFamilyError
       false
     end
+
+    # Whether an address is on the loopback interface.
+    #
+    # This is the RAW SOCKET PEER test used to authenticate a direct local call
+    # (Otto::CaddyTLS::LocalhostGuard) — and, because IPPrivacyMiddleware now
+    # runs outermost and rewrites REMOTE_ADDR, the same test IPPrivacyMiddleware
+    # applies to the original peer and records as the leak-free boolean
+    # env['otto.peer_loopback']. Shared here so the pre-masking record and the
+    # guard's own fallback cannot drift.
+    #
+    # Fails closed: a blank or unparseable value is non-loopback rather than
+    # raising on the hot path.
+    #
+    # #native folds IPv4-mapped IPv6 (::ffff:127.0.0.1, which dual-stack servers
+    # commonly present) so it is recognized as loopback; plain IPAddr#loopback?
+    # returns false for the mapped form.
+    #
+    # Deliberately does NOT strip a ':port' suffix (unlike #private_ip?): a
+    # conforming Rack server reports the peer port in REMOTE_PORT, so an
+    # unexpected format means something upstream is non-standard and denying is
+    # safer than coercing.
+    #
+    # @param address [String, nil] raw socket peer address
+    # @return [Boolean]
+    def loopback_address?(address)
+      addr = address.to_s.strip
+      return false if addr.empty?
+
+      IPAddr.new(addr).native.loopback?
+    rescue IPAddr::InvalidAddressError, IPAddr::AddressFamilyError
+      false
+    end
   end
 end

--- a/spec/otto/caddy_tls/localhost_guard_spec.rb
+++ b/spec/otto/caddy_tls/localhost_guard_spec.rb
@@ -157,6 +157,23 @@ RSpec.describe Otto::CaddyTLS::LocalhostGuard do
       expect(stack_call(env)[0]).to eq(401)
     end
 
+    it 'still denies a relayed request whose forwarded headers privacy DELETED' do
+      # The one path where IPPrivacyMiddleware removes forwarded headers rather
+      # than rewriting them, which would make a relayed request look direct to
+      # #relayed?. It is reached only with no resolvable client IP, which also
+      # forces otto.peer_loopback false — so the peer check denies first. This
+      # pins that interaction (see the note on LocalhostGuard#relayed?).
+      env = env_for(headers: { 'HTTP_X_FORWARDED_FOR' => '127.0.0.1' })
+      env.delete('REMOTE_ADDR')
+
+      status, = stack_call(env)
+
+      expect(env).not_to have_key('HTTP_X_FORWARDED_FOR') # scrubbed: looks direct
+      expect(env['otto.peer_loopback']).to be false       # but the peer check holds
+      expect(status).to eq(401)
+      expect(downstream.calls).to be_empty
+    end
+
     it 'allows a direct IPv6 loopback call even when masking rewrites ::1' do
       security_config.ip_privacy_config.mask_private_ips = true
 

--- a/spec/otto/caddy_tls/localhost_guard_spec.rb
+++ b/spec/otto/caddy_tls/localhost_guard_spec.rb
@@ -86,6 +86,88 @@ RSpec.describe Otto::CaddyTLS::LocalhostGuard do
     end
   end
 
+  # IPPrivacyMiddleware is pinned outermost (issue #219), so it runs AHEAD of
+  # this guard and may have rewritten REMOTE_ADDR by the time the guard sees the
+  # env. It records its verdict on the untouched peer in env['otto.peer_loopback'],
+  # which the guard prefers over the (possibly rewritten) address.
+  describe "env['otto.peer_loopback'] (pre-masking peer record)" do
+    it 'allows when the record says loopback but REMOTE_ADDR was since rewritten' do
+      # What a masked private-IP deployment looks like: peer was ::1, privacy
+      # masked it to an address that no longer reads as loopback.
+      response = call(remote_addr: '::', headers: { 'otto.peer_loopback' => true })
+      expect(response[2]).to eq(['passed-through'])
+    end
+
+    it 'denies when the record says non-loopback even if REMOTE_ADDR now reads as loopback' do
+      # The exploit the raw-peer rule exists to stop: a trusted loopback proxy
+      # resolving a spoofed `X-Forwarded-For: 127.0.0.1` into REMOTE_ADDR.
+      status, = call(remote_addr: '127.0.0.1', headers: { 'otto.peer_loopback' => false })
+      expect(status).to eq(401)
+      expect(downstream.calls).to be_empty
+    end
+
+    it 'falls back to REMOTE_ADDR when the record is absent or not a Boolean' do
+      expect(call(remote_addr: '127.0.0.1')[0]).to eq(200)
+      expect(call(remote_addr: '8.8.8.8')[0]).to eq(401)
+      # A non-Boolean is not a verdict — evaluate the address instead.
+      expect(call(remote_addr: '8.8.8.8', headers: { 'otto.peer_loopback' => 'true' })[0]).to eq(401)
+      expect(call(remote_addr: '127.0.0.1', headers: { 'otto.peer_loopback' => nil })[0]).to eq(200)
+    end
+
+    it 'still requires the absence of forwarding headers' do
+      status, = call(remote_addr: '127.0.0.1',
+                     headers: { 'otto.peer_loopback' => true, 'HTTP_X_FORWARDED_FOR' => '203.0.113.9' })
+      expect(status).to eq(401)
+    end
+  end
+
+  describe 'behind IPPrivacyMiddleware (the real Otto stack order)' do
+    let(:security_config) { Otto::Security::Config.new }
+
+    # IPPrivacy outermost -> guard -> downstream, exactly as Otto builds it.
+    def stack_call(env)
+      Otto::Security::Middleware::IPPrivacyMiddleware.new(guard, security_config).call(env)
+    end
+
+    it 'allows a direct loopback call' do
+      status, = stack_call(env_for(remote_addr: '127.0.0.1'))
+      expect(status).to eq(200)
+    end
+
+    it 'denies a remote peer whose spoofed XFF resolves to loopback through a trusted proxy' do
+      security_config.add_trusted_proxy('203.0.113.7')
+
+      env = env_for(remote_addr: '203.0.113.7', headers: { 'HTTP_X_FORWARDED_FOR' => '127.0.0.1' })
+      status, = stack_call(env)
+
+      # Resolution promoted REMOTE_ADDR to loopback...
+      expect(env['REMOTE_ADDR']).to eq('127.0.0.1')
+      # ...but the guard authenticates the recorded raw peer, so: denied.
+      expect(env['otto.peer_loopback']).to be false
+      expect(status).to eq(401)
+      expect(downstream.calls).to be_empty
+    end
+
+    it 'denies a remote peer when masking is on for private IPs too' do
+      # mask_private_ips rewrites even loopback, so REMOTE_ADDR alone would be
+      # an unreliable basis for the decision in both directions.
+      security_config.ip_privacy_config.mask_private_ips = true
+
+      env = env_for(remote_addr: '8.8.8.8')
+      expect(stack_call(env)[0]).to eq(401)
+    end
+
+    it 'allows a direct IPv6 loopback call even when masking rewrites ::1' do
+      security_config.ip_privacy_config.mask_private_ips = true
+
+      env = env_for(remote_addr: '::1')
+      status, = stack_call(env)
+
+      expect(env['REMOTE_ADDR']).not_to eq('::1') # masked out of loopback range
+      expect(status).to eq(200)
+    end
+  end
+
   describe 'relayed requests (proxy forwarding headers)' do
     # A direct control-plane call from a co-located proxy carries no forwarding
     # headers. A request that was *relayed through* a proxy (even one connecting

--- a/spec/otto/core/middleware_stack_spec.rb
+++ b/spec/otto/core/middleware_stack_spec.rb
@@ -427,6 +427,67 @@ RSpec.describe Otto::Core::MiddlewareStack do
     end
   end
 
+  describe 'pins are per-entry, not per-class' do
+    let(:base_app) { ->(_env) { [200, {}, ['base']] } }
+
+    # Records its args so we can tell two registrations of the SAME class apart.
+    let(:mw) do
+      Class.new do
+        attr_reader :app, :args
+        def initialize(app, *args, **_opts)
+          @app  = app
+          @args = args
+        end
+
+        def call(env) = @app.call(env)
+      end
+    end
+
+    it 'does not drag an unpinned registration of the same class into the pinned tier' do
+      # Entries are identified by (class, args, options), so both of these are
+      # legitimate distinct registrations.
+      stack.add(mw, 'plain')
+      stack.add_with_position(mw, 'pinned', position: :outermost)
+
+      app = stack.wrap(base_app)
+      expect(app.args).to eq(['pinned'])      # the pin moved outermost
+      expect(app.app.args).to eq(['plain'])   # the plain one stayed put
+    end
+
+    it 'keeps an unpinned registration added AFTER the pin inside it' do
+      stack.add_with_position(mw, 'pinned', position: :outermost)
+      stack.add(mw, 'plain')
+
+      app = stack.wrap(base_app)
+      expect(app.args).to eq(['pinned'])
+      expect(app.app.args).to eq(['plain'])
+    end
+
+    it 'gives each registration its own tier rather than the last one written' do
+      stack.add_with_position(mw, 'outer', position: :outermost)
+      stack.add_with_position(mw, 'entry', position: :entrypoint)
+      stack.add(mw, 'plain')
+
+      app = stack.wrap(base_app)
+      expect(app.args).to eq(['entry'])
+      expect(app.app.args).to eq(['outer'])
+      expect(app.app.app.args).to eq(['plain'])
+    end
+
+    it 'removes the tier along with the entry' do
+      # #remove is class-wide (as are #includes? and the middleware set), so
+      # this drops both entries and both tiers with them.
+      stack.add_with_position(mw, 'pinned', position: :outermost)
+      stack.add(mw, 'plain')
+      stack.remove(mw)
+      stack.add(mw, 'plain')
+
+      app = stack.wrap(base_app)
+      expect(app.args).to eq(['plain'])
+      expect(app.app).to eq(base_app)
+    end
+  end
+
   describe '#execution_order' do
     let(:first_mw) { Class.new }
     let(:second_mw) { Class.new }

--- a/spec/otto/core/middleware_stack_spec.rb
+++ b/spec/otto/core/middleware_stack_spec.rb
@@ -343,5 +343,113 @@ RSpec.describe Otto::Core::MiddlewareStack do
       expect(app.app).to be_a(plain_mw)
       expect(app.app.app).to eq(base_app)
     end
+
+    it 'treats :innermost as a synonym for :first' do
+      stack.add_with_position(plain_mw, position: :innermost)
+      stack.add(third_mw)
+
+      app = stack.wrap(base_app)
+      expect(app).to be_a(third_mw)
+      expect(app.app).to be_a(plain_mw)
+    end
+  end
+
+  describe 'add_with_position(:entrypoint)' do
+    let(:base_app) { ->(_env) { [200, {}, ['base']] } }
+
+    let(:entry_mw) { middleware_double }
+    let(:outer_mw) { middleware_double }
+    let(:plain_mw) { middleware_double }
+
+    def middleware_double
+      Class.new do
+        attr_reader :app
+        def initialize(app, *_args, **_opts) = (@app = app)
+        def call(env) = @app.call(env)
+      end
+    end
+
+    it 'runs outside an :outermost pin, whichever is registered first' do
+      stack.add_with_position(entry_mw, position: :entrypoint)
+      stack.add_with_position(outer_mw, position: :outermost)
+
+      app = stack.wrap(base_app)
+      expect(app).to be_a(entry_mw)
+      expect(app.app).to be_a(outer_mw)
+    end
+
+    it 'runs outside an :outermost pin registered before it' do
+      stack.add_with_position(outer_mw, position: :outermost)
+      stack.add_with_position(entry_mw, position: :entrypoint)
+
+      app = stack.wrap(base_app)
+      expect(app).to be_a(entry_mw)
+      expect(app.app).to be_a(outer_mw)
+    end
+
+    it 'stays outermost as ordinary middleware is appended afterward' do
+      stack.add_with_position(entry_mw, position: :entrypoint)
+      stack.add(plain_mw)
+      stack.add(outer_mw)
+
+      app = stack.wrap(base_app)
+      expect(app).to be_a(entry_mw)
+    end
+
+    it 'un-pins the class on removal' do
+      stack.add_with_position(entry_mw, position: :entrypoint)
+      stack.add(plain_mw)
+      stack.remove(entry_mw)
+      stack.add(entry_mw) # re-added plain (not pinned)
+
+      app = stack.wrap(base_app)
+      # Appended last, so outermost by insertion order — the pin is gone, not
+      # merely shadowed.
+      expect(app).to be_a(entry_mw)
+      expect(app.app).to be_a(plain_mw)
+    end
+
+    it 'orders all three tiers: entrypoint > outermost > ordinary > first' do
+      inner_mw = middleware_double
+      stack.add_with_position(outer_mw, position: :outermost)
+      stack.add_with_position(inner_mw, position: :first)
+      stack.add(plain_mw)
+      stack.add_with_position(entry_mw, position: :entrypoint)
+
+      expect(stack.execution_order).to eq([entry_mw, outer_mw, plain_mw, inner_mw])
+
+      app = stack.wrap(base_app)
+      expect(app).to be_a(entry_mw)
+      expect(app.app).to be_a(outer_mw)
+      expect(app.app.app).to be_a(plain_mw)
+      expect(app.app.app.app).to be_a(inner_mw)
+      expect(app.app.app.app.app).to eq(base_app)
+    end
+  end
+
+  describe '#execution_order' do
+    let(:first_mw) { Class.new }
+    let(:second_mw) { Class.new }
+    let(:pinned_mw) { Class.new }
+
+    it 'reverses registration order (last added runs first)' do
+      stack.add(first_mw)
+      stack.add(second_mw)
+
+      expect(stack.middleware_list).to eq([first_mw, second_mw])
+      expect(stack.execution_order).to eq([second_mw, first_mw])
+    end
+
+    it 'resolves pins, unlike #middleware_list' do
+      stack.add_with_position(pinned_mw, position: :entrypoint)
+      stack.add(first_mw)
+
+      expect(stack.middleware_list).to eq([pinned_mw, first_mw])
+      expect(stack.execution_order).to eq([pinned_mw, first_mw])
+    end
+
+    it 'is empty for an empty stack' do
+      expect(stack.execution_order).to eq([])
+    end
   end
 end

--- a/spec/otto/logging_integration_spec.rb
+++ b/spec/otto/logging_integration_spec.rb
@@ -478,6 +478,72 @@ RSpec.describe 'Otto Logging Integration' do
         user_agent: 'Mozilla/*.*'
       })
     end
+
+    it 'prefers the canonical client IP over REMOTE_ADDR' do
+      env = {
+        'REQUEST_METHOD' => 'GET',
+        'PATH_INFO' => '/test',
+        'REMOTE_ADDR' => '203.0.113.7',
+        'otto.client_ip' => '203.0.113.0'
+      }
+
+      expect(Otto::LoggingHelpers.request_context(env)[:ip]).to eq('203.0.113.0')
+    end
+  end
+
+  describe 'LoggingHelpers.privacy_safe_ip' do
+    it 'returns the canonical client IP resolved by IPPrivacyMiddleware' do
+      env = { 'REMOTE_ADDR' => '203.0.113.7', 'otto.client_ip' => '203.0.113.0' }
+
+      expect(Otto::LoggingHelpers.privacy_safe_ip(env)).to eq('203.0.113.0')
+    end
+
+    it 'returns the real IP the middleware resolved when privacy is disabled' do
+      # apply_no_privacy sets otto.client_ip to the unmasked address; honoring
+      # it keeps the helper aligned with the app's configuration.
+      env = { 'REMOTE_ADDR' => '203.0.113.7', 'otto.client_ip' => '203.0.113.7' }
+
+      expect(Otto::LoggingHelpers.privacy_safe_ip(env)).to eq('203.0.113.7')
+    end
+
+    it 'masks REMOTE_ADDR when no canonical IP is present' do
+      # The Rack::Attack case: it is mounted outside Otto, so the privacy
+      # middleware has not run for this env (issue #219).
+      expect(Otto::LoggingHelpers.privacy_safe_ip('REMOTE_ADDR' => '203.0.113.7')).to eq('203.0.113.0')
+    end
+
+    it 'masks the supplied fallback address in preference to REMOTE_ADDR' do
+      env = { 'REMOTE_ADDR' => '10.0.0.1' }
+
+      # Rack::Request#ip factors in forwarded headers; mask whatever was used.
+      expect(Otto::LoggingHelpers.privacy_safe_ip(env, '198.51.100.42')).to eq('198.51.100.0')
+    end
+
+    it 'masks IPv6 addresses too' do
+      expect(Otto::LoggingHelpers.privacy_safe_ip({}, '2001:db8:1:2:3:4:5:6')).to eq('2001:db8:1::')
+    end
+
+    it 'leaves private and loopback addresses readable' do
+      # Matches IPPrivacyMiddleware's own exemption, so development logs stay useful.
+      expect(Otto::LoggingHelpers.privacy_safe_ip('REMOTE_ADDR' => '127.0.0.1')).to eq('127.0.0.1')
+      expect(Otto::LoggingHelpers.privacy_safe_ip('REMOTE_ADDR' => '192.168.1.50')).to eq('192.168.1.50')
+    end
+
+    it 'redacts rather than raising on an unparseable address' do
+      expect(Otto::LoggingHelpers.privacy_safe_ip('REMOTE_ADDR' => 'not-an-ip')).to eq('[redacted]')
+      expect(Otto::LoggingHelpers.privacy_safe_ip('REMOTE_ADDR' => '203.0.113.7:443')).to eq('[redacted]')
+    end
+
+    it 'returns nil when there is no address at all' do
+      expect(Otto::LoggingHelpers.privacy_safe_ip({})).to be_nil
+      expect(Otto::LoggingHelpers.privacy_safe_ip('REMOTE_ADDR' => '')).to be_nil
+    end
+
+    it 'never returns a raw public address' do
+      %w[8.8.8.8 203.0.113.7 2606:4700:4700::1111].each do |ip|
+        expect(Otto::LoggingHelpers.privacy_safe_ip({}, ip)).not_to eq(ip)
+      end
+    end
   end
 
   describe 'LoggingHelpers timing methods' do
@@ -497,7 +563,9 @@ RSpec.describe 'Otto Logging Integration' do
           hash_including(
             method: 'POST',
             path: '/api/test',
-            ip: '192.0.2.100',
+            # No otto.client_ip in this bare env, so the raw REMOTE_ADDR is
+            # masked before it reaches the log (issue #219).
+            ip: '192.0.2.0',
             duration: kind_of(Integer),
             result: 'success'
           )

--- a/spec/otto/middleware_args_edge_cases_spec.rb
+++ b/spec/otto/middleware_args_edge_cases_spec.rb
@@ -70,11 +70,13 @@ RSpec.describe 'Middleware Args Edge Cases' do
       stub_const('RegularMiddleware', regular_middleware)
     end
 
+    # Otto pins IPPrivacyMiddleware outermost (issue #219), so the middleware
+    # under test is the link directly inside it — see #inside_ip_privacy.
     it 'injects security_config into known security middleware' do
       otto.middleware.add(Otto::Security::Middleware::CSRFMiddleware)
 
       base_app = ->(_env) { [200, {}, ['base']] }
-      app = otto.middleware.wrap(base_app, security_config)
+      app = inside_ip_privacy(otto.middleware.wrap(base_app, security_config))
 
       expect(app.security_config).to eq(security_config)
       expect(app.custom_args).to be_empty
@@ -84,7 +86,7 @@ RSpec.describe 'Middleware Args Edge Cases' do
       otto.middleware.add(RegularMiddleware)
 
       base_app = ->(_env) { [200, {}, ['base']] }
-      app = otto.middleware.wrap(base_app, security_config)
+      app = inside_ip_privacy(otto.middleware.wrap(base_app, security_config))
 
       expect(app.args).to be_empty
       expect(app).not_to respond_to(:security_config)
@@ -94,7 +96,7 @@ RSpec.describe 'Middleware Args Edge Cases' do
       otto.middleware.add(Otto::Security::Middleware::ValidationMiddleware, 'custom_arg', option: 'value')
 
       base_app = ->(_env) { [200, {}, ['base']] }
-      app = otto.middleware.wrap(base_app, security_config)
+      app = inside_ip_privacy(otto.middleware.wrap(base_app, security_config))
 
       expect(app.security_config).to eq(security_config)
       expect(app.custom_args).to eq(['custom_arg'])
@@ -105,7 +107,7 @@ RSpec.describe 'Middleware Args Edge Cases' do
       otto.middleware.add(RegularMiddleware, 'arg1', 'arg2', option: 'value')
 
       base_app = ->(_env) { [200, {}, ['base']] }
-      app = otto.middleware.wrap(base_app, security_config)
+      app = inside_ip_privacy(otto.middleware.wrap(base_app, security_config))
 
       expect(app.args).to eq(%w[arg1 arg2])
       expect(app.options).to eq(option: 'value')
@@ -117,9 +119,9 @@ RSpec.describe 'Middleware Args Edge Cases' do
       base_app = ->(_env) { [200, {}, ['base']] }
       app = otto.middleware.wrap(base_app, security_config)
 
-      # With IP Privacy middleware always present, it wraps the base app first
-      expect(app.app).to be_a(Otto::Security::Middleware::IPPrivacyMiddleware)
-      expect(app.app.instance_variable_get(:@app)).to eq(base_app)
+      # IP Privacy is the outermost wrapper; the proc-built middleware sits
+      # between it and the base app.
+      expect(inside_ip_privacy(app).app).to eq(base_app)
     end
   end
 
@@ -163,9 +165,10 @@ RSpec.describe 'Middleware Args Edge Cases' do
       base_app = ->(_env) { [200, {}, ['base']] }
 
       # Build the middleware chain
-      app = otto.middleware.wrap(base_app, security_config)
+      app = inside_ip_privacy(otto.middleware.wrap(base_app, security_config))
 
-      # The outermost middleware should be CSRFMiddleware (added last, wraps the previous ones)
+      # Of the registered middleware, CSRFMiddleware is outermost (added last,
+      # wraps the previous ones)
       expect(app).to be_a(Otto::Security::Middleware::CSRFMiddleware)
       expect(app.custom_args).to eq(['csrf_arg'])
     end
@@ -175,7 +178,7 @@ RSpec.describe 'Middleware Args Edge Cases' do
       otto.middleware.add(RegularMiddleware)
 
       base_app = ->(_env) { [200, {}, ['base']] }
-      app = otto.middleware.wrap(base_app, security_config)
+      app = inside_ip_privacy(otto.middleware.wrap(base_app, security_config))
 
       expect(app).to be_a(regular_middleware)
       expect(app.args).to be_empty
@@ -185,7 +188,7 @@ RSpec.describe 'Middleware Args Edge Cases' do
       otto.middleware.add(RegularMiddleware, option1: 'value1', option2: 'value2')
 
       base_app = ->(_env) { [200, {}, ['base']] }
-      app = otto.middleware.wrap(base_app, security_config)
+      app = inside_ip_privacy(otto.middleware.wrap(base_app, security_config))
 
       expect(app.args).to be_empty
       expect(app.options).to eq(option1: 'value1', option2: 'value2')
@@ -225,7 +228,7 @@ RSpec.describe 'Middleware Args Edge Cases' do
       otto.middleware.add(Otto::Security::Middleware::CSRFMiddleware, 'custom_arg')
 
       base_app = ->(_env) { [200, {}, ['base']] }
-      app = otto.middleware.wrap(base_app, nil)
+      app = inside_ip_privacy(otto.middleware.wrap(base_app, nil))
 
       # Should still work, just without security config injection
       expect(app.custom_args).to eq(['custom_arg'])
@@ -236,7 +239,7 @@ RSpec.describe 'Middleware Args Edge Cases' do
       otto.middleware.add(regular_middleware, 'arg')
 
       base_app = ->(_env) { [200, {}, ['base']] }
-      app = otto.middleware.wrap(base_app, nil)
+      app = inside_ip_privacy(otto.middleware.wrap(base_app, nil))
 
       expect(app.args).to eq(['arg'])
     end
@@ -257,12 +260,17 @@ RSpec.describe 'Middleware Args Edge Cases' do
       # Middleware list should be in addition order (IPPrivacyMiddleware is always first)
       expect(otto.middleware.middleware_list).to eq([Otto::Security::Middleware::IPPrivacyMiddleware, Middleware1, Middleware2, Middleware3])
 
-      # But execution follows standard Rack behavior (last added wraps the others)
+      # But execution follows standard Rack behavior (last added wraps the
+      # others), under the IP-privacy pin which always executes first.
       base_app = ->(_env) { [200, {}, ['base']] }
       app = otto.middleware.wrap(base_app, security_config)
 
-      # The outermost middleware should be the last one added
-      expect(app).to be_a(Middleware3)
+      expect(middleware_chain(app).map(&:class)).to eq(
+        [Otto::Security::Middleware::IPPrivacyMiddleware, Middleware3, Middleware2, Middleware1]
+      )
+      expect(otto.middleware.execution_order).to eq(
+        [Otto::Security::Middleware::IPPrivacyMiddleware, Middleware3, Middleware2, Middleware1]
+      )
     end
   end
 end

--- a/spec/otto/middleware_execution_order_spec.rb
+++ b/spec/otto/middleware_execution_order_spec.rb
@@ -1,0 +1,160 @@
+# spec/otto/middleware_execution_order_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Regression coverage for issue #219.
+#
+# IPPrivacyMiddleware was registered `position: :first`, which is first-in-ARRAY
+# and therefore INNERMOST once MiddlewareStack#wrap folds the stack with reduce.
+# The result inverted the documented contract: only the wrapped application saw
+# masked IPs, while every other middleware Otto mounts saw the raw REMOTE_ADDR
+# and a nil otto.client_ip.
+#
+# These specs pin what OTHER MIDDLEWARE observes, not just what the app observes
+# — the distinction the previous coverage missed entirely.
+RSpec.describe 'Middleware execution order' do
+  # A pass-through that records the env exactly as it was handed to it.
+  def probe_class
+    Class.new do
+      class << self
+        attr_accessor :seen
+      end
+
+      def initialize(app, *_args, **_opts) = (@app = app)
+
+      def call(env)
+        self.class.seen = {
+          remote_addr: env['REMOTE_ADDR'],
+             user_agent: env['HTTP_USER_AGENT'],
+              client_ip: env['otto.client_ip'],
+                    xff: env['HTTP_X_FORWARDED_FOR'],
+        }
+        @app.call(env)
+      end
+    end
+  end
+
+  let(:probe) { probe_class }
+
+  let(:otto) do
+    instance = Otto.new
+    Otto.unfreeze_for_testing(instance)
+    instance
+  end
+
+  def request_env(remote_addr: '203.0.113.7', headers: {})
+    {
+      'REQUEST_METHOD' => 'GET',
+             'PATH_INFO' => '/',
+         'QUERY_STRING' => '',
+          'REMOTE_ADDR' => remote_addr,
+      'HTTP_USER_AGENT' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.6099.109',
+           'rack.input' => StringIO.new(''),
+    }.merge(headers)
+  end
+
+  describe 'IP privacy is the entry point of the stack' do
+    it 'runs first, before any middleware the app adds' do
+      otto.use(probe)
+
+      expect(otto.middleware.execution_order.first)
+        .to eq(Otto::Security::Middleware::IPPrivacyMiddleware)
+      expect(otto.middleware.execution_order.last).to eq(probe)
+    end
+
+    it 'hands other middleware a masked REMOTE_ADDR and the canonical client IP' do
+      otto.use(probe)
+
+      otto.call(request_env)
+
+      expect(probe.seen[:remote_addr]).to eq('203.0.113.0')
+      expect(probe.seen[:client_ip]).to eq('203.0.113.0')
+    end
+
+    it 'hands other middleware an anonymized User-Agent' do
+      otto.use(probe)
+
+      otto.call(request_env)
+
+      expect(probe.seen[:user_agent]).not_to include('10_15_7')
+    end
+
+    it 'masks forwarded headers before other middleware reads them' do
+      otto.use(probe)
+
+      otto.call(request_env(headers: { 'HTTP_X_FORWARDED_FOR' => '203.0.113.7' }))
+
+      expect(probe.seen[:xff]).to eq('203.0.113.0')
+    end
+
+    it 'stays first when rate limiting is enabled (the reported reproduction)' do
+      otto.enable_rate_limiting!
+      otto.use(probe)
+
+      expect(otto.middleware.execution_order.first)
+        .to eq(Otto::Security::Middleware::IPPrivacyMiddleware)
+
+      otto.call(request_env)
+      expect(probe.seen[:remote_addr]).to eq('203.0.113.0')
+      expect(probe.seen[:client_ip]).to eq('203.0.113.0')
+    end
+
+    it 'stays first when a middleware is pinned :outermost' do
+      otto.enable_csp_reporting!('/_/csp-report') { |_report| nil }
+      otto.use(probe)
+
+      expect(otto.middleware.execution_order.first)
+        .to eq(Otto::Security::Middleware::IPPrivacyMiddleware)
+      expect(otto.middleware.execution_order[1])
+        .to eq(Otto::Security::CSP::ReportMiddleware)
+    end
+
+    it 'stays first regardless of how many middleware are added after it' do
+      5.times { otto.use(probe_class) }
+
+      expect(otto.middleware.execution_order.first)
+        .to eq(Otto::Security::Middleware::IPPrivacyMiddleware)
+    end
+  end
+
+  describe 'exemptions still apply to other middleware' do
+    it 'leaves private/localhost addresses unmasked' do
+      otto.use(probe)
+
+      otto.call(request_env(remote_addr: '127.0.0.1'))
+
+      expect(probe.seen[:remote_addr]).to eq('127.0.0.1')
+      expect(probe.seen[:client_ip]).to eq('127.0.0.1')
+    end
+
+    it 'gives other middleware the real IP when privacy is disabled' do
+      otto.security_config.ip_privacy_config.disable!
+      otto.use(probe)
+
+      otto.call(request_env)
+
+      expect(probe.seen[:remote_addr]).to eq('203.0.113.7')
+      expect(probe.seen[:client_ip]).to eq('203.0.113.7')
+    end
+  end
+
+  describe 'pre-masking peer records' do
+    it 'records the raw-peer facts before any other middleware runs' do
+      seen = nil
+      recorder = Class.new do
+        define_method(:initialize) { |app, *_a, **_o| @app = app }
+        define_method(:call) do |env|
+          seen = env.slice('otto.via_trusted_proxy', 'otto.peer_loopback')
+          @app.call(env)
+        end
+      end
+      otto.use(recorder)
+
+      otto.call(request_env(remote_addr: '127.0.0.1'))
+
+      expect(seen).to eq('otto.via_trusted_proxy' => false, 'otto.peer_loopback' => true)
+    end
+  end
+end

--- a/spec/otto/middleware_execution_order_spec.rb
+++ b/spec/otto/middleware_execution_order_spec.rb
@@ -112,7 +112,11 @@ RSpec.describe 'Middleware execution order' do
     end
 
     it 'stays first regardless of how many middleware are added after it' do
+      # probe_class mints a fresh anonymous class per call, so these are five
+      # distinct entries — not one entry deduplicated by #add's identical-config
+      # check. Asserted, because the pin is only interesting if they all landed.
       5.times { otto.use(probe_class) }
+      expect(otto.middleware.size).to eq(6) # 5 probes + the IP-privacy pin
 
       expect(otto.middleware.execution_order.first)
         .to eq(Otto::Security::Middleware::IPPrivacyMiddleware)

--- a/spec/otto/middleware_stack_synchronization_spec.rb
+++ b/spec/otto/middleware_stack_synchronization_spec.rb
@@ -110,10 +110,12 @@ RSpec.describe 'Middleware Stack Synchronization' do
 
       otto.use(TestExecutionMiddleware)
 
-      # After adding middleware, count is 2 and app should be TestExecutionMiddleware instance
+      # After adding middleware, count is 2 and the rebuilt app must actually
+      # run TestExecutionMiddleware — directly inside the outermost IP-privacy
+      # pin (issue #219).
       expect(otto.middleware.size).to eq(2)
       app = otto.instance_variable_get(:@app)
-      expect(app).to be_a(TestExecutionMiddleware)
+      expect(inside_ip_privacy(app)).to be_a(TestExecutionMiddleware)
     end
   end
 
@@ -128,7 +130,8 @@ RSpec.describe 'Middleware Stack Synchronization' do
       # ...and @app must have been rebuilt so the middleware actually executes.
       # List membership alone is not enough: it was already true while the
       # Configurator-enabled middleware was silently bypassed.
-      expect(otto.instance_variable_get(:@app)).to be_a(Otto::Security::CSRFMiddleware)
+      expect(middleware_chain(otto.instance_variable_get(:@app)).map(&:class))
+        .to include(Otto::Security::CSRFMiddleware)
     end
 
     it 'maintains security configuration' do
@@ -144,7 +147,8 @@ RSpec.describe 'Middleware Stack Synchronization' do
 
       # Middleware should be in stack and wired into the running chain
       expect(otto.middleware.includes?(Otto::Security::CSRFMiddleware)).to be true
-      expect(otto.instance_variable_get(:@app)).to be_a(Otto::Security::CSRFMiddleware)
+      expect(middleware_chain(otto.instance_variable_get(:@app)).map(&:class))
+        .to include(Otto::Security::CSRFMiddleware)
     end
   end
 

--- a/spec/otto/rate_limiting_spec.rb
+++ b/spec/otto/rate_limiting_spec.rb
@@ -284,4 +284,78 @@ RSpec.describe Otto, 'rate limiting features' do
       expect(body.first).to include('Rate limit exceeded')
     end
   end
+
+  # Issue #219: the 'rack.attack' subscriber interpolated req.ip straight into a
+  # warn-level line, so a deployment on the default :masked privacy profile
+  # still wrote raw client IPs to its logs every time a limit tripped.
+  #
+  # ActiveSupport is not a dependency, so the subscriber is normally never
+  # registered. Stand in a minimal Notifications double to capture the block and
+  # drive it with a payload.
+  describe 'blocked-request logging' do
+    let(:notifications) do
+      Class.new do
+        attr_reader :subscriptions
+
+        def initialize = (@subscriptions = {})
+        def subscribe(name, &block) = (@subscriptions[name] = block)
+
+        def publish(name, payload)
+          @subscriptions.fetch(name).call(name, nil, nil, nil, payload)
+        end
+      end.new
+    end
+
+    let(:logged) { [] }
+
+    def publish_throttle(env)
+      request = instance_double('Rack::Request', env: env, ip: env['REMOTE_ADDR'], path: env['PATH_INFO'])
+      notifications.publish('rack.attack', request: request, match_type: :throttle, matched: 'requests')
+    end
+
+    before do
+      stub_const('ActiveSupport::Notifications', notifications)
+      allow(Otto.logger).to receive(:warn) { |message| logged << message }
+    end
+
+    it 'logs a masked IP, never the raw client address' do
+      Otto::Security::RateLimiting.configure_rack_attack!({})
+
+      publish_throttle('REMOTE_ADDR' => '203.0.113.7', 'PATH_INFO' => '/api')
+
+      expect(logged.last).to include('203.0.113.0')
+      expect(logged.last).not_to include('203.0.113.7')
+    end
+
+    it 'prefers the canonical client IP when Rack::Attack runs inside Otto' do
+      Otto::Security::RateLimiting.configure_rack_attack!({})
+
+      publish_throttle(
+        'REMOTE_ADDR' => '203.0.113.0',
+        'PATH_INFO' => '/api',
+        'otto.client_ip' => '203.0.113.0'
+      )
+
+      expect(logged.last).to include('203.0.113.0')
+    end
+
+    it 'masks the IP on the MCP subscriber too' do
+      Otto::MCP::RateLimiter.configure_mcp_logging
+
+      publish_throttle('REMOTE_ADDR' => '198.51.100.42', 'PATH_INFO' => '/_mcp')
+
+      expect(logged.last).to start_with('[MCP]')
+      expect(logged.last).to include('198.51.100.0')
+      expect(logged.last).not_to include('198.51.100.42')
+    end
+
+    it 'masks the IP on the MCP subscriber for non-MCP paths' do
+      Otto::MCP::RateLimiter.configure_mcp_logging
+
+      publish_throttle('REMOTE_ADDR' => '198.51.100.42', 'PATH_INFO' => '/other')
+
+      expect(logged.last).to start_with('[Otto]')
+      expect(logged.last).not_to include('198.51.100.42')
+    end
+  end
 end

--- a/spec/otto/utils_spec.rb
+++ b/spec/otto/utils_spec.rb
@@ -253,6 +253,42 @@ RSpec.describe Otto::Utils do
     end
   end
 
+  describe "#loopback_address?" do
+    it "recognizes the IPv4 loopback block, not just 127.0.0.1" do
+      expect(Otto::Utils.loopback_address?("127.0.0.1")).to be true
+      expect(Otto::Utils.loopback_address?("127.5.5.5")).to be true
+    end
+
+    it "recognizes IPv6 loopback, including the IPv4-mapped form" do
+      expect(Otto::Utils.loopback_address?("::1")).to be true
+      expect(Otto::Utils.loopback_address?("::ffff:127.0.0.1")).to be true
+    end
+
+    it "treats other private addresses as non-loopback" do
+      # Narrower than #private_ip?: RFC1918 is private but not loopback.
+      expect(Otto::Utils.loopback_address?("10.0.0.1")).to be false
+      expect(Otto::Utils.loopback_address?("192.168.1.1")).to be false
+      expect(Otto::Utils.loopback_address?("fc00::1")).to be false
+    end
+
+    it "treats public addresses as non-loopback" do
+      expect(Otto::Utils.loopback_address?("8.8.8.8")).to be false
+      expect(Otto::Utils.loopback_address?("2001:db8::1")).to be false
+    end
+
+    it "fails closed on blank, malformed or ported input instead of raising" do
+      # A conforming Rack server reports the peer port in REMOTE_PORT, so a
+      # ported REMOTE_ADDR signals something non-standard: deny, don't coerce.
+      [nil, "", "   ", "garbage", "127.0.0.1:53422"].each do |value|
+        expect(Otto::Utils.loopback_address?(value)).to be(false), "expected #{value.inspect} to be non-loopback"
+      end
+    end
+
+    it "tolerates surrounding whitespace" do
+      expect(Otto::Utils.loopback_address?("  127.0.0.1  ")).to be true
+    end
+  end
+
   describe "#resolve_client_ip" do
     def config_with(*proxies)
       cfg = Otto::Security::Config.new

--- a/spec/support/test_helpers.rb
+++ b/spec/support/test_helpers.rb
@@ -100,4 +100,37 @@ module OttoTestHelpers
       end
     end
   end
+
+  # Walk a chain built by MiddlewareStack#wrap from the OUTSIDE IN, returning
+  # each middleware instance in execution order. Stops at the first object that
+  # wraps nothing — the base application.
+  #
+  # Every middleware in the chain must hold its inner app in @app (Otto's own
+  # do, as do the spec doubles).
+  #
+  # @param app [#call] the wrapped application
+  # @return [Array<Object>] middleware instances, outermost first
+  def middleware_chain(app)
+    chain = []
+    current = app
+
+    while current.instance_variable_defined?(:@app)
+      chain << current
+      current = current.instance_variable_get(:@app)
+    end
+
+    chain
+  end
+
+  # The middleware Otto's outermost IP-privacy pin wraps — i.e. the outermost
+  # middleware the application itself registered. Otto pins
+  # IPPrivacyMiddleware to the :entrypoint tier (issue #219), so it is always
+  # the first link of a chain built from an Otto instance's stack.
+  #
+  # @param app [#call] the wrapped application
+  # @return [Object] the second link of the chain
+  def inside_ip_privacy(app)
+    expect(app).to be_a(Otto::Security::Middleware::IPPrivacyMiddleware)
+    app.instance_variable_get(:@app)
+  end
 end


### PR DESCRIPTION
Fixes #219.

## The bug

`IPPrivacyMiddleware` was registered `position: :first`. That is first-in-**array**, and `MiddlewareStack#wrap` folds with `reduce`, so index 0 becomes the **innermost** wrapper. Only the wrapped application saw masked values; every other middleware Otto mounts — and anything the app adds via `Otto#use` — got the raw `REMOTE_ADDR`, an un-anonymized User-Agent, and a nil `env['otto.client_ip']`.

Reproduced before the fix:

```
probe (outside IPPrivacy?) saw: REMOTE_ADDR=203.0.113.7 otto.client_ip=nil
inner app saw:                  REMOTE_ADDR=203.0.113.0 otto.client_ip="203.0.113.0"
```

and after:

```
probe saw:      REMOTE_ADDR=203.0.113.0 otto.client_ip="203.0.113.0"
inner app saw:  REMOTE_ADDR=203.0.113.0 otto.client_ip="203.0.113.0"
```

## Ordering

`:outermost` alone was not enough: the CSP report receiver already uses it, and pinned entries kept insertion order, so IP privacy (registered in `Otto#initialize`) would have landed *inside* it — the same "ordering by accident" that caused this bug.

`ordered_stack` now sorts by `(pin tier, insertion index)` instead of partitioning a boolean set. Existing `:outermost` behavior is unchanged; a new `:entrypoint` tier sits outside it and is where IP privacy is pinned. The CSP receiver keeps its short-circuit guarantee — `IPPrivacyMiddleware` is a pass-through.

Pin tiers are recorded **per entry**, not per class. Entries are identified by `(class, args, options)`, so the same class can legitimately be registered more than once with different configuration; a class-wide pin dragged those other registrations into the pinned tier along with it. That behavior predates this PR (`main`'s `@outermost` was a `Set` of classes and `ordered_stack` partitioned on class membership) — fixed here since this PR reworks that code. It also removed the pin bookkeeping from `#remove`/`#clear!`: a removed entry takes its tier with it.

Two smaller pieces addressing the root confusion: `:innermost` is accepted as a synonym for the misleading `:first`, and `#execution_order` reports what actually runs first (`#middleware_list` reports registration order, which is the reverse and ignores pins).

## Audit of middleware that read a raw `REMOTE_ADDR`

`Otto::CaddyTLS::LocalhostGuard` is the one that mattered. It authenticates the **raw TCP peer** — deliberately not the resolved client IP, since a co-located loopback proxy is a natural trusted proxy and would let `X-Forwarded-For: 127.0.0.1` promote a remote caller. It could only do that because IP privacy used to run after it.

Rather than restore that ordering, `IPPrivacyMiddleware` now records its verdict on the untouched peer as `env['otto.peer_loopback']` — a boolean, never an address — mirroring the existing `otto.via_trusted_proxy`. The guard prefers that record and falls back to `REMOTE_ADDR` when absent (mounted outside Otto, or no privacy middleware). Both paths share `Otto::Utils.loopback_address?` so they cannot drift.

Specs cover both directions of the exploit, plus a latent false-deny this also fixes: with `mask_private_ips` on, an IPv6 loopback peer masks to `::`, which is no longer in the loopback range.

The guard's *other* check, `relayed?`, reads header state that IP privacy has now already touched. Masking rewrites forwarded headers rather than removing them, so a relayed request still looks relayed; the no-resolvable-IP path deletes them, but that path forces `otto.peer_loopback` false, so the peer check denies first. Safe — but it was safe by an unwritten coincidence of two methods, so the reasoning is now documented and pinned by a spec.

Everything else was checked and needs no change: CSRF and validation middleware do not read IPs; `RateLimitMiddleware` is a pass-through configurator; the CSP receiver never touches the client address.

## Rate-limit logging (independent of ordering)

The `rack.attack` subscribers interpolated `req.ip` into a `warn`-level line on every blocked request, so any deployment on the default `:masked` profile wrote raw public IPs to its logs. Ordering cannot fix this — Rack::Attack is mounted by the hosting app *outside* Otto — so both subscribers (`Otto::Security::RateLimiting`, `Otto::MCP::RateLimiter`) now log through a new `LoggingHelpers.privacy_safe_ip`, which prefers the canonical `otto.client_ip` when present (already correct for both masked and privacy-disabled configs) and otherwise masks. Private/localhost stays readable; unparseable input becomes `[redacted]` instead of raising.

`LoggingHelpers.request_context` used the same `otto.client_ip || REMOTE_ADDR` fallback and now goes through the helper too.

## Deliberately not changed

Throttling still keys on the raw IP, because Rack::Attack runs outside Otto — the `/24` blast-radius question raised in the issue does not arise from this reorder. Worth deciding explicitly, but as its own change.

`Otto::MCP::Server` has the same inverted-`:first` reading (rate limiting "first" is actually innermost, schema validation "last" is outermost, and `validate_mcp_middleware_order` validates the array order that encodes it). Out of scope here — `:first` semantics are untouched by this PR — but it is the same root confusion and probably wants its own issue.

`Otto::MCP::RateLimiter.configure_rack_attack!` registers the `rack.attack` subscriber **twice**: `super` installs the generic one, then `configure_mcp_logging` installs the MCP-aware one, so an MCP deployment logs every blocked request twice (and now runs `privacy_safe_ip` twice). Confirmed pre-existing and not a privacy leak — both lines mask — but deciding which subscriber should win changes MCP log output, so it belongs in its own change. (Surfaced by the automated review on this PR.)

## Testing

- `bundle exec rspec`: 1964 examples, 0 failures (was 1912; +52 new).
- New `spec/otto/middleware_execution_order_spec.rb` pins what *other middleware* observes, not just what the app observes — the gap the issue identified.
- 15 pre-existing specs asserted the inverted order by navigating a built chain from the outside; they now assert the same intent against the corrected order.
- Regression-checked against `onetimesecret`: with its Gemfile pointed at this branch, a fixed-seed run of its full suite produced a byte-identical failure set before and after (5029 examples, 209 pre-existing failures either way). It mounts `IPPrivacyMiddleware` explicitly first in its own Rack builder — precisely because Otto's built-in mount was innermost — so Otto's instance is a no-op there via the `otto.client_ip` idempotency guard. This change makes Otto's default match what that app hand-rolled.
- RuboCop: no new offenses on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXyK53CrxTTfdutipBCpFG