### PR TITLE
Support error handler inheritance via ancestor chain matching

### DIFF
--- a/lib/otto/core/error_handler.rb
+++ b/lib/otto/core/error_handler.rb
@@ -11,8 +11,8 @@ class Otto
     # Error handling module providing secure error reporting and logging functionality
     module ErrorHandler
       def handle_error(error, env)
-        # Check if this is a registered expected error
-        if handler_config = @error_handlers[error.class.name]
+        # Check if this is a registered expected error (exact match first, then ancestors)
+        if handler_config = find_error_handler(error)
           return handle_expected_error(error, env, handler_config)
         end
 
@@ -115,6 +115,19 @@ class Otto
       end
 
       private
+
+      # Find the best matching error handler by walking the exception's ancestor chain.
+      # Returns the handler config for the most specific registered class, or nil.
+      def find_error_handler(error)
+        error.class.ancestors.each do |klass|
+          break unless klass.is_a?(Class)
+
+          if handler_config = @error_handlers[klass.name]
+            return handler_config
+          end
+        end
+        nil
+      end
 
       # Register all Otto framework error classes with appropriate status codes
       #

--- a/lib/otto/core/error_handler.rb
+++ b/lib/otto/core/error_handler.rb
@@ -120,7 +120,7 @@ class Otto
       # Returns the handler config for the most specific registered class, or nil.
       def find_error_handler(error)
         error.class.ancestors.each do |klass|
-          break unless klass.is_a?(Class)
+          next unless klass.is_a?(Class)
 
           if handler_config = @error_handlers[klass.name]
             return handler_config

--- a/spec/otto/error_handler_registration_spec.rb
+++ b/spec/otto/error_handler_registration_spec.rb
@@ -435,4 +435,76 @@ RSpec.describe Otto, 'Error Handler Registration' do
       expect(response[0]).to eq(400)
     end
   end
+
+  describe 'ancestor chain matching' do
+    # Simulate a downstream app subclassing Otto errors
+    class AppNotFoundError < Otto::NotFoundError; end
+    class AppSpecificNotFoundError < AppNotFoundError; end
+
+    class AppForbiddenError < Otto::ForbiddenError; end
+
+    it 'catches subclass with handler registered for parent class' do
+      error = AppNotFoundError.new('Widget not found')
+      allow(Otto.logger).to receive(:info)
+
+      response = test_app.send(:handle_error, error, env)
+
+      expect(response[0]).to eq(404)
+    end
+
+    it 'catches deeply nested subclass via ancestor chain' do
+      error = AppSpecificNotFoundError.new('Specific widget not found')
+      allow(Otto.logger).to receive(:info)
+
+      response = test_app.send(:handle_error, error, env)
+
+      expect(response[0]).to eq(404)
+    end
+
+    it 'prefers the most specific registered handler' do
+      test_app.register_error_handler(AppNotFoundError, status: 410, log_level: :warn)
+
+      error = AppNotFoundError.new('Widget gone')
+      allow(Otto.logger).to receive(:warn)
+
+      response = test_app.send(:handle_error, error, env)
+
+      expect(response[0]).to eq(410)
+    end
+
+    it 'falls back to parent handler when no exact match exists' do
+      test_app.register_error_handler(AppNotFoundError, status: 410, log_level: :warn)
+
+      error = AppSpecificNotFoundError.new('Specific widget gone')
+      allow(Otto.logger).to receive(:warn)
+
+      response = test_app.send(:handle_error, error, env)
+
+      expect(response[0]).to eq(410)
+    end
+
+    it 'uses parent handler block for subclass errors' do
+      test_app.register_error_handler(AppForbiddenError, status: 403, log_level: :warn) do |error, _req|
+        { error: 'CustomForbidden', message: error.message, custom: true }
+      end
+
+      error = AppForbiddenError.new('No access')
+      allow(Otto.logger).to receive(:warn)
+
+      response = test_app.send(:handle_error, error, env)
+      body = JSON.parse(response[2].first)
+
+      expect(response[0]).to eq(403)
+      expect(body['custom']).to eq(true)
+    end
+
+    it 'still falls through to 500 for unrelated errors' do
+      error = RuntimeError.new('Something unexpected')
+      allow(Otto.logger).to receive(:error)
+
+      response = test_app.send(:handle_error, error, env)
+
+      expect(response[0]).to eq(500)
+    end
+  end
 end

--- a/spec/otto/error_handler_registration_spec.rb
+++ b/spec/otto/error_handler_registration_spec.rb
@@ -441,6 +441,11 @@ RSpec.describe Otto, 'Error Handler Registration' do
     class AppNotFoundError < Otto::NotFoundError; end
     class AppSpecificNotFoundError < AppNotFoundError; end
 
+    module AppErrorContext; end
+    class AppMixedInNotFoundError < AppNotFoundError
+      include AppErrorContext
+    end
+
     class AppForbiddenError < Otto::ForbiddenError; end
 
     it 'catches subclass with handler registered for parent class' do
@@ -476,6 +481,17 @@ RSpec.describe Otto, 'Error Handler Registration' do
       test_app.register_error_handler(AppNotFoundError, status: 410, log_level: :warn)
 
       error = AppSpecificNotFoundError.new('Specific widget gone')
+      allow(Otto.logger).to receive(:warn)
+
+      response = test_app.send(:handle_error, error, env)
+
+      expect(response[0]).to eq(410)
+    end
+
+    it 'falls back to a superclass handler when the error includes a module' do
+      test_app.register_error_handler(AppNotFoundError, status: 410, log_level: :warn)
+
+      error = AppMixedInNotFoundError.new('Mixed-in widget gone')
       allow(Otto.logger).to receive(:warn)
 
       response = test_app.send(:handle_error, error, env)


### PR DESCRIPTION
## Summary
This change enables Otto's error handler system to match handlers registered for parent error classes when handling subclasses of those errors. Previously, only exact class name matches were supported, requiring separate handler registrations for each error subclass.

## Key Changes
- **Modified `handle_error` method** in `lib/otto/core/error_handler.rb` to use a new `find_error_handler` method instead of direct hash lookup by class name
- **Added `find_error_handler` method** that walks the exception's ancestor chain to find the most specific registered handler, enabling inheritance-based matching
- **Added comprehensive test coverage** in `spec/otto/error_handler_registration_spec.rb` with 6 new test cases validating:
  - Basic subclass handler matching
  - Deeply nested subclass handling
  - Preference for most specific registered handlers
  - Fallback to parent handlers when no exact match exists
  - Custom handler blocks working with subclass errors
  - Unrelated errors still falling through to 500 status

## Implementation Details
The `find_error_handler` method iterates through `error.class.ancestors` to find the first registered handler, ensuring the most specific (closest to the actual error class) handler is used. This maintains backward compatibility while enabling more flexible error handling hierarchies for downstream applications that subclass Otto's built-in error classes.

https://claude.ai/code/session_01TJT19MX65et3tqSmCd4vbY