### PR TITLE
Record peer trust in otto.via_trusted_proxy for depth mode (#226)

### DIFF
--- a/changelog.d/20260807_120000_claude_depth_mode_peer_trust.rst
+++ b/changelog.d/20260807_120000_claude_depth_mode_peer_trust.rst
@@ -1,0 +1,16 @@
+Fixed
+-----
+
+- Depth mode now records a peer-trust verdict in
+  ``env['otto.via_trusted_proxy']``. Configuring ``trusted_proxy_depth >= 1``
+  forces an empty trusted-proxy matcher list (the modes are mutually
+  exclusive), which short-circuited the identity check to ``false`` on every
+  request — while ``REMOTE_ADDR`` was still rewritten to the resolved client
+  IP, leaving downstream middleware (e.g. forwarded-host handling) with no
+  trust signal at all. Configuring a depth is the operator's assertion that
+  the connecting peer is their proxy tier, so the peer is now trusted
+  whenever depth mode is active; ``Otto::Request#forwarded_by_trusted_proxy?``
+  (and therefore ``#secure?``'s X-Forwarded-Proto authorization) mirrors the
+  same grant on its no-middleware fallback path. Geo-header trust is
+  unchanged: it stays gated on enumerated CIDR matchers, since a hop trusted
+  by count cannot be verified as a geo-setting CDN. (#226)

--- a/docs/migrating/v2.3.0.md
+++ b/docs/migrating/v2.3.0.md
@@ -56,7 +56,11 @@ return `false` behind a TLS-terminating trusted proxy.
 The middleware now records the peer-trust decision once (before masking) in a
 leak-free boolean `env['otto.via_trusted_proxy']`, and `secure?` reads it.
 When the middleware has not run (standalone request use), `secure?` falls back
-to its previous behavior. No app changes are required.
+to the same decision the middleware would have recorded: a CIDR check of the
+connecting peer — or, since the depth-mode peer-trust fix
+([#226](https://github.com/delano/otto/issues/226), first release after
+2.7.0), an unconditional grant when `trusted_proxy_depth` is configured. No
+app changes are required.
 
 ### 3. Privacy helpers now return values (previously `nil`)
 
@@ -100,7 +104,7 @@ use `Otto::Request` standalone without the Otto middleware stack.
 | Key | Type | Meaning |
 |-----|------|---------|
 | `otto.client_ip` | String | Canonical client IP, resolved once. Masked when privacy is enabled; resolved real IP when disabled or exempt. Read by `Request#ip` / `#client_ipaddress`. |
-| `otto.via_trusted_proxy` | Boolean | Whether the request arrived via a trusted proxy, decided before masking. Read by `Request#secure?`. |
+| `otto.via_trusted_proxy` | Boolean | Whether the request arrived via a trusted proxy, decided before masking: `true` on a CIDR match — or unconditionally when depth mode is configured ([#226](https://github.com/delano/otto/issues/226), first release after 2.7.0). Read by `Request#secure?`. |
 
 The privacy data keys remain `otto.privacy.{fingerprint,masked_ip,hashed_ip,geo_country}`.
 
@@ -187,15 +191,21 @@ them). Which *multi-hop* header depth counts from — `X-Forwarded-For` (default
 the RFC 7239 `Forwarded` header, or `Both` — is configurable as of 2.3.1; see
 *Selecting the forwarded header* below.
 
-**`secure?` is independent of depth.** Depth mode resolves the client **IP**
-only; it does **not** grant proxy trust for `X-Forwarded-Proto` / `X-Scheme`.
-`env['otto.via_trusted_proxy']` — which `Otto::Request#secure?` consults to honor
-a forwarded proto — is derived solely from the trusted-proxy *identity* check
-(does `REMOTE_ADDR` match a configured `trusted_proxies` CIDR?), never from hop
-depth. Because depth mode and `trusted_proxies` are mutually exclusive, that
-check is `false` under depth, so `secure?` does not honor a forwarded proto and
-reflects only a direct TLS connection (`HTTPS=on` / port 443). This mirrors the
-downstream (OneTimeSecret) behavior: proto-trust is never derived from depth.
+**Depth grants peer trust ([#226](https://github.com/delano/otto/issues/226),
+first release after 2.7.0).** Configuring a depth asserts that the connecting
+peer *is* your proxy tier — that is what the setting means — so depth mode
+records `env['otto.via_trusted_proxy'] = true` on every request, and
+`Otto::Request#secure?` (which consults that flag) honors a forwarded
+`X-Forwarded-Proto` / `X-Scheme` in depth mode. Releases up to and including
+2.7.0 behaved differently: the flag was derived solely from the
+`trusted_proxies` CIDR identity check, which is always empty under depth
+(the modes are mutually exclusive), so it was recorded `false` and `secure?`
+reflected only a direct TLS connection (`HTTPS=on` / port 443). Because the
+grant is unconditional, the *origin lockdown* prerequisite below now covers
+proto trust exactly as it covers IP resolution. Geo headers are unaffected:
+they remain gated on enumerated `trusted_proxies` matchers and are still
+**not** trusted in depth mode (a hop trusted by count cannot be verified as a
+geo-setting CDN).
 
 ### Selecting the forwarded header (added in 2.3.1)
 
@@ -249,9 +259,10 @@ Otto.new(routes, trusted_proxy_depth: 1, trusted_proxy_header: 'Forwarded')
 This is the inherent trade-off versus CIDR-walk: depth relies on a fixed network
 **topology** instead of enumerable proxy **addresses**. If a client can reach
 your app directly (origin not locked down), it can pad `X-Forwarded-For` so that
-a forged value lands at `chain[-(N+1)]`, spoofing the resolved client IP. (Proto
-trust is unaffected — depth never feeds `secure?` — but the resolved IP is only
-as trustworthy as the lockdown.)
+a forged value lands at `chain[-(N+1)]`, spoofing the resolved client IP. (Since
+[#226](https://github.com/delano/otto/issues/226) this applies to proto trust
+too: depth grants `otto.via_trusted_proxy`, so a directly-reachable origin
+could spoof the scheme via `X-Forwarded-Proto` as well as the client IP.)
 
 Before enabling depth, ensure the origin only accepts connections from the proxy
 tier (private networking, security groups, an authenticating header the proxy

--- a/lib/otto/env_keys.rb
+++ b/lib/otto/env_keys.rb
@@ -74,12 +74,15 @@ class Otto
     # Whether the request arrived via a trusted proxy.
     # Type: Boolean
     # Set by: IPPrivacyMiddleware (every request, evaluated on the original
-    #   peer BEFORE REMOTE_ADDR is masked). This is the trusted-proxy identity
-    #   check (does REMOTE_ADDR match a configured trusted_proxies CIDR?) — it is
-    #   independent of count-based depth mode, which resolves the client IP but
-    #   never grants proxy trust for forwarded proto.
+    #   peer BEFORE REMOTE_ADDR is masked). True when the peer matches a
+    #   configured trusted_proxies CIDR (filter mode), or unconditionally when
+    #   count-based depth mode is active (trusted_proxy_depth >= 1) — the modes
+    #   are mutually exclusive, and configuring a depth is the operator's
+    #   assertion that the connecting peer is their proxy tier (#226).
     # Used by: Otto::Request#secure? to authorize X-Forwarded-Proto / X-Scheme
-    #   without depending on the (masked) REMOTE_ADDR
+    #   without depending on the (masked) REMOTE_ADDR, and by downstream
+    #   middleware (e.g. forwarded-host handling) as the peer-trust signal now
+    #   that REMOTE_ADDR no longer identifies the connecting peer
     VIA_TRUSTED_PROXY = 'otto.via_trusted_proxy'
 
     # Whether the connecting peer was the loopback interface.

--- a/lib/otto/request.rb
+++ b/lib/otto/request.rb
@@ -245,15 +245,21 @@ class Otto
     # to evaluating the current REMOTE_ADDR when the middleware has not run
     # (standalone request use).
     #
-    # This is the trusted-proxy *identity* check only and is independent of
-    # count-based depth mode: depth resolves the client IP but never grants
-    # proxy trust for X-Forwarded-Proto.
+    # A peer earns trust two ways (#226): its identity matches a configured
+    # trusted-proxy CIDR (filter mode), or count-based depth mode is active —
+    # configuring a depth asserts the connecting peer is the operator's
+    # (non-enumerable) proxy tier. The fallback mirrors the grant
+    # IPPrivacyMiddleware records so the two paths cannot disagree.
     #
     # @return [Boolean]
     def forwarded_by_trusted_proxy?
       return env['otto.via_trusted_proxy'] if env.key?('otto.via_trusted_proxy')
 
-      otto_security_config ? trusted_proxy?(env['REMOTE_ADDR']) : false
+      config = otto_security_config
+      return false unless config
+      return true if config.trusted_proxy_depth_mode?
+
+      trusted_proxy?(env['REMOTE_ADDR'])
     end
 
     # See: http://stackoverflow.com/questions/10013812/how-to-prevent-jquery-ajax-from-following-a-redirect-after-a-post

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -219,12 +219,11 @@ class Otto
 
       # Whether any trusted-proxy IP/CIDR/Regexp matchers are configured.
       #
-      # This mirrors {#trusted_proxy?}, which consults the same matcher list, so
-      # the two answers stay consistent: a request can only be "via a trusted
-      # proxy" when matchers exist. It deliberately EXCLUDES count-based depth
-      # mode — depth resolves the client IP but never confers proxy identity
-      # trust (the same decoupling {Otto::Request#forwarded_by_trusted_proxy?}
-      # applies to X-Forwarded-Proto). Used to gate geo-header trust.
+      # This mirrors {#trusted_proxy?}, which consults the same matcher list.
+      # It deliberately EXCLUDES count-based depth mode: depth grants the peer
+      # blanket trust for otto.via_trusted_proxy (#226), but it cannot verify
+      # that the hop is a geo-setting CDN, so header-based geo stays gated on
+      # enumerated matchers only. Used to gate geo-header trust.
       #
       # @return [Boolean] true when at least one trusted-proxy matcher exists
       def trusted_proxies_configured?

--- a/lib/otto/security/middleware/ip_privacy_middleware.rb
+++ b/lib/otto/security/middleware/ip_privacy_middleware.rb
@@ -62,10 +62,14 @@ class Otto
           # secure? can authorize X-Forwarded-Proto canonically even after
           # REMOTE_ADDR is rewritten to the masked client IP. Leak-free boolean.
           #
-          # This is the trusted-proxy *identity* check only — it is deliberately
-          # independent of count-based depth mode. Depth resolves the client IP;
-          # it never grants proxy trust for X-Forwarded-Proto (matching the
-          # downstream OneTimeSecret behavior).
+          # A peer earns trust two ways (see #trusted_proxy?): its identity
+          # matches a configured trusted-proxy CIDR, or count-based depth mode
+          # is active — configuring a depth asserts the connecting peer IS the
+          # operator's proxy tier. Depth mode has no CIDR matchers (the modes
+          # are mutually exclusive), so without that grant this key would be
+          # false on every depth-mode request while REMOTE_ADDR below is
+          # rewritten to the resolved client IP, leaving downstream middleware
+          # with no peer-trust signal at all (#226).
           env['otto.via_trusted_proxy'] = trusted_proxy?(env['REMOTE_ADDR'])
 
           # Same rationale, for loopback: this middleware runs outermost, so a
@@ -420,12 +424,20 @@ class Otto
           Otto.logger.debug "[IPPrivacyMiddleware] Masked forwarded headers" if Otto.debug
         end
 
-        # Check if an IP is from a trusted proxy
+        # Check if the connecting peer counts as a trusted proxy
+        #
+        # CIDR filter mode checks the peer's identity against the configured
+        # matchers. Count-based depth mode has no enumerable matchers — the
+        # depth setting itself is the operator's assertion that the peer is
+        # their proxy tier — so an active depth grants peer trust outright
+        # (#226). Geo-header trust is unaffected: geo_headers_trusted? gates on
+        # trusted_proxies_configured?, which stays matcher-only.
         #
         # @param ip [String] IP address to check
         # @return [Boolean] true if IP is from a trusted proxy
         def trusted_proxy?(ip)
           return false unless @security_config
+          return true if @security_config.trusted_proxy_depth_mode?
 
           @security_config.trusted_proxy?(ip)
         end

--- a/spec/otto/ip_harmonization_spec.rb
+++ b/spec/otto/ip_harmonization_spec.rb
@@ -219,14 +219,41 @@ RSpec.describe 'IP resolution harmonization (otto#58 / OTS#3436)' do
         expect(env['REMOTE_ADDR']).to eq('203.0.113.0')
       end
 
-      it 'leaves otto.via_trusted_proxy false (proto-trust is decoupled from depth)' do
-        # Depth resolves the client IP, but via_trusted_proxy is the CIDR
-        # identity check only — never derived from depth. No CIDRs configured
-        # (and depth is mutually exclusive with them), so it stays false.
+      it 'records peer trust in otto.via_trusted_proxy (otto#226)' do
+        # Depth mode has no CIDR matchers (the modes are mutually exclusive),
+        # so the empty-matcher identity check would always say false while
+        # REMOTE_ADDR is rewritten to the resolved client — leaving downstream
+        # middleware no trust signal at all. Configuring a depth asserts the
+        # connecting peer is the operator's proxy tier, so the peer is trusted.
         env = { 'REMOTE_ADDR' => '198.51.100.1', 'HTTP_X_FORWARDED_FOR' => '203.0.113.50' }
         middleware.call(env)
 
-        expect(env['otto.via_trusted_proxy']).to be false
+        expect(env['otto.via_trusted_proxy']).to be true
+      end
+
+      it 'records peer trust even when the forwarded chain is short (peer fallback)' do
+        # The trust verdict is about the PEER, not the resolved client:
+        # a chain too short for the configured depth falls back to REMOTE_ADDR
+        # for the client IP, but the peer is still asserted to be the proxy tier.
+        env = { 'REMOTE_ADDR' => '198.51.100.1' }
+        middleware.call(env)
+
+        expect(env['otto.via_trusted_proxy']).to be true
+      end
+
+      it 'still withholds geo-header trust in depth mode' do
+        # via_trusted_proxy is a peer-trust signal; geo-header trust stays
+        # gated on enumerated matchers (trusted_proxies_configured?), because
+        # a hop trusted by count cannot be verified as a geo-setting CDN.
+        env = {
+          'REMOTE_ADDR' => '198.51.100.1',
+          'HTTP_X_FORWARDED_FOR' => '203.0.113.50',
+          'HTTP_CF_IPCOUNTRY' => 'GB',
+        }
+        middleware.call(env)
+
+        expect(env['otto.via_trusted_proxy']).to be true
+        expect(env['otto.privacy.geo_country']).not_to eq('GB')
       end
     end
   end
@@ -287,12 +314,14 @@ RSpec.describe 'IP resolution harmonization (otto#58 / OTS#3436)' do
         expect(req.client_ipaddress).to eq('203.0.113.50')
       end
 
-      it '#secure? does not honor X-Forwarded-Proto in depth mode (proto-trust decoupled)' do
-        # Depth never grants proxy trust for forwarded proto; with no CIDR
-        # identity match, secure? reflects only a direct TLS connection.
+      it '#secure? honors X-Forwarded-Proto in depth mode (peer trusted by depth)' do
+        # Configuring a depth asserts the connecting peer is the operator's
+        # proxy tier (otto#226), so its forwarded proto is authorized — same
+        # grant the middleware records in otto.via_trusted_proxy, mirrored on
+        # this no-middleware fallback path so the two cannot disagree.
         req = depth_request('REMOTE_ADDR' => '198.51.100.1', 'HTTP_X_FORWARDED_PROTO' => 'https')
 
-        expect(req.secure?).to be false
+        expect(req.secure?).to be true
       end
     end
 


### PR DESCRIPTION
Fixes #226. Upstream half of onetimesecret/onetimesecret#4024, following the 2026-08-05 trusted-proxy custom-domain incident (onetimesecret/onetimesecret#4021).

## Problem

Depth mode (`trusted_proxy_depth >= 1`) forces an empty trusted-proxy matcher list (the modes are mutually exclusive), so `Otto::Security::Config#trusted_proxy?` short-circuited to `false` on every request. `IPPrivacyMiddleware` therefore recorded `otto.via_trusted_proxy = false` while still rewriting `REMOTE_ADDR` to the resolved client IP — downstream middleware was left with no peer-trust signal at all. In OneTimeSecret this made `Rack::DetectHost` discard forwarded host headers in depth mode, classifying every custom domain as canonical.

## Fix (option 1 from the issue)

Configuring a depth is the operator's assertion that the connecting peer is their (non-enumerable) proxy tier, so the peer is treated as trusted whenever depth mode is active. This keeps the signal a leak-free boolean rather than exposing the pre-rewrite peer address in env (option 2), consistent with the middleware's privacy design.

- `IPPrivacyMiddleware#trusted_proxy?` grants peer trust outright when `trusted_proxy_depth_mode?` is active, so `otto.via_trusted_proxy` is `true` on every depth-mode request (recorded pre-mask, as before).
- `Otto::Request#forwarded_by_trusted_proxy?` mirrors the same grant on its no-middleware fallback path, so `#secure?` now authorizes `X-Forwarded-Proto` / `X-Scheme` in depth mode and the two paths cannot disagree.
- **Geo-header trust is deliberately unchanged**: `geo_headers_trusted?` stays gated on `trusted_proxies_configured?` (enumerated matchers only), because a hop trusted by count cannot be verified as a geo-setting CDN.
- Updated `EnvKeys::VIA_TRUSTED_PROXY` docs, the now-stale "decoupled from depth" comments, and added a scriv changelog fragment.

## Tests

- Flipped the two specs that pinned the old decoupling (`ip_harmonization_spec.rb`: middleware depth-mode key, and standalone `#secure?` in depth mode).
- Added coverage: depth mode records peer trust with and without a forwarded chain (short-chain peer fallback), and geo headers remain untrusted in depth mode.
- Full suite: 2044 examples, 0 failures.

## Downstream

`try/integration/middleware/detect_host_ip_privacy_stack_try.rb` in onetimesecret pins the old behavior as a KNOWN LIMITATION and will deliberately fail once this lands in a release, prompting removal of the workaround. The depth-value `+1` remap (#151) is addressed in the stacked follow-ups: **#228** (stacked on this PR) hardens the trust signal to tri-state and corrects the depth-porting docs, and **onetimesecret#4028** drops the `+1` itself with padding-resistance tests — see the reconciliation note on #151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJ6BDA3VXsTtToXKp2To1x