### PR TITLE
Make concurrency spec deterministic

### DIFF
--- a/spec/otto/error_handler_registration_spec.rb
+++ b/spec/otto/error_handler_registration_spec.rb
@@ -511,7 +511,7 @@ RSpec.describe Otto, 'Error Handler Registration' do
       body = JSON.parse(response[2].first)
 
       expect(response[0]).to eq(403)
-      expect(body['custom']).to eq(true)
+      expect(body['custom']).to be(true)
     end
 
     it 'still falls through to 500 for unrelated errors' do

--- a/spec/otto/route_class_otto_accessor_spec.rb
+++ b/spec/otto/route_class_otto_accessor_spec.rb
@@ -38,16 +38,27 @@ RSpec.describe Otto::Route::ClassMethods do
     # Two "requests" for two different Otto instances dispatch through the
     # same target class concurrently. With a plain class ivar, thread_b's
     # assignment clobbers thread_a's for the duration of thread_a's request.
+    #
+    # The interleaving is forced deterministically with Queue handoffs (no
+    # sleep-based timing, which flakes on loaded CI): thread_a assigns, THEN
+    # thread_b assigns (which would overwrite a shared slot), and only THEN
+    # thread_a reads back — so a shared ivar would make thread_a observe
+    # otto_b. Fiber/thread-local storage keeps each thread on its own value.
+    a_assigned = Queue.new
+    b_assigned = Queue.new
+
     thread_a = Thread.new do
       target_class.otto = otto_a
-      sleep 0.05
+      a_assigned.push(true)   # let thread_b assign now
+      b_assigned.pop          # wait until thread_b has assigned (would clobber)
       observed_a = target_class.otto
     end
 
     thread_b = Thread.new do
-      sleep 0.02
+      a_assigned.pop          # wait until thread_a has assigned
       target_class.otto = otto_b
       observed_b = target_class.otto
+      b_assigned.push(true)   # release thread_a to read back
     end
 
     [thread_a, thread_b].each(&:join)

--- a/spec/otto/route_class_otto_accessor_spec.rb
+++ b/spec/otto/route_class_otto_accessor_spec.rb
@@ -48,20 +48,29 @@ RSpec.describe Otto::Route::ClassMethods do
     b_assigned = Queue.new
 
     thread_a = Thread.new do
-      target_class.otto = otto_a
-      a_assigned.push(true)   # let thread_b assign now
+      begin
+        target_class.otto = otto_a
+      ensure
+        a_assigned.push(true) # let thread_b assign now
+      end
+
       b_assigned.pop          # wait until thread_b has assigned (would clobber)
       observed_a = target_class.otto
     end
 
     thread_b = Thread.new do
       a_assigned.pop          # wait until thread_a has assigned
-      target_class.otto = otto_b
-      observed_b = target_class.otto
-      b_assigned.push(true)   # release thread_a to read back
+
+      begin
+        target_class.otto = otto_b
+        observed_b = target_class.otto
+      ensure
+        b_assigned.push(true) # release thread_a to read back
+      end
     end
 
     [thread_a, thread_b].each(&:join)
+    [thread_a, thread_b].each(&:value)
 
     expect(observed_a).to eq(otto_a)
     expect(observed_b).to eq(otto_b)

--- a/spec/otto/security/csp/policy_spec.rb
+++ b/spec/otto/security/csp/policy_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Otto::Security::CSP::Policy do
 
     it 'supports proxied and direct Vite scripts without allowing arbitrary inline scripts' do
       script_src = described_class.nonce_policy('N', development_mode: true)
-                   .split('; ').find { |directive| directive.start_with?('script-src ') }
+                                  .split('; ').find { |directive| directive.start_with?('script-src ') }
 
       expect(script_src).to eq("script-src 'self' 'nonce-N' http: https:")
     end


### PR DESCRIPTION
## Summary
- Replace timing-dependent sleeps in the route-class Otto accessor concurrency spec with ordered Queue handoffs, making the shared-state regression scenario deterministic on loaded CI.
- Propagate thread failures with Thread#value and retain coverage that separate Otto instances remain isolated across concurrent dispatches.
- Apply small RSpec style and indentation cleanups in adjacent specs.

## Review guide
- Start with spec/otto/route_class_otto_accessor_spec.rb; verify the Queue ordering forces the write/read interleaving that a shared class instance variable would fail.
- This is test-only: it does not change runtime behavior, public APIs, or configuration.

## Validation
- Pre-commit, pre-push, and CI checks will validate this change.

Related to #188