### PR TITLE
RouteAuthWrapper: terminal auth failures so mixed credentialed/noauth chains fail closed

### DIFF
--- a/changelog.d/20260730_terminal_auth_failures.rst
+++ b/changelog.d/20260730_terminal_auth_failures.rst
@@ -1,0 +1,32 @@
+Added
+-----
+
+- ``AuthFailure`` now carries a ``terminal`` flag (``terminal?`` predicate),
+  and ``AuthStrategy#failure`` accepts ``terminal: true``. A terminal failure
+  means "this request explicitly presented credentials and they were examined
+  and rejected — do not consult further strategies." ``RouteAuthWrapper``
+  halts the chain on a terminal failure and renders the 401 with that
+  failure's reason, regardless of strategy order, so mixed
+  credentialed/anonymous chains (``auth=basicauth,noauth``) can fail closed on
+  invalid credentials instead of silently proceeding as anonymous. Plain
+  failures keep the existing OR fallthrough, so credential-less requests still
+  reach ``noauth``, and noauth-only routes are unaffected. (#220)
+
+Changed
+-------
+
+- ``RouteAuthWrapper`` multi-strategy chains now treat an anonymous success
+  (a ``StrategyResult`` with no user, e.g. from ``noauth``) as a held
+  fallback rather than an immediate win: the rest of the chain still runs so
+  a later credentialed strategy can reject explicitly presented credentials
+  terminally — this is what makes terminal failures order-independent. The
+  fallback wins once the chain completes without an authenticated success or
+  terminal failure, preserving OR semantics for requests without
+  credentials. Consequently, in a chain like ``auth=noauth,apikey`` a later
+  authenticated success now wins over an earlier anonymous one. (#220)
+
+AI Assistance
+-------------
+
+- Design, implementation, and regression specs written with AI assistance.
+  (#220)

--- a/lib/otto/security/authentication/auth_failure.rb
+++ b/lib/otto/security/authentication/auth_failure.rb
@@ -6,10 +6,44 @@ class Otto
   module Security
     module Authentication
       # Failure result for authentication failures
-      AuthFailure = Data.define(:failure_reason, :auth_method) do
+      AuthFailure = Data.define(:failure_reason, :auth_method, :terminal) do
         # AuthFailure represents authentication failure
         # Returned by strategies when authentication fails
         # Contains failure reason for error messages
+        #
+        # TERMINAL FAILURES
+        # -----------------
+        # By default a failure is non-terminal: RouteAuthWrapper records it and
+        # consults the next strategy in the route's chain (OR logic), so a
+        # request without credentials can still fall through to an
+        # anonymous-capable strategy like noauth.
+        #
+        # A failure constructed with `terminal: true` means "this request
+        # explicitly presented credentials and they were examined and
+        # rejected — do not consult further strategies." RouteAuthWrapper
+        # halts the chain and renders the 401 with this failure's reason,
+        # regardless of where the strategy sits in the chain. This lets mixed
+        # credentialed/anonymous chains (e.g. auth=basicauth,noauth) fail
+        # closed on invalid credentials instead of silently degrading to
+        # anonymous.
+        #
+        # Only reject terminally when credentials were EXPLICITLY presented
+        # (e.g. an Authorization header). Ambient credentials such as session
+        # cookies should fail non-terminally so a logged-out browser can still
+        # degrade to anonymous on noauth-capable routes.
+
+        # terminal defaults to false so existing keyword construction
+        # (failure_reason:, auth_method:) is unaffected.
+        def initialize(failure_reason:, auth_method:, terminal: false)
+          super
+        end
+
+        # Check if this failure halts the strategy chain
+        #
+        # @return [Boolean] True when the chain must fail closed
+        def terminal?
+          terminal
+        end
 
         # Check if authenticated - always false for failures
         #
@@ -36,7 +70,7 @@ class Otto
         #
         # @return [String] Debug representation
         def inspect
-          "#<AuthFailure reason=#{failure_reason.inspect} method=#{auth_method}>"
+          "#<AuthFailure reason=#{failure_reason.inspect} method=#{auth_method}#{' terminal' if terminal}>"
         end
       end
     end

--- a/lib/otto/security/authentication/auth_strategy.rb
+++ b/lib/otto/security/authentication/auth_strategy.rb
@@ -42,11 +42,21 @@ class Otto
         # Use for a missing, invalid, or expired credential. RouteAuthWrapper maps
         # this to 401 Unauthorized. For a VALID credential that is not permitted,
         # use #authorization_failure instead (403 Forbidden).
-        def failure(reason = nil)
+        #
+        # Pass terminal: true when the request EXPLICITLY presented credentials
+        # (e.g. an Authorization header) that were examined and rejected.
+        # RouteAuthWrapper then halts the strategy chain and fails closed with
+        # 401 instead of consulting further strategies — so an anonymous-capable
+        # strategy later (or earlier) in the chain cannot silently accept the
+        # request as anonymous. Leave it false for missing credentials and for
+        # ambient credentials (session cookies), which should keep today's OR
+        # fallthrough. See AuthFailure.
+        def failure(reason = nil, terminal: false)
           Otto.logger.debug "[#{self.class}] Authentication failed: #{reason}" if reason
           Otto::Security::Authentication::AuthFailure.new(
             failure_reason: reason || 'Authentication failed',
-            auth_method: strategy_auth_method
+            auth_method: strategy_auth_method,
+            terminal: terminal
           )
         end
 

--- a/lib/otto/security/authentication/authorization_failure.rb
+++ b/lib/otto/security/authentication/authorization_failure.rb
@@ -26,6 +26,13 @@ class Otto
       # StrategyResult. This type covers the complementary case: a strategy that
       # owns authorization itself (including permission tiers, which Layer-1 does
       # not model) and needs to signal a 403 directly.
+      #
+      # DELIBERATELY has no `terminal` member (unlike AuthFailure): an
+      # authorization denial must not halt the strategy chain — a later
+      # strategy's success still wins (a different credential may well be
+      # permitted). When the chain DOES end in failure, a recorded denial
+      # already takes response precedence (403 over 401, even over a terminal
+      # halt), so there is nothing a terminal flag here would add.
       AuthorizationFailure = Data.define(:failure_reason, :auth_method) do
         # Authorization failures are not an authenticated request state. The
         # request never reaches the handler, so handler-facing predicates report

--- a/lib/otto/security/authentication/route_auth_wrapper.rb
+++ b/lib/otto/security/authentication/route_auth_wrapper.rb
@@ -25,7 +25,9 @@ class Otto
       # - ANONYMOUS success (StrategyResult with no user, e.g. from noauth) is
       #   held as a fallback while the rest of the chain runs. It wins once the
       #   chain completes without an authenticated success or terminal failure,
-      #   so credential-less requests still fall through to noauth.
+      #   so credential-less requests still fall through to noauth. When more
+      #   than one strategy produces an anonymous success, the first declared
+      #   is the fallback; later ones are deliberately ignored.
       # - Plain failures are recorded and the next strategy is consulted
       #   (OR logic). If everything fails, an AuthorizationFailure (valid
       #   credential, denied) yields 403; otherwise 401.
@@ -329,8 +331,9 @@ class Otto
               total_duration: total_duration,
               # Every strategy that ran, including the winner (already in
               # chain[:executed] by the time a success is handled) and any
-              # held anonymous fallback — not just the failures.
-              strategies_attempted: chain[:executed].size
+              # held anonymous fallback — not just the failures. Same array
+              # shape as the failure log so consumers see one type.
+              strategies_attempted: chain[:executed]
             ))
         end
 

--- a/lib/otto/security/authentication/route_auth_wrapper.rb
+++ b/lib/otto/security/authentication/route_auth_wrapper.rb
@@ -12,8 +12,23 @@ class Otto
       # This is the main orchestrator that:
       # - Sets anonymous StrategyResult for unauthenticated routes
       # - Enforces authentication for protected routes
-      # - Supports multi-strategy with OR logic (first success wins)
+      # - Supports multi-strategy with OR logic (first authenticated success wins)
       # - Performs Layer 1 (route-level) role authorization
+      #
+      # Multi-strategy chain semantics (in precedence order):
+      # - AUTHENTICATED success wins immediately; later strategies never run.
+      # - TERMINAL failure (AuthFailure with terminal: true — explicit
+      #   credentials examined and rejected) halts the chain and fails closed,
+      #   regardless of strategy order. An anonymous success from an
+      #   anonymous-capable strategy elsewhere in the chain does not rescue the
+      #   request. See AuthFailure.
+      # - ANONYMOUS success (StrategyResult with no user, e.g. from noauth) is
+      #   held as a fallback while the rest of the chain runs. It wins once the
+      #   chain completes without an authenticated success or terminal failure,
+      #   so credential-less requests still fall through to noauth.
+      # - Plain failures are recorded and the next strategy is consulted
+      #   (OR logic). If everything fails, an AuthorizationFailure (valid
+      #   credential, denied) yields 403; otherwise 401.
       #
       # @example Basic usage
       #   wrapper = RouteAuthWrapper.new(handler, route_def, auth_config)
@@ -53,7 +68,8 @@ class Otto
           validation_error = validate_strategies(auth_requirements, env)
           return validation_error if validation_error
 
-          # Try each strategy in order (first success wins)
+          # Try each strategy in order (first authenticated success wins;
+          # anonymous success is a fallback; terminal failure halts the chain)
           authenticate_and_authorize(env, extra_params, auth_requirements)
         end
 
@@ -85,6 +101,7 @@ class Otto
         # Main authentication and authorization flow
         def authenticate_and_authorize(env, extra_params, auth_requirements)
           failed_strategies = []
+          anonymous_fallback = nil
           total_start_time = Otto::Utils.now_in_μs
 
           auth_requirements.each do |requirement|
@@ -100,10 +117,22 @@ class Otto
             # Inject strategy_name into result
             result = result.with(strategy_name: strategy_name) if result.is_a?(StrategyResult)
 
-            # Handle authentication success
-            if result.is_a?(StrategyResult) && (result.authenticated? || result.anonymous?)
+            # Handle authenticated success - wins immediately
+            if authenticated_result?(result)
               return handle_auth_success(env, extra_params, result, strategy_name,
                                         duration, total_start_time, failed_strategies)
+            end
+
+            # An anonymous success (e.g. noauth) is held as a fallback rather
+            # than winning outright, so a credentialed strategy elsewhere in
+            # the chain still gets to examine explicitly presented credentials
+            # and reject them terminally, regardless of declaration order.
+            # When the chain completes without a terminal failure, the
+            # fallback wins (see below), preserving OR fallthrough for
+            # credential-less requests.
+            if anonymous_result?(result)
+              anonymous_fallback ||= { result: result, strategy_name: strategy_name, duration: duration }
+              next
             end
 
             # Handle a failure (authentication OR authorization) - record it and
@@ -113,15 +142,47 @@ class Otto
             next unless result.is_a?(AuthFailure) || result.is_a?(AuthorizationFailure)
 
             log_strategy_failure(env, strategy_name, result, duration, auth_requirements, requirement)
-            failed_strategies << {
-              strategy: strategy_name,
-              reason: result.failure_reason,
-              authorization: result.is_a?(AuthorizationFailure),
-            }
+
+            # A terminal failure means explicit credentials were examined and
+            # rejected: fail the whole chain closed (401) instead of letting an
+            # anonymous-capable strategy accept the request as anonymous.
+            if record_failure(failed_strategies, strategy_name, result)
+              return handle_all_strategies_failed(env, auth_requirements, failed_strategies,
+                                                  total_start_time, terminal: true)
+            end
+          end
+
+          # Chain completed without authenticated success or terminal failure:
+          # a held anonymous success wins (OR fallthrough to noauth et al.)
+          if anonymous_fallback
+            return handle_auth_success(env, extra_params, anonymous_fallback[:result],
+                                       anonymous_fallback[:strategy_name],
+                                       anonymous_fallback[:duration],
+                                       total_start_time, failed_strategies)
           end
 
           # All strategies failed
           handle_all_strategies_failed(env, auth_requirements, failed_strategies, total_start_time)
+        end
+
+        def authenticated_result?(result)
+          result.is_a?(StrategyResult) && result.authenticated?
+        end
+
+        def anonymous_result?(result)
+          result.is_a?(StrategyResult) && result.anonymous?
+        end
+
+        # Append the failure to the running list; returns true when it was terminal
+        def record_failure(failed_strategies, strategy_name, result)
+          terminal = result.is_a?(AuthFailure) && result.terminal?
+          failed_strategies << {
+            strategy: strategy_name,
+            reason: result.failure_reason,
+            authorization: result.is_a?(AuthorizationFailure),
+            terminal: terminal,
+          }
+          terminal
         end
 
         # Handle successful authentication
@@ -148,14 +209,16 @@ class Otto
           wrapped_handler.call(env, extra_params)
         end
 
-        # Handle case when all authentication strategies fail
-        def handle_all_strategies_failed(env, auth_requirements, failed_strategies, total_start_time)
+        # Handle case when authentication fails for the whole chain — either
+        # every strategy failed, or a terminal failure halted the chain early
+        # (terminal: true; remaining strategies were deliberately not consulted).
+        def handle_all_strategies_failed(env, auth_requirements, failed_strategies, total_start_time, terminal: false)
           total_duration = Otto::Utils.now_in_μs - total_start_time
 
-          log_all_failed(env, failed_strategies, total_duration)
+          log_all_failed(env, failed_strategies, total_duration, terminal: terminal)
 
           # Create anonymous result with failure info
-          metadata = build_failure_metadata(env, failed_strategies)
+          metadata = build_failure_metadata(env, failed_strategies, terminal: terminal)
           failure_strategy_name = determine_failure_strategy_name(auth_requirements, failed_strategies)
 
           env['otto.strategy_result'] = StrategyResult.anonymous(
@@ -167,14 +230,18 @@ class Otto
           # authenticated the subject but denied authorization (wrong role/missing
           # permission), respond 403 Forbidden rather than 401 — the subject IS
           # authenticated, they simply lack access. A bare 401 would (incorrectly)
-          # tell a logged-in client to re-authenticate.
+          # tell a logged-in client to re-authenticate. This precedence also holds
+          # on a terminal halt: the denial's 403 is the more specific outcome.
           authz_denial = failed_strategies.find { |f| f[:authorization] }
           return @response_builder.forbidden(env, authz_denial[:reason]) if authz_denial
 
+          # On a terminal halt the terminal failure is necessarily the last one
+          # recorded, so its reason is what gets rendered.
           last_failure = if failed_strategies.any?
                            AuthFailure.new(
                              failure_reason: failed_strategies.last[:reason],
-                             auth_method: failed_strategies.last[:strategy]
+                             auth_method: failed_strategies.last[:strategy],
+                             terminal: failed_strategies.last[:terminal] || false
                            )
                          else
                            AuthFailure.new(
@@ -194,13 +261,19 @@ class Otto
         end
 
         # Build metadata for failed authentication
-        def build_failure_metadata(env, failed_strategies)
+        def build_failure_metadata(env, failed_strategies, terminal: false)
+          failure_summary = if terminal
+                              'Authentication halted by terminal failure'
+                            else
+                              'All authentication strategies failed'
+                            end
           metadata = {
                           ip: env['otto.client_ip'] || env['REMOTE_ADDR'],
-                auth_failure: 'All authentication strategies failed',
+                auth_failure: failure_summary,
             attempted_strategies: failed_strategies.map { |f| f[:strategy] },
                  failure_reasons: failed_strategies.map { |f| f[:reason] },
           }
+          metadata[:terminal_failure] = true if terminal
           metadata[:country] = env['otto.privacy.geo_country'] if env['otto.privacy.geo_country']
           metadata
         end
@@ -251,12 +324,14 @@ class Otto
             ))
         end
 
-        def log_all_failed(env, failed_strategies, total_duration)
-          Otto.structured_log(:warn, 'All auth strategies failed',
+        def log_all_failed(env, failed_strategies, total_duration, terminal: false)
+          message = terminal ? 'Auth chain halted by terminal failure' : 'All auth strategies failed'
+          Otto.structured_log(:warn, message,
             Otto::LoggingHelpers.request_context(env).merge(
               strategies_attempted: failed_strategies.map { |f| f[:strategy] },
               total_duration: total_duration,
-              failure_count: failed_strategies.size
+              failure_count: failed_strategies.size,
+              terminal: terminal
             ))
         end
       end

--- a/lib/otto/security/authentication/route_auth_wrapper.rb
+++ b/lib/otto/security/authentication/route_auth_wrapper.rb
@@ -127,7 +127,7 @@ class Otto
             # Handle authenticated success - wins immediately
             if authenticated_result?(result)
               return handle_auth_success(env, extra_params, result, strategy_name,
-                                        duration, total_start_time, chain[:failed])
+                                        duration, total_start_time, chain)
             end
 
             # An anonymous success (e.g. noauth) is held as a fallback rather
@@ -146,7 +146,13 @@ class Otto
             # continue to the next strategy (OR logic; a later success still wins).
             # AuthorizationFailure (valid credential, denied) is tagged so the
             # final response is 403 instead of 401. See handle_all_strategies_failed.
-            next unless result.is_a?(AuthFailure) || result.is_a?(AuthorizationFailure)
+            # Anything else is a strategy-author bug (wrong return type): the
+            # chain skips it as if it failed without a reason, but leaves a
+            # trace — a silent drop makes those bugs hard to debug.
+            unless result.is_a?(AuthFailure) || result.is_a?(AuthorizationFailure)
+              log_unexpected_result(env, strategy_name, result)
+              next
+            end
 
             log_strategy_failure(env, strategy_name, result, duration, auth_requirements, requirement)
 
@@ -165,7 +171,7 @@ class Otto
             return handle_auth_success(env, extra_params, anonymous_fallback[:result],
                                        anonymous_fallback[:strategy_name],
                                        anonymous_fallback[:duration],
-                                       total_start_time, chain[:failed])
+                                       total_start_time, chain)
           end
 
           # All strategies failed
@@ -193,10 +199,10 @@ class Otto
         end
 
         # Handle successful authentication
-        def handle_auth_success(env, extra_params, result, strategy_name, duration, total_start_time, failed_strategies)
+        def handle_auth_success(env, extra_params, result, strategy_name, duration, total_start_time, chain)
           total_duration = Otto::Utils.now_in_μs - total_start_time
 
-          log_auth_success(env, strategy_name, result, duration, total_duration, failed_strategies)
+          log_auth_success(env, strategy_name, result, duration, total_duration, chain)
 
           # Set environment variables for controllers/logic
           env['otto.strategy_result'] = result
@@ -278,14 +284,10 @@ class Otto
         # reasons of strategies that FAILED, in failure order. The two arrays
         # are therefore not index-aligned.
         def build_failure_metadata(env, chain, terminal: false)
-          failure_summary = if terminal
-                              'Authentication halted by terminal failure'
-                            else
-                              'All authentication strategies failed'
-                            end
+          summary = terminal ? 'Authentication halted by terminal failure' : 'All authentication strategies failed'
           metadata = {
                           ip: env['otto.client_ip'] || env['REMOTE_ADDR'],
-                auth_failure: failure_summary,
+                auth_failure: summary,
             attempted_strategies: chain[:executed],
                  failure_reasons: chain[:failed].map { |f| f[:reason] },
           }
@@ -317,7 +319,7 @@ class Otto
             ))
         end
 
-        def log_auth_success(env, strategy_name, result, duration, total_duration, failed_strategies)
+        def log_auth_success(env, strategy_name, result, duration, total_duration, chain)
           Otto.structured_log(:info, 'Auth strategy result',
             Otto::LoggingHelpers.request_context(env).merge(
               strategy: strategy_name,
@@ -325,7 +327,10 @@ class Otto
               user_id: result.user_id,
               duration: duration,
               total_duration: total_duration,
-              strategies_attempted: failed_strategies.size + 1
+              # Every strategy that ran, including the winner (already in
+              # chain[:executed] by the time a success is handled) and any
+              # held anonymous fallback — not just the failures.
+              strategies_attempted: chain[:executed].size
             ))
         end
 
@@ -337,6 +342,14 @@ class Otto
               failure_reason: result.failure_reason,
               duration: duration,
               remaining_strategies: auth_requirements.size - auth_requirements.index(requirement) - 1
+            ))
+        end
+
+        def log_unexpected_result(env, strategy_name, result)
+          Otto.structured_log(:warn, 'Auth strategy returned unexpected type',
+            Otto::LoggingHelpers.request_context(env).merge(
+              strategy: strategy_name,
+              result_class: result.class.name
             ))
         end
 

--- a/lib/otto/security/authentication/route_auth_wrapper.rb
+++ b/lib/otto/security/authentication/route_auth_wrapper.rb
@@ -99,8 +99,14 @@ class Otto
         end
 
         # Main authentication and authorization flow
+        #
+        # chain tracks two views of the run: :executed is every strategy that
+        # ran (including one whose anonymous success is merely held as the
+        # fallback), :failed only those that returned a failure result. Failure
+        # metadata reports :executed as attempted_strategies so a terminal halt
+        # after a deferred anonymous success doesn't under-report what ran.
         def authenticate_and_authorize(env, extra_params, auth_requirements)
-          failed_strategies = []
+          chain = { failed: [], executed: [] }
           anonymous_fallback = nil
           total_start_time = Otto::Utils.now_in_μs
 
@@ -113,6 +119,7 @@ class Otto
             start_time = Otto::Utils.now_in_μs
             result = strategy.authenticate(env, requirement)
             duration = Otto::Utils.now_in_μs - start_time
+            chain[:executed] << strategy_name
 
             # Inject strategy_name into result
             result = result.with(strategy_name: strategy_name) if result.is_a?(StrategyResult)
@@ -120,7 +127,7 @@ class Otto
             # Handle authenticated success - wins immediately
             if authenticated_result?(result)
               return handle_auth_success(env, extra_params, result, strategy_name,
-                                        duration, total_start_time, failed_strategies)
+                                        duration, total_start_time, chain[:failed])
             end
 
             # An anonymous success (e.g. noauth) is held as a fallback rather
@@ -146,8 +153,8 @@ class Otto
             # A terminal failure means explicit credentials were examined and
             # rejected: fail the whole chain closed (401) instead of letting an
             # anonymous-capable strategy accept the request as anonymous.
-            if record_failure(failed_strategies, strategy_name, result)
-              return handle_all_strategies_failed(env, auth_requirements, failed_strategies,
+            if record_failure(chain[:failed], strategy_name, result)
+              return handle_all_strategies_failed(env, auth_requirements, chain,
                                                   total_start_time, terminal: true)
             end
           end
@@ -158,11 +165,11 @@ class Otto
             return handle_auth_success(env, extra_params, anonymous_fallback[:result],
                                        anonymous_fallback[:strategy_name],
                                        anonymous_fallback[:duration],
-                                       total_start_time, failed_strategies)
+                                       total_start_time, chain[:failed])
           end
 
           # All strategies failed
-          handle_all_strategies_failed(env, auth_requirements, failed_strategies, total_start_time)
+          handle_all_strategies_failed(env, auth_requirements, chain, total_start_time)
         end
 
         def authenticated_result?(result)
@@ -212,13 +219,16 @@ class Otto
         # Handle case when authentication fails for the whole chain — either
         # every strategy failed, or a terminal failure halted the chain early
         # (terminal: true; remaining strategies were deliberately not consulted).
-        def handle_all_strategies_failed(env, auth_requirements, failed_strategies, total_start_time, terminal: false)
+        # chain is the { failed:, executed: } state built by
+        # authenticate_and_authorize.
+        def handle_all_strategies_failed(env, auth_requirements, chain, total_start_time, terminal: false)
+          failed_strategies = chain[:failed]
           total_duration = Otto::Utils.now_in_μs - total_start_time
 
-          log_all_failed(env, failed_strategies, total_duration, terminal: terminal)
+          log_all_failed(env, chain, total_duration, terminal: terminal)
 
           # Create anonymous result with failure info
-          metadata = build_failure_metadata(env, failed_strategies, terminal: terminal)
+          metadata = build_failure_metadata(env, chain, terminal: terminal)
           failure_strategy_name = determine_failure_strategy_name(auth_requirements, failed_strategies)
 
           env['otto.strategy_result'] = StrategyResult.anonymous(
@@ -261,7 +271,13 @@ class Otto
         end
 
         # Build metadata for failed authentication
-        def build_failure_metadata(env, failed_strategies, terminal: false)
+        #
+        # attempted_strategies lists every strategy that EXECUTED (including
+        # one whose anonymous success was held as the fallback and then
+        # overruled by a terminal failure); failure_reasons lists only the
+        # reasons of strategies that FAILED, in failure order. The two arrays
+        # are therefore not index-aligned.
+        def build_failure_metadata(env, chain, terminal: false)
           failure_summary = if terminal
                               'Authentication halted by terminal failure'
                             else
@@ -270,8 +286,8 @@ class Otto
           metadata = {
                           ip: env['otto.client_ip'] || env['REMOTE_ADDR'],
                 auth_failure: failure_summary,
-            attempted_strategies: failed_strategies.map { |f| f[:strategy] },
-                 failure_reasons: failed_strategies.map { |f| f[:reason] },
+            attempted_strategies: chain[:executed],
+                 failure_reasons: chain[:failed].map { |f| f[:reason] },
           }
           metadata[:terminal_failure] = true if terminal
           metadata[:country] = env['otto.privacy.geo_country'] if env['otto.privacy.geo_country']
@@ -324,13 +340,13 @@ class Otto
             ))
         end
 
-        def log_all_failed(env, failed_strategies, total_duration, terminal: false)
+        def log_all_failed(env, chain, total_duration, terminal: false)
           message = terminal ? 'Auth chain halted by terminal failure' : 'All auth strategies failed'
           Otto.structured_log(:warn, message,
             Otto::LoggingHelpers.request_context(env).merge(
-              strategies_attempted: failed_strategies.map { |f| f[:strategy] },
+              strategies_attempted: chain[:executed],
               total_duration: total_duration,
-              failure_count: failed_strategies.size,
+              failure_count: chain[:failed].size,
               terminal: terminal
             ))
         end

--- a/spec/otto/security/route_auth_wrapper_spec.rb
+++ b/spec/otto/security/route_auth_wrapper_spec.rb
@@ -1629,6 +1629,62 @@ RSpec.describe Otto::Security::Authentication::RouteAuthWrapper do
       end
     end
 
+    context 'unexpected strategy return types' do
+      # A strategy returning something that is neither a StrategyResult nor a
+      # failure type is a strategy-author bug: the chain skips it (logging a
+      # warning) and continues, so the rest of the chain still decides the
+      # outcome.
+      let(:broken_strategy) do
+        Class.new(Otto::Security::Authentication::AuthStrategy) do
+          def authenticate(_env, _requirement)
+            :not_a_result
+          end
+        end.new
+      end
+
+      let(:broken_config) do
+        {
+          auth_strategies: {
+            'broken' => broken_strategy,
+            'basicauth' => credentialed_strategy,
+            'noauth' => counting_noauth,
+          },
+          login_path: '/signin',
+        }
+      end
+
+      it 'continues past the unexpected result to the rest of the chain' do
+        route = Otto::RouteDefinition.new('GET', '/thing', 'App#thing auth=broken,noauth response=json')
+        chain_wrapper = described_class.new(mock_handler, route, broken_config)
+
+        status, _headers, _body = chain_wrapper.call(mock_rack_env)
+
+        expect(status).to eq(200)
+        expect(noauth_calls.size).to eq(1)
+      end
+
+      it 'still fails closed when a later strategy rejects terminally' do
+        route = Otto::RouteDefinition.new('GET', '/thing', 'App#thing auth=broken,basicauth,noauth response=json')
+        chain_wrapper = described_class.new(mock_handler, route, broken_config)
+
+        env = mock_rack_env(headers: { 'Authorization' => 'Basic bogus' })
+        status, _headers, body = chain_wrapper.call(env)
+
+        expect(status).to eq(401)
+        expect(JSON.parse(body.first)['message']).to eq('Invalid credentials')
+      end
+
+      it 'returns 401 when the unexpected result is the whole chain' do
+        route = Otto::RouteDefinition.new('GET', '/thing', 'App#thing auth=broken response=json')
+        chain_wrapper = described_class.new(mock_handler, route, broken_config)
+
+        status, _headers, body = chain_wrapper.call(mock_rack_env)
+
+        expect(status).to eq(401)
+        expect(JSON.parse(body.first)['message']).to eq('Authentication required')
+      end
+    end
+
     context 'backward compatibility' do
       it 'defaults AuthFailure#terminal to false when constructed without it' do
         legacy = Otto::Security::Authentication::AuthFailure.new(

--- a/spec/otto/security/route_auth_wrapper_spec.rb
+++ b/spec/otto/security/route_auth_wrapper_spec.rb
@@ -952,15 +952,29 @@ RSpec.describe Otto::Security::Authentication::RouteAuthWrapper do
         described_class.new(mock_handler, noauth_route, multi_auth_config)
       end
 
-      it 'succeeds with first strategy (noauth) without trying others' do
+      it 'wins with the anonymous fallback (noauth) when the other strategies fail' do
         env = mock_rack_env
-        # No session, no API key - noauth always succeeds
+        # No session, no API key - noauth's anonymous success is held as a
+        # fallback while session/apikey run, then wins when neither succeeds
 
         status, _headers, body = noauth_wrapper.call(env)
 
         expect(status).to eq(200)
         expect(body).to eq(['handler called'])
         expect(env['otto.strategy_result'].strategy_name).to eq('noauth')
+      end
+
+      it 'lets a later authenticated strategy win over an earlier anonymous success' do
+        env = mock_rack_env(headers: { 'X-Api-Key' => 'valid_key' })
+        # noauth (first) yields an anonymous result, but apikey (last)
+        # authenticates - the authenticated result wins over the fallback
+
+        status, _headers, body = noauth_wrapper.call(env)
+
+        expect(status).to eq(200)
+        expect(body).to eq(['handler called'])
+        expect(env['otto.strategy_result']).to be_authenticated
+        expect(env['otto.strategy_result'].strategy_name).to eq('apikey')
       end
     end
   end
@@ -1365,6 +1379,227 @@ RSpec.describe Otto::Security::Authentication::RouteAuthWrapper do
         env = mock_rack_env(headers: { 'Accept' => 'application/json' })
         status, = multi_wrapper.call(env)
         expect(status).to eq(401)
+      end
+    end
+  end
+
+  describe 'terminal authentication failure (fail-closed chains)' do
+    # A credentialed strategy: plain (non-terminal) failure when no credentials
+    # were presented, terminal failure when explicitly presented credentials
+    # are examined and rejected. This is the contract that lets mixed
+    # credentialed/anonymous chains fail closed on invalid credentials while
+    # header-less requests still fall through to noauth.
+    let(:credentialed_strategy) do
+      Class.new(Otto::Security::Authentication::AuthStrategy) do
+        def authenticate(env, _requirement)
+          header = env['HTTP_AUTHORIZATION']
+          return failure('No credentials presented') unless header
+
+          if header == 'Basic valid'
+            success(user: { id: 'api-user' }, auth_method: 'basicauth')
+          else
+            failure('Invalid credentials', terminal: true)
+          end
+        end
+      end.new
+    end
+
+    let(:noauth_calls) { [] }
+
+    # NoAuthStrategy stand-in that records every invocation so specs can
+    # assert whether the chain consulted it after a terminal failure.
+    let(:counting_noauth) do
+      calls = noauth_calls
+      Class.new(Otto::Security::Authentication::AuthStrategy) do
+        define_method(:authenticate) do |_env, requirement|
+          calls << requirement
+          Otto::Security::Authentication::StrategyResult.anonymous(metadata: {})
+        end
+      end.new
+    end
+
+    let(:terminal_auth_config) do
+      {
+        auth_strategies: {
+          'basicauth' => credentialed_strategy,
+          'noauth' => counting_noauth,
+        },
+        login_path: '/signin',
+      }
+    end
+
+    context 'credentialed strategy first (auth=basicauth,noauth)' do
+      let(:route) do
+        Otto::RouteDefinition.new('POST', '/secret/conceal', 'Api#conceal auth=basicauth,noauth response=json')
+      end
+
+      let(:chain_wrapper) { described_class.new(mock_handler, route, terminal_auth_config) }
+
+      it 'falls through to noauth when no credentials are presented' do
+        env = mock_rack_env
+
+        status, _headers, body = chain_wrapper.call(env)
+
+        expect(status).to eq(200)
+        expect(body).to eq(['handler called'])
+        expect(env['otto.strategy_result'].anonymous?).to be true
+        expect(env['otto.strategy_result'].strategy_name).to eq('noauth')
+      end
+
+      it 'authenticates with valid credentials' do
+        env = mock_rack_env(headers: { 'Authorization' => 'Basic valid' })
+
+        status, _headers, _body = chain_wrapper.call(env)
+
+        expect(status).to eq(200)
+        expect(env['otto.strategy_result']).to be_authenticated
+      end
+
+      it 'fails closed with 401 on invalid credentials instead of degrading to anonymous' do
+        env = mock_rack_env(headers: { 'Authorization' => 'Basic bogus' })
+
+        status, headers, body = chain_wrapper.call(env)
+
+        expect(status).to eq(401)
+        expect(headers['content-type']).to eq('application/json')
+        data = JSON.parse(body.first)
+        expect(data['error']).to eq('Authentication Required')
+        expect(data['message']).to eq('Invalid credentials')
+      end
+
+      it 'does not consult later strategies after a terminal failure' do
+        env = mock_rack_env(headers: { 'Authorization' => 'Basic bogus' })
+
+        chain_wrapper.call(env)
+
+        expect(noauth_calls).to be_empty
+      end
+
+      it 'records the terminal halt in the strategy result metadata' do
+        env = mock_rack_env(headers: { 'Authorization' => 'Basic bogus' })
+
+        chain_wrapper.call(env)
+
+        result = env['otto.strategy_result']
+        expect(result.anonymous?).to be true
+        expect(result.metadata[:auth_failure]).to eq('Authentication halted by terminal failure')
+        expect(result.metadata[:terminal_failure]).to be true
+        expect(result.metadata[:attempted_strategies]).to eq(['basicauth'])
+        expect(result.metadata[:failure_reasons]).to eq(['Invalid credentials'])
+      end
+    end
+
+    context 'anonymous-capable strategy first (auth=noauth,basicauth)' do
+      # The ordering-independence guarantee: even when the anonymous-capable
+      # strategy is declared first (and produces its anonymous result before
+      # the credentialed strategy runs), a terminal failure still fails the
+      # chain closed.
+      let(:route) do
+        Otto::RouteDefinition.new('POST', '/secret/conceal', 'Api#conceal auth=noauth,basicauth response=json')
+      end
+
+      let(:chain_wrapper) { described_class.new(mock_handler, route, terminal_auth_config) }
+
+      it 'still fails closed with 401 on invalid credentials' do
+        env = mock_rack_env(headers: { 'Authorization' => 'Basic bogus' })
+
+        status, _headers, body = chain_wrapper.call(env)
+
+        expect(status).to eq(401)
+        expect(JSON.parse(body.first)['message']).to eq('Invalid credentials')
+        expect(noauth_calls).not_to be_empty # noauth ran first, its anonymous result did not rescue the request
+      end
+
+      it 'still proceeds as anonymous when no credentials are presented' do
+        env = mock_rack_env
+
+        status, _headers, _body = chain_wrapper.call(env)
+
+        expect(status).to eq(200)
+        expect(env['otto.strategy_result'].anonymous?).to be true
+        expect(env['otto.strategy_result'].strategy_name).to eq('noauth')
+      end
+
+      it 'still authenticates with valid credentials' do
+        env = mock_rack_env(headers: { 'Authorization' => 'Basic valid' })
+
+        status, _headers, _body = chain_wrapper.call(env)
+
+        expect(status).to eq(200)
+        expect(env['otto.strategy_result']).to be_authenticated
+      end
+    end
+
+    context 'noauth-only route' do
+      # Routes that deliberately ignore Authorization headers (reverse proxies,
+      # cached browser Basic credentials) must keep working: no credentialed
+      # strategy runs, so nothing can fail terminally.
+      let(:route) do
+        Otto::RouteDefinition.new('GET', '/guest/thing', 'Guest#thing auth=noauth response=json')
+      end
+
+      let(:noauth_wrapper) { described_class.new(mock_handler, route, terminal_auth_config) }
+
+      it 'ignores an Authorization header entirely' do
+        env = mock_rack_env(headers: { 'Authorization' => 'Basic bogus' })
+
+        status, _headers, _body = noauth_wrapper.call(env)
+
+        expect(status).to eq(200)
+        expect(env['otto.strategy_result'].anonymous?).to be true
+      end
+    end
+
+    context 'HTML routes' do
+      let(:route) do
+        Otto::RouteDefinition.new('POST', '/secret/conceal', 'Api#conceal auth=basicauth,noauth')
+      end
+
+      let(:chain_wrapper) { described_class.new(mock_handler, route, terminal_auth_config) }
+
+      it 'renders the terminal failure through the standard auth-failure path (302 to login)' do
+        env = mock_rack_env(headers: { 'Authorization' => 'Basic bogus', 'Accept' => 'text/html' })
+
+        status, headers, _body = chain_wrapper.call(env)
+
+        expect(status).to eq(302)
+        expect(headers['location']).to eq('/signin')
+      end
+    end
+
+    context 'backward compatibility' do
+      it 'defaults AuthFailure#terminal to false when constructed without it' do
+        legacy = Otto::Security::Authentication::AuthFailure.new(
+          failure_reason: 'nope',
+          auth_method: 'basicauth'
+        )
+
+        expect(legacy.terminal).to be false
+        expect(legacy.terminal?).to be false
+      end
+
+      it 'defaults AuthStrategy#failure to non-terminal' do
+        strategy = Class.new(Otto::Security::Authentication::AuthStrategy) do
+          def authenticate(_env, _requirement)
+            failure('nope')
+          end
+        end.new
+
+        result = strategy.authenticate({}, nil)
+        expect(result.terminal?).to be false
+      end
+
+      it 'builds a terminal AuthFailure via AuthStrategy#failure(reason, terminal: true)' do
+        strategy = Class.new(Otto::Security::Authentication::AuthStrategy) do
+          def authenticate(_env, _requirement)
+            failure('rejected', terminal: true)
+          end
+        end.new
+
+        result = strategy.authenticate({}, nil)
+        expect(result).to be_a(Otto::Security::Authentication::AuthFailure)
+        expect(result.terminal?).to be true
+        expect(result.failure_reason).to eq('rejected')
       end
     end
   end

--- a/spec/otto/security/route_auth_wrapper_spec.rb
+++ b/spec/otto/security/route_auth_wrapper_spec.rb
@@ -1567,6 +1567,56 @@ RSpec.describe Otto::Security::Authentication::RouteAuthWrapper do
       end
     end
 
+    context 'precedence against an authorization denial' do
+      # An earlier AuthorizationFailure (valid credential, denied -> 403) still
+      # wins the response over a later terminal AuthFailure (401), while the
+      # terminal failure still halts the chain before any anonymous-capable
+      # strategy runs.
+      let(:authz_denying_strategy) do
+        Class.new(Otto::Security::Authentication::AuthStrategy) do
+          def authenticate(_env, _requirement)
+            authorization_failure('Requires role: admin')
+          end
+        end.new
+      end
+
+      let(:precedence_config) do
+        {
+          auth_strategies: {
+            'roletoken' => authz_denying_strategy,
+            'basicauth' => credentialed_strategy,
+            'noauth' => counting_noauth,
+          },
+          login_path: '/signin',
+        }
+      end
+
+      let(:route) do
+        Otto::RouteDefinition.new('GET', '/api/admin', 'Api#admin auth=roletoken,basicauth,noauth response=json')
+      end
+
+      let(:chain_wrapper) { described_class.new(mock_handler, route, precedence_config) }
+
+      it 'renders the earlier 403 authorization denial over the later terminal 401' do
+        env = mock_rack_env(headers: { 'Authorization' => 'Basic bogus' })
+
+        status, _headers, body = chain_wrapper.call(env)
+
+        expect(status).to eq(403)
+        data = JSON.parse(body.first)
+        expect(data['error']).to eq('Forbidden')
+        expect(data['message']).to eq('Requires role: admin')
+      end
+
+      it 'still halts the chain at the terminal failure' do
+        env = mock_rack_env(headers: { 'Authorization' => 'Basic bogus' })
+
+        chain_wrapper.call(env)
+
+        expect(noauth_calls).to be_empty
+      end
+    end
+
     context 'backward compatibility' do
       it 'defaults AuthFailure#terminal to false when constructed without it' do
         legacy = Otto::Security::Authentication::AuthFailure.new(

--- a/spec/otto/security/route_auth_wrapper_spec.rb
+++ b/spec/otto/security/route_auth_wrapper_spec.rb
@@ -1510,6 +1510,18 @@ RSpec.describe Otto::Security::Authentication::RouteAuthWrapper do
         expect(noauth_calls).not_to be_empty # noauth ran first, its anonymous result did not rescue the request
       end
 
+      it 'reports every executed strategy in attempted_strategies, not just failures' do
+        env = mock_rack_env(headers: { 'Authorization' => 'Basic bogus' })
+
+        chain_wrapper.call(env)
+
+        result = env['otto.strategy_result']
+        # noauth executed (its anonymous success was held, then overruled by
+        # the terminal failure) so it must appear alongside basicauth
+        expect(result.metadata[:attempted_strategies]).to eq(%w[noauth basicauth])
+        expect(result.metadata[:failure_reasons]).to eq(['Invalid credentials'])
+      end
+
       it 'still proceeds as anonymous when no credentials are presented' do
         env = mock_rack_env
 


### PR DESCRIPTION
Closes #220.

## What

Makes chain short-circuiting a first-class concept in `RouteAuthWrapper`, per the proposal in #220:

- `AuthFailure` gains a `terminal` member (default `false`) with a `terminal?` predicate; keyword construction without it is unchanged.
- `AuthStrategy#failure` accepts `terminal: true`, meaning "this request explicitly presented credentials and they were examined and rejected — do not consult further strategies."
- `RouteAuthWrapper` halts the chain on a terminal failure and renders the 401 with that failure's reason. The failed-auth `StrategyResult` metadata records the halt (`auth_failure: 'Authentication halted by terminal failure'`, `terminal_failure: true`), and the structured log distinguishes a halt from an exhausted chain.

## Order independence

Stopping on a terminal failure isn't enough by itself: under first-success-wins, a chain like `auth=noauth,basicauth` would let noauth's anonymous success win before the credentialed strategy ever ran. So an **anonymous** success (a `StrategyResult` with no user) is now held as a fallback while the rest of the chain runs, instead of winning immediately:

- Authenticated success still wins immediately.
- Terminal failure fails the chain closed regardless of where either strategy sits.
- The held anonymous result wins once the chain completes without either of the above — so credential-less requests still fall through to `noauth`, and noauth-only routes (which deliberately ignore `Authorization` headers) are untouched.

One deliberate behavior change falls out of this: in a chain like `auth=noauth,apikey`, a later authenticated success now wins over an earlier anonymous one. Declaring a credentialed strategy after an anonymous one previously made it unreachable, so this reads as a fix rather than a break.

Existing precedence is preserved: `AuthorizationFailure` (valid credential, denied) still yields 403 over a 401, including on a terminal halt.

## Why

Invalid credentials on `auth=basicauth,noauth` routes previously became a 200 with no owner — indistinguishable from success to the caller. This bit onetimesecret in practice (onetimesecret/onetimesecret#3945): secrets created with mistyped API credentials were silently orphaned. With this change, onetimesecret's env-marker workaround collapses to `failure(reason, terminal: true)` and its `NoAuthStrategy` guard can be deleted.

## Testing

- New specs cover: fail-closed 401 in both chain orders, OR fallthrough for credential-less requests, noauth-only routes ignoring `Authorization`, terminal-halt metadata, HTML rendering path, and backward-compatible `AuthFailure`/`failure` construction.
- Full otto suite: 1926 examples, 0 failures.
- Integration check against onetimesecret (main, Ruby 3.4.9) with this branch of otto substituted via a local path override: `rake try:unit` 7168 passed / 0 failed, `rake spec:fast` 7539 examples / 0 failures (the only failures seen were sandbox artifacts — proxy-injected AWS env vars and a missing UTF-8 locale — and reproduced independently of this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrxDuuvfNojQ3W1b13J4Vm

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrxDuuvfNojQ3W1b13J4Vm)_