### PR TITLE
Request-scoped CSP directive extras (opt-in, additive, drop-and-log)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    otto (2.8.1)
+    otto (2.9.0.pre1)
       concurrent-ruby (~> 1.3, < 2.0)
       logger (~> 1, < 2.0)
       loofah (~> 2.20)

--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ end
 Without the opt-in, the env key is ignored entirely — no sanitization, no
 logs. The `Writer::Result` returned by the emission surfaces reports what
 actually happened: `result.extra_directives` carries only the extras that
-landed in the policy (entries dropped because their directive was absent are
-excluded, and logged with request context instead).
+landed in the policy; rejected or dropped entries are excluded and logged with
+request context instead.
 
 The extras channel is **additive-only** and deliberately narrow:
 
@@ -170,10 +170,11 @@ The extras channel is **additive-only** and deliberately narrow:
   the policy (`form-action` does not fall back to `default-src`), and
   re-adding one would resurrect a deliberate removal.
 - Directives that take **no value** (`upgrade-insecure-requests`,
-  `block-all-mixed-content`) are left byte-identical and their entry is
-  dropped: a source appended there would emit
-  `upgrade-insecure-requests https://…`, which browsers treat as malformed and
-  discard — an extras key would silently switch the directive *off*.
+  `block-all-mixed-content`) are refused during sanitization: a source appended
+  there would emit `upgrade-insecure-requests https://…`, which browsers treat
+  as malformed and discard — an extras key would silently switch the directive
+  *off*. The policy assembler independently leaves such directives
+  byte-identical for direct callers that bypass the sanitizer.
 - Only **origins** are accepted: `scheme://host[:port]` with an http(s) scheme
   — no keywords (`'self'`, `'unsafe-inline'`), no scheme sources (`data:`,
   `https:`), no wildcards, no paths, nothing that could smuggle a separator.

--- a/README.md
+++ b/README.md
@@ -169,6 +169,11 @@ The extras channel is **additive-only** and deliberately narrow:
   by a boot override) is dropped — creating one at request time would tighten
   the policy (`form-action` does not fall back to `default-src`), and
   re-adding one would resurrect a deliberate removal.
+- Directives that take **no value** (`upgrade-insecure-requests`,
+  `block-all-mixed-content`) are left byte-identical and their entry is
+  dropped: a source appended there would emit
+  `upgrade-insecure-requests https://…`, which browsers treat as malformed and
+  discard — an extras key would silently switch the directive *off*.
 - Only **origins** are accepted: `scheme://host[:port]` with an http(s) scheme
   — no keywords (`'self'`, `'unsafe-inline'`), no scheme sources (`data:`,
   `https:`), no wildcards, no paths, nothing that could smuggle a separator.

--- a/README.md
+++ b/README.md
@@ -129,7 +129,50 @@ result.skip_reason     # => nil (or :disabled / :blank_nonce / :non_html / :exis
 
 Apps with an existing nonce env-key convention can point the accessor at it with
 `app.security_config.csp_nonce_key = 'onetime.nonce'` — the views and the header
-still share one value.
+still share one value. Boot-time policy shaping goes through
+`security_config.csp_directive_overrides = { 'worker-src' => "'self' data: blob:" }`,
+which replaces (or with `nil`, removes) a directive's sources wholesale.
+
+#### Request-scoped directive extras
+
+Some directive values only exist at request time — the canonical case is a
+multi-tenant app that must allow the resolved tenant's SSO IdP origin in
+`form-action`. For that, a handler (or middleware) writes a hash of directive
+name => additional source tokens to the env before the response is finalized:
+
+```ruby
+def signin(req, res)
+  idp_origin = resolve_tenant(req).idp_origin  # e.g. "https://login.example-idp.com"
+  req.env['otto.csp.extra_directives'] = { 'form-action' => [idp_origin] }
+  # ... render as usual; the emitted CSP now carries the origin
+end
+```
+
+The extras channel is **additive-only** and deliberately narrow:
+
+- Tokens are appended to directives already present in the built policy,
+  deduplicated. A directive that is *absent* (not in the base set, or removed
+  by a boot override) is dropped — creating one at request time would tighten
+  the policy (`form-action` does not fall back to `default-src`), and
+  re-adding one would resurrect a deliberate removal.
+- Only **origins** are accepted: `scheme://host[:port]` with an http(s) scheme
+  — no keywords (`'self'`, `'unsafe-inline'`), no scheme sources (`data:`,
+  `https:`), no wildcards, no paths, nothing that could smuggle a separator.
+- `script-src` (and `-elem`/`-attr`) and `default-src` are refused outright.
+  For the script family that is defence-in-depth policy, not nonce protection
+  (extras append, so the nonce would survive); `default-src` is refused
+  because widening it widens every unlisted directive at once.
+- Everything that fails validation is **dropped and logged** (`warn`, with the
+  directive, token, and reason) — a hostile value never raises, and the
+  response ships with the rest of the policy intact.
+
+Otto validates defensively, but it is not the policy authority: the app
+decides *which* origins to admit (resolve them from trusted per-request data,
+never echo attacker-controlled input). Extras live only in the request env —
+nothing is memoized on the (frozen-in-production) security config, so
+concurrent requests can never bleed into each other. The constant
+`Otto::EnvKeys::CSP::EXTRA_DIRECTIVES` (via `require 'otto/env_keys'`) names
+the key for downstream apps.
 
 > [!NOTE]
 > `res.send_csp_headers(content_type, nonce)` is **deprecated** in favour of

--- a/README.md
+++ b/README.md
@@ -137,7 +137,15 @@ which replaces (or with `nil`, removes) a directive's sources wholesale.
 
 Some directive values only exist at request time — the canonical case is a
 multi-tenant app that must allow the resolved tenant's SSO IdP origin in
-`form-action`. For that, a handler (or middleware) writes a hash of directive
+`form-action`. The channel is **boot-time opt-in** (the env key is a write
+surface any middleware in the Rack stack can reach, so it does not exist until
+boot code says so):
+
+```ruby
+app.security_config.enable_csp_request_extras!  # default: off
+```
+
+With the channel enabled, a handler (or middleware) writes a hash of directive
 name => additional source tokens to the env before the response is finalized:
 
 ```ruby
@@ -147,6 +155,12 @@ def signin(req, res)
   # ... render as usual; the emitted CSP now carries the origin
 end
 ```
+
+Without the opt-in, the env key is ignored entirely — no sanitization, no
+logs. The `Writer::Result` returned by the emission surfaces reports what
+actually happened: `result.extra_directives` carries only the extras that
+landed in the policy (entries dropped because their directive was absent are
+excluded, and logged with request context instead).
 
 The extras channel is **additive-only** and deliberately narrow:
 

--- a/changelog.d/20260818_160000_claude_csp_request_extras.rst
+++ b/changelog.d/20260818_160000_claude_csp_request_extras.rst
@@ -1,48 +1,18 @@
 Added
 -----
 
-- Request-scoped CSP directive extras (#243): an opt-in channel for widening
-  directives with values only known at request time. The app opts in at boot
-  with ``security_config.enable_csp_request_extras!`` (default OFF — the env
-  key is a write surface any middleware in the Rack stack can reach, so the
-  channel does not exist until boot code says so). With the channel enabled,
-  a handler writes a hash of directive name => additional source tokens to
-  ``env['otto.csp.extra_directives']`` before the response is finalized, and
-  every emission surface (``Otto::Response#apply_csp`` via its wired request,
-  the ``EmitMiddleware`` backstop, and ``Writer.apply(..., env:)``) folds the
-  sanitized survivors ADDITIVELY into the policy at build time. The
-  motivating case is multi-tenant installs that must admit the resolved
-  tenant's SSO IdP origin into ``form-action`` — per-request data no
-  boot-time ``csp_directive_overrides`` can express. New public API:
-  ``Otto::Security::Config#enable_csp_request_extras!`` /
-  ``#csp_request_extras_enabled?``,
-  ``Otto::Security::CSP::RequestExtras.from_env`` (returns nil when the key
-  is absent, malformed, or nothing survived sanitization — never an empty
-  hash), ``Policy.append_extra_sources`` (pure: returns
-  ``[merged, applied, dropped]``, no logging), an ``extra_directives:``
-  keyword plus an optional applied/dropped outcome block on
-  ``Config#generate_nonce_csp`` / ``Policy.nonce_policy``, an ``env:``
-  keyword on ``Writer.apply``, an ``extra_directives`` reader on
-  ``Writer::Result`` (only the extras that ACTUALLY landed in the policy),
-  and ``Otto::EnvKeys::CSP::EXTRA_DIRECTIVES``. Extras live in the env only —
-  nothing is memoized on the deep-frozen production config, so concurrent
-  requests cannot bleed into each other.
+- Add opt-in request-scoped CSP directive extras for sources that are known
+  only while handling a request. Enable the feature at boot with
+  ``security_config.enable_csp_request_extras!``, then add approved source
+  origins by directive through ``env['otto.csp.extra_directives']``. This
+  supports cases such as adding a tenant's SSO provider to ``form-action``.
+  Disabled by default. (#243)
 
 Security
 --------
 
-- The extras channel is additive-only and validated defensively (#243):
-  tokens must be http(s) origins (``scheme://host[:port]``, normalized, no
-  paths/userinfo/query, no keywords or scheme sources, no wildcards, no
-  ``;``/CR/LF, no ``%`` in the host, explicit ports limited to 1..65535, a
-  single trailing host dot stripped and any further trailing dot rejected),
-  the ``script-src`` family and ``default-src`` are refused wholesale
-  (defence-in-depth — appends would keep the nonce regardless), and a
-  directive absent from the built policy is never created (that would
-  TIGHTEN the policy, since e.g. ``form-action`` does not fall back to
-  ``default-src``) nor a boot-removed one resurrected. Every rejected
-  key/token is dropped and logged at ``:warn`` with a distinct reason and
-  request context — request-time input never raises (a config with the
-  pre-#243 ``generate_nonce_csp`` signature falls back to the legacy call
-  shape, dropping the extras with a single warn), and the response ships
-  with the rest of the policy byte-identical to the no-extras build.
+- Validate request-scoped CSP extras before adding them to a response policy.
+  Extras can only add valid HTTP(S) origins to compatible directives already
+  present in the configured policy; script and default source directives are
+  excluded. Invalid or unsupported entries are ignored and logged without
+  affecting the remaining policy. (#243)

--- a/changelog.d/20260818_160000_claude_csp_request_extras.rst
+++ b/changelog.d/20260818_160000_claude_csp_request_extras.rst
@@ -2,8 +2,11 @@ Added
 -----
 
 - Request-scoped CSP directive extras (#243): an opt-in channel for widening
-  directives with values only known at request time. A handler writes a hash
-  of directive name => additional source tokens to
+  directives with values only known at request time. The app opts in at boot
+  with ``security_config.enable_csp_request_extras!`` (default OFF — the env
+  key is a write surface any middleware in the Rack stack can reach, so the
+  channel does not exist until boot code says so). With the channel enabled,
+  a handler writes a hash of directive name => additional source tokens to
   ``env['otto.csp.extra_directives']`` before the response is finalized, and
   every emission surface (``Otto::Response#apply_csp`` via its wired request,
   the ``EmitMiddleware`` backstop, and ``Writer.apply(..., env:)``) folds the
@@ -11,13 +14,19 @@ Added
   motivating case is multi-tenant installs that must admit the resolved
   tenant's SSO IdP origin into ``form-action`` — per-request data no
   boot-time ``csp_directive_overrides`` can express. New public API:
-  ``Otto::Security::CSP::RequestExtras.from_env``,
-  ``Policy.append_extra_sources``, an ``extra_directives:`` keyword on
+  ``Otto::Security::Config#enable_csp_request_extras!`` /
+  ``#csp_request_extras_enabled?``,
+  ``Otto::Security::CSP::RequestExtras.from_env`` (returns nil when the key
+  is absent, malformed, or nothing survived sanitization — never an empty
+  hash), ``Policy.append_extra_sources`` (pure: returns
+  ``[merged, applied, dropped]``, no logging), an ``extra_directives:``
+  keyword plus an optional applied/dropped outcome block on
   ``Config#generate_nonce_csp`` / ``Policy.nonce_policy``, an ``env:``
   keyword on ``Writer.apply``, an ``extra_directives`` reader on
-  ``Writer::Result``, and ``Otto::EnvKeys::CSP::EXTRA_DIRECTIVES``. Extras
-  live in the env only — nothing is memoized on the deep-frozen production
-  config, so concurrent requests cannot bleed into each other.
+  ``Writer::Result`` (only the extras that ACTUALLY landed in the policy),
+  and ``Otto::EnvKeys::CSP::EXTRA_DIRECTIVES``. Extras live in the env only —
+  nothing is memoized on the deep-frozen production config, so concurrent
+  requests cannot bleed into each other.
 
 Security
 --------
@@ -25,11 +34,15 @@ Security
 - The extras channel is additive-only and validated defensively (#243):
   tokens must be http(s) origins (``scheme://host[:port]``, normalized, no
   paths/userinfo/query, no keywords or scheme sources, no wildcards, no
-  ``;``/CR/LF), the ``script-src`` family and ``default-src`` are refused
-  wholesale (defence-in-depth — appends would keep the nonce regardless),
-  and a directive absent from the built policy is never created (that would
+  ``;``/CR/LF, no ``%`` in the host, explicit ports limited to 1..65535, a
+  single trailing host dot stripped and any further trailing dot rejected),
+  the ``script-src`` family and ``default-src`` are refused wholesale
+  (defence-in-depth — appends would keep the nonce regardless), and a
+  directive absent from the built policy is never created (that would
   TIGHTEN the policy, since e.g. ``form-action`` does not fall back to
   ``default-src``) nor a boot-removed one resurrected. Every rejected
-  key/token is dropped and logged at ``:warn`` with a distinct reason —
-  request-time input never raises, and the response ships with the rest of
-  the policy byte-identical to the no-extras build.
+  key/token is dropped and logged at ``:warn`` with a distinct reason and
+  request context — request-time input never raises (a config with the
+  pre-#243 ``generate_nonce_csp`` signature falls back to the legacy call
+  shape, dropping the extras with a single warn), and the response ships
+  with the rest of the policy byte-identical to the no-extras build.

--- a/changelog.d/20260818_160000_claude_csp_request_extras.rst
+++ b/changelog.d/20260818_160000_claude_csp_request_extras.rst
@@ -1,0 +1,35 @@
+Added
+-----
+
+- Request-scoped CSP directive extras (#243): an opt-in channel for widening
+  directives with values only known at request time. A handler writes a hash
+  of directive name => additional source tokens to
+  ``env['otto.csp.extra_directives']`` before the response is finalized, and
+  every emission surface (``Otto::Response#apply_csp`` via its wired request,
+  the ``EmitMiddleware`` backstop, and ``Writer.apply(..., env:)``) folds the
+  sanitized survivors ADDITIVELY into the policy at build time. The
+  motivating case is multi-tenant installs that must admit the resolved
+  tenant's SSO IdP origin into ``form-action`` — per-request data no
+  boot-time ``csp_directive_overrides`` can express. New public API:
+  ``Otto::Security::CSP::RequestExtras.from_env``,
+  ``Policy.append_extra_sources``, an ``extra_directives:`` keyword on
+  ``Config#generate_nonce_csp`` / ``Policy.nonce_policy``, an ``env:``
+  keyword on ``Writer.apply``, an ``extra_directives`` reader on
+  ``Writer::Result``, and ``Otto::EnvKeys::CSP::EXTRA_DIRECTIVES``. Extras
+  live in the env only — nothing is memoized on the deep-frozen production
+  config, so concurrent requests cannot bleed into each other.
+
+Security
+--------
+
+- The extras channel is additive-only and validated defensively (#243):
+  tokens must be http(s) origins (``scheme://host[:port]``, normalized, no
+  paths/userinfo/query, no keywords or scheme sources, no wildcards, no
+  ``;``/CR/LF), the ``script-src`` family and ``default-src`` are refused
+  wholesale (defence-in-depth — appends would keep the nonce regardless),
+  and a directive absent from the built policy is never created (that would
+  TIGHTEN the policy, since e.g. ``form-action`` does not fall back to
+  ``default-src``) nor a boot-removed one resurrected. Every rejected
+  key/token is dropped and logged at ``:warn`` with a distinct reason —
+  request-time input never raises, and the response ships with the rest of
+  the policy byte-identical to the no-extras build.

--- a/changelog.d/20260818_202500_claude_csp_valueless_directives.rst
+++ b/changelog.d/20260818_202500_claude_csp_valueless_directives.rst
@@ -1,21 +1,7 @@
 Fixed
 -----
 
-- CSP request extras keyed to a directive that takes no value no longer
-  corrupt it (#243). ``upgrade-insecure-requests`` and
-  ``block-all-mixed-content`` carry no source list, so appending an extra
-  origin emitted ``upgrade-insecure-requests https://idp.example.com;`` —
-  syntactically malformed, which browsers discard wholesale, silently turning
-  the directive OFF instead of widening it. ``Policy.append_extra_sources``
-  now leaves such a directive BYTE-IDENTICAL and reports the entry through the
-  same ``dropped`` channel as an absent directive (never applied, never
-  silently discarded); the new ``Policy::VALUELESS_DIRECTIVES`` constant and
-  ``Policy.valueless_directive?`` predicate name the set, matched through the
-  shared ``Policy.normalize_directive_name`` so ``:upgrade_insecure_requests``
-  and ``'Upgrade-Insecure-Requests'`` are caught too. ``Writer`` logs these
-  drops with ``reason: :valueless_directive`` (distinct from
-  ``:absent_directive`` — the entry is an app bug, not a policy gap). Other
-  entries in the same request are unaffected: one bad key does not poison the
-  batch. Scope is limited to the two valueless directives; ``sandbox``,
-  ``trusted-types``, and ``require-trusted-types-for`` still accept appends
-  since they produce valid syntax.
+- Prevent request-scoped CSP extras from invalidating valueless directives,
+  including ``upgrade-insecure-requests`` and ``block-all-mixed-content``.
+  Unsupported extras are ignored and logged; valid extras for other
+  directives continue to apply. (#243)

--- a/changelog.d/20260818_202500_claude_csp_valueless_directives.rst
+++ b/changelog.d/20260818_202500_claude_csp_valueless_directives.rst
@@ -1,0 +1,21 @@
+Fixed
+-----
+
+- CSP request extras keyed to a directive that takes no value no longer
+  corrupt it (#243). ``upgrade-insecure-requests`` and
+  ``block-all-mixed-content`` carry no source list, so appending an extra
+  origin emitted ``upgrade-insecure-requests https://idp.example.com;`` —
+  syntactically malformed, which browsers discard wholesale, silently turning
+  the directive OFF instead of widening it. ``Policy.append_extra_sources``
+  now leaves such a directive BYTE-IDENTICAL and reports the entry through the
+  same ``dropped`` channel as an absent directive (never applied, never
+  silently discarded); the new ``Policy::VALUELESS_DIRECTIVES`` constant and
+  ``Policy.valueless_directive?`` predicate name the set, matched through the
+  shared ``Policy.normalize_directive_name`` so ``:upgrade_insecure_requests``
+  and ``'Upgrade-Insecure-Requests'`` are caught too. ``Writer`` logs these
+  drops with ``reason: :valueless_directive`` (distinct from
+  ``:absent_directive`` — the entry is an app bug, not a policy gap). Other
+  entries in the same request are unaffected: one bad key does not poison the
+  batch. Scope is limited to the two valueless directives; ``sandbox``,
+  ``trusted-types``, and ``require-trusted-types-for`` still accept appends
+  since they produce valid syntax.

--- a/changelog.d/20260818_210000_csp_refuse_valueless_request_extras.rst
+++ b/changelog.d/20260818_210000_csp_refuse_valueless_request_extras.rst
@@ -1,8 +1,6 @@
 Security
 --------
 
-- Refuse request-scoped CSP extras targeting valueless directives
-  (``upgrade-insecure-requests`` and ``block-all-mixed-content``) during
-  sanitization (#243). The policy assembler retains its independent guard for
-  direct ``Policy.nonce_policy(extra_directives:)`` callers that bypass the
-  request sanitizer.
+- Reject request-scoped CSP extras for valueless directives during input
+  validation, with equivalent protection for direct CSP policy generation.
+  (#243)

--- a/changelog.d/20260818_210000_csp_refuse_valueless_request_extras.rst
+++ b/changelog.d/20260818_210000_csp_refuse_valueless_request_extras.rst
@@ -1,0 +1,8 @@
+Security
+--------
+
+- Refuse request-scoped CSP extras targeting valueless directives
+  (``upgrade-insecure-requests`` and ``block-all-mixed-content``) during
+  sanitization (#243). The policy assembler retains its independent guard for
+  direct ``Policy.nonce_policy(extra_directives:)`` callers that bypass the
+  request sanitizer.

--- a/lib/otto/env_keys.rb
+++ b/lib/otto/env_keys.rb
@@ -74,6 +74,23 @@ class Otto
     #   (e.g. 'onetime.nonce'), so the header and views still share one value.
     NONCE = 'otto.nonce'
 
+    # Content-Security-Policy request-scoped keys
+    module CSP
+      # Request-scoped CSP directive extras (delano/otto#243).
+      # Type: Hash{String|Symbol directive-name => String|Array<String> tokens}
+      # Set by: the consuming application (a handler, logic class, or
+      #   middleware) any time before the response is finalized
+      # Used by: Otto::Security::CSP::RequestExtras (read + sanitized) and
+      #   folded ADDITIVELY into the nonce policy by
+      #   Otto::Security::CSP::Policy.append_extra_sources at build time
+      # Note: additive-only — extras can only APPEND origin tokens
+      #   (scheme://host[:port], http/https) to directives already present in
+      #   the built policy. The script-src family and default-src are refused
+      #   outright, keyword/scheme sources and wildcards are dropped, and every
+      #   drop is logged. See Otto::Security::CSP::RequestExtras.
+      EXTRA_DIRECTIVES = 'otto.csp.extra_directives'
+    end
+
     # Whether the request arrived via a trusted proxy. TRI-STATE.
     # Type: Boolean when present; the key may be ABSENT.
     # Set by: IPPrivacyMiddleware, evaluated on the original peer BEFORE

--- a/lib/otto/env_keys.rb
+++ b/lib/otto/env_keys.rb
@@ -83,6 +83,11 @@ class Otto
       # Used by: Otto::Security::CSP::RequestExtras (read + sanitized) and
       #   folded ADDITIVELY into the nonce policy by
       #   Otto::Security::CSP::Policy.append_extra_sources at build time
+      # Note: BOOT-TIME OPT-IN — the channel does not exist until the app
+      #   calls Otto::Security::Config#enable_csp_request_extras! (default
+      #   off); without it the key is ignored entirely, no sanitize work and
+      #   no logs. The env key is a write surface any middleware in the Rack
+      #   stack can reach, a lower-trust position than boot code.
       # Note: additive-only — extras can only APPEND origin tokens
       #   (scheme://host[:port], http/https) to directives already present in
       #   the built policy. The script-src family and default-src are refused

--- a/lib/otto/response.rb
+++ b/lib/otto/response.rb
@@ -124,6 +124,11 @@ class Otto
     # @return [Otto::Security::CSP::Writer::Result] the outcome (applied?, policy,
     #   skip_reason) for uniform observability
     #
+    # @note request-scoped directive extras (`env['otto.csp.extra_directives']`,
+    #   delano/otto#243) are seen only when this response has its {#request}
+    #   wired — the env is resolved via `request&.env`, so a bare Response
+    #   degrades gracefully to the base policy.
+    #
     # @example
     #   res['content-type'] = 'text/html; charset=utf-8'
     #   res.apply_csp(req.csp_nonce)
@@ -131,7 +136,8 @@ class Otto
       config = security_config || (request&.env && request.env['otto.security_config'])
       Otto::Security::CSP::Writer.apply(
         headers, nonce,
-        config: config, mode: mode, development_mode: development_mode
+        config: config, mode: mode, development_mode: development_mode,
+        env: request&.env # nil-safe: specs and bare responses have no request
       )
     end
 

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -90,7 +90,7 @@ class Otto
                   :csp_nonce_enabled, :debug_csp, :mcp_auth, :csp_nonce_key,
                   :ip_privacy_config, :trusted_proxy_depth, :trusted_proxy_header,
                   :csp_report_uri, :csp_report_to_url, :csp_violation_callback,
-                  :csp_directive_overrides
+                  :csp_directive_overrides, :csp_request_extras_enabled
 
       # Initialize security configuration with safe defaults
       #
@@ -119,6 +119,7 @@ class Otto
         @csp_report_to_url      = nil
         @csp_violation_callback = nil
         @csp_directive_overrides = {}
+        @csp_request_extras_enabled = false
         @csp_script_src_override_warned = false
         @rate_limiting_config   = { custom_rules: {} }
         @ip_privacy_config      = Otto::Privacy::Config.new
@@ -510,6 +511,39 @@ class Otto
       # @return [Boolean] true if CSP nonce support is enabled
       def csp_nonce_enabled?
         @csp_nonce_enabled
+      end
+
+      # Enable the request-scoped CSP directive extras channel (delano/otto#243)
+      #
+      # Off by default: `env['otto.csp.extra_directives']` is a write surface
+      # that ANY middleware in the Rack stack can reach — a lower-trust
+      # position than boot code — so the channel does not exist until the app
+      # explicitly opts in here. Until then the Writer ignores the env key
+      # entirely (no sanitize work, no logs).
+      #
+      # With the channel enabled, a handler (or middleware) can widen
+      # directives with values only known at request time by writing a hash of
+      # directive name => additional origin tokens to the env before the
+      # response is finalized. Extras are additive-only and sanitized
+      # defensively; see {Otto::Security::CSP::RequestExtras}.
+      #
+      # @return [void]
+      # @raise [FrozenError] if configuration is frozen
+      #
+      # @example At boot, alongside nonce CSP
+      #   config.enable_csp_with_nonce!
+      #   config.enable_csp_request_extras!
+      def enable_csp_request_extras!
+        ensure_not_frozen!
+
+        @csp_request_extras_enabled = true
+      end
+
+      # Check if the request-scoped CSP directive extras channel is enabled
+      #
+      # @return [Boolean] true when {#enable_csp_request_extras!} was called
+      def csp_request_extras_enabled?
+        @csp_request_extras_enabled
       end
 
       # Set the Rack env key the framework-owned lazy nonce is memoized under

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -688,15 +688,20 @@ class Otto
       #   (see {Otto::Security::CSP::Policy.append_extra_sources}, delano/otto#243).
       #   Per-request data — passed through, never stored on this (deep-frozen
       #   in production) config.
+      # @yield [applied, dropped] forwarded to
+      #   {Otto::Security::CSP::Policy.nonce_policy}: the extras entries that
+      #   actually landed in the policy and the entries dropped because their
+      #   directive was absent.
       # @return [String] Complete CSP policy string
-      def generate_nonce_csp(nonce, development_mode: false, extra_directives: nil)
+      def generate_nonce_csp(nonce, development_mode: false, extra_directives: nil, &extras_outcome)
         Otto::Security::CSP::Policy.nonce_policy(
           nonce,
-          development_mode: development_mode,
-          report_uri: @csp_report_uri,
-          report_to_url: @csp_report_to_url,
-          directive_overrides: @csp_directive_overrides,
-          extra_directives: extra_directives
+          development_mode:    development_mode,
+                report_uri:    @csp_report_uri,
+             report_to_url:    @csp_report_to_url,
+       directive_overrides:    @csp_directive_overrides,
+          extra_directives:    extra_directives,
+          &extras_outcome
         )
       end
 

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -649,14 +649,20 @@ class Otto
       #
       # @param nonce [String] The nonce value to include in the CSP
       # @param development_mode [Boolean] Whether to use development-friendly directives
+      # @param extra_directives [Hash{String=>Array<String>}, nil] request-scoped
+      #   extra source tokens appended additively after the overrides merge
+      #   (see {Otto::Security::CSP::Policy.append_extra_sources}, delano/otto#243).
+      #   Per-request data — passed through, never stored on this (deep-frozen
+      #   in production) config.
       # @return [String] Complete CSP policy string
-      def generate_nonce_csp(nonce, development_mode: false)
+      def generate_nonce_csp(nonce, development_mode: false, extra_directives: nil)
         Otto::Security::CSP::Policy.nonce_policy(
           nonce,
           development_mode: development_mode,
           report_uri: @csp_report_uri,
           report_to_url: @csp_report_to_url,
-          directive_overrides: @csp_directive_overrides
+          directive_overrides: @csp_directive_overrides,
+          extra_directives: extra_directives
         )
       end
 

--- a/lib/otto/security/csp.rb
+++ b/lib/otto/security/csp.rb
@@ -14,6 +14,10 @@
 #                  Result object, :override / :backstop modes) that every surface
 #                  routes through: Otto::Response#apply_csp, the EmitMiddleware,
 #                  and the deprecated Otto::Response#send_csp_headers shim.
+# - RequestExtras — reads + sanitizes the opt-in request-scoped directive
+#                  extras from env['otto.csp.extra_directives'] (delano/otto#243);
+#                  the Writer folds the survivors in additively via
+#                  Policy.append_extra_sources.
 # - EmitMiddleware — passive backstop that emits a nonce CSP for responses whose
 #                  request consumed a nonce (emit-if-consumed). See
 #                  Otto::Security::Core#enable_csp_emission!.
@@ -23,6 +27,7 @@
 #   callback API. See Otto::Security::Core#enable_csp_reporting!.
 
 require_relative 'csp/policy'
+require_relative 'csp/request_extras'
 require_relative 'csp/nonce'
 require_relative 'csp/writer'
 require_relative 'csp/report'

--- a/lib/otto/security/csp/emit_middleware.rb
+++ b/lib/otto/security/csp/emit_middleware.rb
@@ -66,7 +66,8 @@ class Otto
 
           Otto::Security::CSP::Writer.apply(
             headers, nonce,
-            config: @config, mode: :backstop, development_mode: development_mode?(env)
+            config: @config, mode: :backstop, development_mode: development_mode?(env),
+            env: env # request-scoped extras (env['otto.csp.extra_directives'], #243)
           )
         end
 

--- a/lib/otto/security/csp/policy.rb
+++ b/lib/otto/security/csp/policy.rb
@@ -233,17 +233,31 @@ class Otto
           "#{name} #{(existing + additions).join(' ')};"
         end
 
+        # Normalize one directive name: stripped, lowercased, underscores
+        # mapped to hyphens (no CSP directive contains an underscore), so a
+        # Symbol like `:worker_src` addresses the `worker-src` directive.
+        #
+        # The SINGLE normalization used by both {.normalize_overrides} and
+        # {Otto::Security::CSP::RequestExtras.from_env} — the present/absent
+        # matching in {.append_extra_sources} depends on both sides applying
+        # identical normalization, so it lives in exactly one place.
+        #
+        # @param name [String, Symbol]
+        # @return [String] normalized directive name (may be empty for blank input)
+        def normalize_directive_name(name)
+          name.to_s.strip.downcase.tr('_', '-')
+        end
+
         # Normalize an overrides hash to lowercased, hyphenated String keys so
         # lookups are case-insensitive and Symbol/String keys are
-        # interchangeable. Underscores map to hyphens (no CSP directive contains
-        # an underscore) so a Symbol key like `:worker_src` addresses the
-        # `worker-src` directive. Blank keys are dropped.
+        # interchangeable (see {.normalize_directive_name}). Blank keys are
+        # dropped.
         #
         # @param overrides [Hash]
         # @return [Hash{String=>Object}]
         def normalize_overrides(overrides)
           overrides.each_with_object({}) do |(key, value), acc|
-            name = key.to_s.strip.downcase.tr('_', '-')
+            name = normalize_directive_name(key)
             acc[name] = value unless name.empty?
           end
         end

--- a/lib/otto/security/csp/policy.rb
+++ b/lib/otto/security/csp/policy.rb
@@ -47,10 +47,18 @@ class Otto
         #   into the base set before reporting directives are appended. See
         #   {.merge_directives} for the accepted shape (replace a directive's
         #   sources, add a new directive, or remove one with a nil/false value).
+        # @param extra_directives [Hash{String=>Array<String>}, nil]
+        #   request-scoped extra source tokens appended additively AFTER the
+        #   overrides merge and BEFORE the reporting directives. Expected
+        #   pre-sanitized (see {Otto::Security::CSP::RequestExtras.from_env});
+        #   see {.append_extra_sources} for the semantics (append to present
+        #   directives only, dedupe, drop absent-directive keys).
         # @return [String] complete CSP policy string
-        def nonce_policy(nonce, development_mode: false, report_uri: nil, report_to_url: nil, directive_overrides: nil)
+        def nonce_policy(nonce, development_mode: false, report_uri: nil, report_to_url: nil,
+                         directive_overrides: nil, extra_directives: nil)
           directives = development_mode ? development_directives(nonce) : production_directives(nonce)
           directives = merge_directives(directives, directive_overrides)
+          directives = append_extra_sources(directives, extra_directives)
           uri_directive = report_uri_directive(report_uri)
           to_directive  = report_to_directive(report_to_url)
           directives += ["#{uri_directive};"] if uri_directive
@@ -149,6 +157,80 @@ class Otto
           end
 
           merged
+        end
+
+        # Fold request-scoped extra source tokens ADDITIVELY into a built
+        # directive set (delano/otto#243). A SIBLING of {.merge_directives},
+        # deliberately not a change to it: boot-time overrides REPLACE a
+        # directive's sources wholesale, request-time extras only ever APPEND.
+        #
+        # Semantics:
+        # - A directive PRESENT in the built list gets the extra tokens
+        #   appended to its source list, deduplicated (a token already present
+        #   is not appended again).
+        # - A directive ABSENT from the built list (base set minus any
+        #   boot-override removals) is DROPPED and logged: directives like
+        #   `form-action` do not fall back to `default-src`, so CREATING one
+        #   here would tighten the policy (suddenly blocking unrelated forms),
+        #   and re-adding a directive a boot override deliberately removed
+        #   (nil/false override) would resurrect it.
+        # - An entry whose token list is nil/empty leaves the base directive
+        #   BYTE-IDENTICAL — the directive string is returned as-is, never
+        #   rebuilt, so `worker-src 'self' blob:;` can never collapse into a
+        #   bare `worker-src;`.
+        #
+        # Callers pass PRE-SANITIZED extras
+        # ({Otto::Security::CSP::RequestExtras.from_env} guarantees no
+        # `;`/CR/LF and origin-only tokens), so this helper does not
+        # re-validate the grammar; it stays defensive only about shape
+        # (nil/empty values are skipped gracefully, request-time input must
+        # never raise).
+        #
+        # @note the absent-directive drop is logged via {Otto.structured_log}
+        #   WITHOUT request context — this module never sees the Rack env (its
+        #   methods stay pure functions of their arguments); the
+        #   sanitization-time drops in RequestExtras carry the request context.
+        #
+        # @param directives [Array<String>] built directive strings, each
+        #   `;`-terminated (post {.merge_directives})
+        # @param extras [Hash{String=>Array<String>}, nil] normalized directive
+        #   name => extra source tokens
+        # @return [Array<String>] directive strings with extras appended
+        def append_extra_sources(directives, extras)
+          return directives if extras.nil? || extras.empty?
+
+          remaining = extras.dup
+          merged = directives.map do |directive|
+            tokens = remaining.delete(directive_name(directive))
+            tokens.nil? || tokens.empty? ? directive : append_sources_to(directive, tokens)
+          end
+
+          remaining.each do |name, tokens|
+            Otto.structured_log(
+              :warn, 'CSP request extra dropped',
+              directive: name, token: Array(tokens).join(' ').inspect.slice(0, 128),
+              reason: :absent_directive
+            )
+          end
+
+          merged
+        end
+
+        # Append tokens to one `;`-terminated directive string, deduplicated
+        # against its existing sources. Returns the directive UNCHANGED when
+        # every token is already present (the byte-identical invariant).
+        #
+        # @param directive [String] e.g. `"form-action 'self';"`
+        # @param tokens [Array<String>] pre-sanitized source tokens
+        # @return [String] `;`-terminated directive string
+        def append_sources_to(directive, tokens)
+          body = directive.to_s.strip.delete_suffix(';')
+          name, sources = body.split(/\s+/, 2)
+          existing  = sources.to_s.split(/\s+/)
+          additions = Array(tokens).map(&:to_s).reject { |token| token.empty? || existing.include?(token) }
+          return directive if additions.empty?
+
+          "#{name} #{(existing + additions).join(' ')};"
         end
 
         # Normalize an overrides hash to lowercased, hyphenated String keys so

--- a/lib/otto/security/csp/policy.rb
+++ b/lib/otto/security/csp/policy.rb
@@ -53,12 +53,20 @@ class Otto
         #   pre-sanitized (see {Otto::Security::CSP::RequestExtras.from_env});
         #   see {.append_extra_sources} for the semantics (append to present
         #   directives only, dedupe, drop absent-directive keys).
+        # @yield [applied, dropped] the extras outcome from
+        #   {.append_extra_sources} (both empty hashes when no extras were
+        #   given): the entries actually folded into the policy and the
+        #   entries dropped because their directive was absent. This is the
+        #   return channel {Otto::Security::CSP::Writer} uses to log drops
+        #   with request context and report only real appends — the policy
+        #   string stays the sole return value.
         # @return [String] complete CSP policy string
         def nonce_policy(nonce, development_mode: false, report_uri: nil, report_to_url: nil,
                          directive_overrides: nil, extra_directives: nil)
           directives = development_mode ? development_directives(nonce) : production_directives(nonce)
           directives = merge_directives(directives, directive_overrides)
-          directives = append_extra_sources(directives, extra_directives)
+          directives, applied_extras, dropped_extras = append_extra_sources(directives, extra_directives)
+          yield(applied_extras, dropped_extras) if block_given?
           uri_directive = report_uri_directive(report_uri)
           to_directive  = report_to_directive(report_to_url)
           directives += ["#{uri_directive};"] if uri_directive
@@ -169,11 +177,11 @@ class Otto
         #   appended to its source list, deduplicated (a token already present
         #   is not appended again).
         # - A directive ABSENT from the built list (base set minus any
-        #   boot-override removals) is DROPPED and logged: directives like
-        #   `form-action` do not fall back to `default-src`, so CREATING one
-        #   here would tighten the policy (suddenly blocking unrelated forms),
-        #   and re-adding a directive a boot override deliberately removed
-        #   (nil/false override) would resurrect it.
+        #   boot-override removals) is DROPPED and reported in the return:
+        #   directives like `form-action` do not fall back to `default-src`,
+        #   so CREATING one here would tighten the policy (suddenly blocking
+        #   unrelated forms), and re-adding a directive a boot override
+        #   deliberately removed (nil/false override) would resurrect it.
         # - An entry whose token list is nil/empty leaves the base directive
         #   BYTE-IDENTICAL — the directive string is returned as-is, never
         #   rebuilt, so `worker-src 'self' blob:;` can never collapse into a
@@ -186,34 +194,40 @@ class Otto
         # (nil/empty values are skipped gracefully, request-time input must
         # never raise).
         #
-        # @note the absent-directive drop is logged via {Otto.structured_log}
-        #   WITHOUT request context — this module never sees the Rack env (its
-        #   methods stay pure functions of their arguments); the
-        #   sanitization-time drops in RequestExtras carry the request context.
+        # Pure — like everything in this module, a function of its arguments
+        # with no logging and no env access. Dropped entries are RETURNED,
+        # not logged, so the one caller with the request in hand
+        # ({Otto::Security::CSP::Writer}) can log them with full request
+        # context.
         #
         # @param directives [Array<String>] built directive strings, each
         #   `;`-terminated (post {.merge_directives})
         # @param extras [Hash{String=>Array<String>}, nil] normalized directive
         #   name => extra source tokens
-        # @return [Array<String>] directive strings with extras appended
+        # @return [Array(Array<String>, Hash, Hash)] `[merged, applied, dropped]`:
+        #   the directive strings with extras appended; the extras entries that
+        #   addressed a PRESENT directive (their tokens are in the merged
+        #   policy — a token already present is simply not duplicated); and
+        #   the entries dropped because their directive was absent. Entries
+        #   with nil/empty token lists appear in neither hash.
         def append_extra_sources(directives, extras)
-          return directives if extras.nil? || extras.empty?
+          return [directives, {}, {}] if extras.nil? || extras.empty?
 
           remaining = extras.dup
+          applied = {}
           merged = directives.map do |directive|
-            tokens = remaining.delete(directive_name(directive))
-            tokens.nil? || tokens.empty? ? directive : append_sources_to(directive, tokens)
+            name = directive_name(directive)
+            tokens = remaining.delete(name)
+            if tokens.nil? || Array(tokens).empty?
+              directive
+            else
+              applied[name] = tokens
+              append_sources_to(directive, tokens)
+            end
           end
 
-          remaining.each do |name, tokens|
-            Otto.structured_log(
-              :warn, 'CSP request extra dropped',
-              directive: name, token: Array(tokens).join(' ').inspect.slice(0, 128),
-              reason: :absent_directive
-            )
-          end
-
-          merged
+          dropped = remaining.reject { |_name, tokens| Array(tokens).empty? }
+          [merged, applied, dropped]
         end
 
         # Append tokens to one `;`-terminated directive string, deduplicated

--- a/lib/otto/security/csp/policy.rb
+++ b/lib/otto/security/csp/policy.rb
@@ -29,6 +29,23 @@ class Otto
         # can never drift.
         REPORTING_GROUP = 'otto-csp'
 
+        # CSP directives that take NO value at all. Appending a source to one
+        # of these does not widen it — it makes the directive SYNTACTICALLY
+        # malformed (`upgrade-insecure-requests https://x;`), and a browser
+        # drops a malformed directive wholesale. So an extras entry keyed to
+        # one of them would silently DISABLE the directive it names, the exact
+        # inverse of the additive contract. {.append_extra_sources} therefore
+        # leaves them byte-identical and reports the entry as dropped.
+        #
+        # Deliberately only these two: `sandbox`, `trusted-types`, and
+        # `require-trusted-types-for` take non-source values, which makes
+        # appending an origin to them useless, but the result is still valid
+        # syntax the browser honours — no silent policy loss.
+        # `upgrade-insecure-requests` remains a CSP extension. Conversely,
+        # `block-all-mixed-content` is obsolete in the Mixed Content standard,
+        # but is retained here to protect legacy policies that still emit it.
+        VALUELESS_DIRECTIVES = %w[upgrade-insecure-requests block-all-mixed-content].freeze
+
         # Build the per-request nonce CSP policy string.
         #
         # Byte-identical to Otto's historical {Otto::Security::Config#generate_nonce_csp}
@@ -182,6 +199,12 @@ class Otto
         #   so CREATING one here would tighten the policy (suddenly blocking
         #   unrelated forms), and re-adding a directive a boot override
         #   deliberately removed (nil/false override) would resurrect it.
+        # - A directive that takes NO value ({VALUELESS_DIRECTIVES}, e.g.
+        #   `upgrade-insecure-requests`) is left BYTE-IDENTICAL and its entry
+        #   is DROPPED: appending a source there would emit
+        #   `upgrade-insecure-requests https://x;`, which browsers treat as
+        #   malformed and discard — an extras key would silently turn the
+        #   directive OFF instead of widening it.
         # - An entry whose token list is nil/empty leaves the base directive
         #   BYTE-IDENTICAL — the directive string is returned as-is, never
         #   rebuilt, so `worker-src 'self' blob:;` can never collapse into a
@@ -208,8 +231,9 @@ class Otto
         #   the directive strings with extras appended; the extras entries that
         #   addressed a PRESENT directive (their tokens are in the merged
         #   policy — a token already present is simply not duplicated); and
-        #   the entries dropped because their directive was absent. Entries
-        #   with nil/empty token lists appear in neither hash.
+        #   the entries dropped because their directive was absent or takes no
+        #   value ({VALUELESS_DIRECTIVES}). Entries with nil/empty token lists
+        #   appear in neither hash.
         def append_extra_sources(directives, extras)
           return [directives, {}, {}] if extras.nil? || extras.empty?
 
@@ -218,12 +242,18 @@ class Otto
           merged = directives.map do |directive|
             name = directive_name(directive)
             tokens = remaining.delete(name)
-            if tokens.nil? || Array(tokens).empty?
-              directive
-            else
-              applied[name] = tokens
-              append_sources_to(directive, tokens)
+            next directive if tokens.nil? || Array(tokens).empty?
+
+            if valueless_directive?(name)
+              # Put the entry back so it surfaces in `dropped` rather than
+              # vanishing: the caller with the request in hand must be able to
+              # log that these tokens never landed.
+              remaining[name] = tokens
+              next directive
             end
+
+            applied[name] = tokens
+            append_sources_to(directive, tokens)
           end
 
           dropped = remaining.reject { |_name, tokens| Array(tokens).empty? }
@@ -277,12 +307,24 @@ class Otto
         end
 
         # The directive name (first token) of a `;`-terminated directive string,
-        # lowercased for case-insensitive matching.
+        # run through {.normalize_directive_name} so the built policy and the
+        # extras/override hashes are compared on ONE normalization.
         #
         # @param directive [String]
         # @return [String]
         def directive_name(directive)
-          directive.to_s.strip.delete_suffix(';').split(/\s+/, 2).first.to_s.downcase
+          normalize_directive_name(directive.to_s.strip.delete_suffix(';').split(/\s+/, 2).first)
+        end
+
+        # True when +name+ addresses a directive that takes no value at all
+        # (see {VALUELESS_DIRECTIVES}). Normalizes through
+        # {.normalize_directive_name}, so `:upgrade_insecure_requests` and
+        # `'Upgrade-Insecure-Requests'` are recognized like the canonical form.
+        #
+        # @param name [String, Symbol]
+        # @return [Boolean]
+        def valueless_directive?(name)
+          VALUELESS_DIRECTIVES.include?(normalize_directive_name(name))
         end
 
         # Build a single `;`-terminated directive string from a name and an

--- a/lib/otto/security/csp/request_extras.rb
+++ b/lib/otto/security/csp/request_extras.rb
@@ -43,7 +43,10 @@ class Otto
       #   are additive, so the nonce source would survive an append — refusing
       #   the family simply keeps the request channel away from the one
       #   directive class that gates script execution. `default-src` is refused
-      #   because widening it widens every unlisted directive at once.
+      #   because widening it widens every unlisted directive at once. Directives
+      #   with no value are refused because an appended origin makes the entire
+      #   directive malformed; {Policy.append_extra_sources} retains the same
+      #   guard for callers that bypass this sanitizer.
       # - Tokens must be ORIGINS: `scheme://host[:port]` with an http/https
       #   scheme and a non-empty host — no path/query/fragment/userinfo, no
       #   whitespace, no `;`/CR/LF, no wildcards, no quotes. Keyword sources
@@ -62,9 +65,11 @@ class Otto
       # {Otto.structured_log} with a distinct reason (`:invalid_shape`,
       # `:refused_directive`, `:not_an_origin`) and privacy-safe request
       # context. Entries dropped later, during the policy append (an absent
-      # directive, or a config without extras support), are logged by
+      # directive, a valueless directive supplied by a caller that bypassed this
+      # sanitizer, or a config without extras support), are logged by
       # {Otto::Security::CSP::Writer} — the same message, `reason:
-      # :absent_directive` / `:config_without_extras_support`.
+      # :absent_directive` / `:valueless_directive` /
+      # `:config_without_extras_support`.
       module RequestExtras
         # The env key the consuming app writes. Hardcoded on purpose (not
         # configurable) — it is a cross-gem contract; see also
@@ -73,9 +78,14 @@ class Otto
 
         # Directives the request channel refuses to touch, wholesale. See the
         # module docs for why (defence-in-depth for the script family — NOT
-        # nonce-stripping, since appends keep the nonce — and blast radius for
-        # default-src).
-        REFUSED_DIRECTIVES = %w[script-src script-src-elem script-src-attr default-src].freeze
+        # nonce-stripping, since appends keep the nonce — blast radius for
+        # default-src — and invalid syntax for directives with no value).
+        # Keep the policy-level guard too: Policy.nonce_policy(extra_directives:)
+        # is public and can bypass this sanitizer.
+        REFUSED_DIRECTIVES = (
+          %w[script-src script-src-elem script-src-attr default-src] +
+          Policy::VALUELESS_DIRECTIVES
+        ).freeze
 
         # The only schemes an extra origin may carry.
         ALLOWED_SCHEMES = %w[http https].freeze

--- a/lib/otto/security/csp/request_extras.rb
+++ b/lib/otto/security/csp/request_extras.rb
@@ -4,6 +4,8 @@
 
 require 'uri'
 
+require_relative 'policy'
+
 class Otto
   module Security
     module CSP
@@ -27,9 +29,12 @@ class Otto
       # logged, and the response still ships with the base policy intact.
       #
       # Sanitization rules:
-      # - Directive names are normalized like
-      #   {Otto::Security::CSP::Policy.normalize_overrides}
-      #   (`to_s.strip.downcase.tr('_', '-')`); blank keys are dropped.
+      # - Directive names are normalized via
+      #   {Otto::Security::CSP::Policy.normalize_directive_name} (the same
+      #   normalization {Policy.normalize_overrides} applies to boot-time
+      #   overrides); blank keys are dropped. Two raw keys that normalize to
+      #   the same directive (`'form_action'` and `'form-action'`) have their
+      #   token lists merged (union) — nothing is silently overwritten.
       # - {REFUSED_DIRECTIVES} are dropped wholesale. For the `script-src`
       #   family this is defence-in-depth policy, NOT nonce protection: extras
       #   are additive, so the nonce source would survive an append — refusing
@@ -42,7 +47,13 @@ class Otto
       #   (`'self'`, `'unsafe-inline'`, ...) and scheme sources (`data:`,
       #   `https:`) are rejected. Accepted tokens are normalized to
       #   `scheme://host[:port]` with a downcased host and default ports
-      #   omitted.
+      #   omitted. Hosts follow strip-then-validate: a single trailing dot
+      #   (the FQDN root form browsers do NOT treat as the same origin) is
+      #   stripped before validation, any remaining trailing dot rejects the
+      #   token, and a host containing `%` (percent-encoding that URI's host
+      #   parser passes through literally) is rejected outright. An explicit
+      #   port must fall in 1..65535 — URI accepts arbitrarily large all-digit
+      #   ports that no browser can match.
       #
       # Every dropped key/token is logged at :warn via {Otto.structured_log}
       # with a distinct reason (`:invalid_shape`, `:refused_directive`,
@@ -77,31 +88,44 @@ class Otto
         #
         # @param env [Hash] the Rack environment
         # @return [Hash{String=>Array<String>}, nil] normalized directive name
-        #   => normalized origin tokens; nil when the env key is absent or the
-        #   value is not a Hash, possibly empty when everything was dropped
+        #   => normalized origin tokens; nil when the env key is absent, the
+        #   value is not a Hash, or nothing survived sanitization — callers
+        #   never see an empty hash
         def from_env(env)
           raw = env[ENV_KEY]
           return nil if raw.nil?
 
+          # Compute the request context once per call and thread it through —
+          # a hostile payload can produce many drops, and re-deriving the
+          # context per token would defeat LoggingHelpers' compute-once-then-
+          # merge pattern.
+          context = Otto::LoggingHelpers.request_context(env)
+
           unless raw.is_a?(Hash)
-            log_drop(env, directive: nil, token: raw, reason: :invalid_shape)
+            log_drop(context, directive: nil, token: raw, reason: :invalid_shape)
             return nil
           end
 
-          raw.each_with_object({}) do |(key, value), acc|
-            name = key.to_s.strip.downcase.tr('_', '-')
+          extras = raw.each_with_object({}) do |(key, value), acc|
+            name = Policy.normalize_directive_name(key)
             if name.empty?
-              log_drop(env, directive: key, token: value, reason: :invalid_shape)
+              log_drop(context, directive: key, token: value, reason: :invalid_shape)
               next
             end
             if REFUSED_DIRECTIVES.include?(name)
-              log_drop(env, directive: name, token: value, reason: :refused_directive)
+              log_drop(context, directive: name, token: value, reason: :refused_directive)
               next
             end
 
-            tokens = sanitize_tokens(env, name, value)
-            acc[name] = tokens unless tokens.empty?
+            tokens = sanitize_tokens(context, name, value)
+            next if tokens.empty?
+
+            # Two raw keys can normalize to the same directive ('form_action'
+            # and 'form-action'): union the token lists rather than letting
+            # the later key silently clobber the earlier one.
+            acc[name] = (acc[name] || []) | tokens
           end
+          extras.empty? ? nil : extras
         end
 
         # Sanitize one directive's token value into normalized origin strings.
@@ -109,29 +133,29 @@ class Otto
         # same ergonomics as a {Policy.merge_directives} String override); an
         # Array is taken element-wise. Anything else drops the key.
         #
-        # @param env [Hash] the Rack environment (for log context)
+        # @param context [Hash] precomputed request context (for log payloads)
         # @param name [String] normalized directive name (for log context)
         # @param value [String, Array<String>, Object]
         # @return [Array<String>] surviving normalized origins (deduplicated)
-        def sanitize_tokens(env, name, value)
+        def sanitize_tokens(context, name, value)
           candidates =
             case value
             when String then value.split
             when Array then value
             else
-              log_drop(env, directive: name, token: value, reason: :invalid_shape)
+              log_drop(context, directive: name, token: value, reason: :invalid_shape)
               return []
             end
 
           candidates.filter_map do |token|
             unless token.is_a?(String)
-              log_drop(env, directive: name, token: token, reason: :invalid_shape)
+              log_drop(context, directive: name, token: token, reason: :invalid_shape)
               next
             end
 
             normalized = normalize_origin(token)
             if normalized.nil?
-              log_drop(env, directive: name, token: token, reason: :not_an_origin)
+              log_drop(context, directive: name, token: token, reason: :not_an_origin)
               next
             end
             normalized
@@ -156,23 +180,53 @@ class Otto
 
           scheme = uri.scheme.to_s.downcase
           return nil unless ALLOWED_SCHEMES.include?(scheme)
-          return nil if uri.host.nil? || uri.host.empty?
           return nil if uri.userinfo
           return nil unless uri.path.to_s.empty?
           return nil if uri.query || uri.fragment
 
-          origin = "#{scheme}://#{uri.host.downcase}"
+          host = normalize_host(uri.host)
+          return nil if host.nil?
+          # URI accepts arbitrarily large all-digit ports (and port 0); no
+          # browser can match an origin outside the TCP port range, so an
+          # out-of-range port is a silent-failure token — reject it. uri.port
+          # is never nil for URI::HTTP (defaults apply), and the default ports
+          # 80/443 are in range, so one check covers both shapes.
+          return nil unless (1..65_535).cover?(uri.port)
+
+          origin = "#{scheme}://#{host}"
           origin << ":#{uri.port}" unless uri.port == uri.default_port
           origin
+        end
+
+        # Validate and normalize an origin host: downcased, strip-then-validate
+        # for trailing dots (a single trailing dot — the FQDN root form — is
+        # stripped, since browsers do not equate `example.com.` with
+        # `example.com`; any dot still trailing after the strip rejects the
+        # host), and any `%` rejects the host outright (URI's host parser
+        # passes percent-encodings through literally, so accepting one would
+        # ship raw `%00`-style bytes in a response header).
+        #
+        # @param raw [String, nil] the parsed URI host
+        # @return [String, nil] normalized host, or nil when unacceptable
+        def normalize_host(raw)
+          host = raw.to_s.downcase
+          return nil if host.empty? || host.include?('%')
+
+          host = host.delete_suffix('.')
+          return nil if host.empty? || host.end_with?('.')
+
+          host
         end
 
         # Log one dropped key/token at :warn with privacy-safe request context.
         # Never :debug — drops are actionable signal, and structured_log skips
         # :debug unless Otto.debug is on.
-        def log_drop(env, directive:, token:, reason:)
+        #
+        # @param context [Hash] precomputed request context ({Otto::LoggingHelpers.request_context})
+        def log_drop(context, directive:, token:, reason:)
           Otto.structured_log(
             :warn, 'CSP request extra dropped',
-            Otto::LoggingHelpers.request_context(env).merge(
+            context.merge(
               directive: directive&.to_s,
               token: token.inspect.slice(0, 128),
               reason: reason

--- a/lib/otto/security/csp/request_extras.rb
+++ b/lib/otto/security/csp/request_extras.rb
@@ -1,0 +1,185 @@
+# lib/otto/security/csp/request_extras.rb
+#
+# frozen_string_literal: true
+
+require 'uri'
+
+class Otto
+  module Security
+    module CSP
+      # Reads and sanitizes request-scoped CSP directive extras from the Rack
+      # env (delano/otto#243).
+      #
+      # This is the opt-in channel for widening CSP directives with values only
+      # known at request time: the consuming app writes a hash of directive
+      # name => additional source tokens to `env['otto.csp.extra_directives']`
+      # before the response is finalized, and the policy build folds the
+      # sanitized survivors in ADDITIVELY (see
+      # {Otto::Security::CSP::Policy.append_extra_sources}). The motivating
+      # case is a multi-tenant app that must admit the resolved tenant's SSO
+      # IdP origin into `form-action` — per-request data no boot-time override
+      # can express.
+      #
+      # This module deliberately has the OPPOSITE failure mode of
+      # {Otto::Security::CSP::Policy}: Policy is pure functions that raise on
+      # bad input (boot-time overrides should fail loud), while request-time
+      # extras must NEVER raise — a hostile or malformed value is dropped and
+      # logged, and the response still ships with the base policy intact.
+      #
+      # Sanitization rules:
+      # - Directive names are normalized like
+      #   {Otto::Security::CSP::Policy.normalize_overrides}
+      #   (`to_s.strip.downcase.tr('_', '-')`); blank keys are dropped.
+      # - {REFUSED_DIRECTIVES} are dropped wholesale. For the `script-src`
+      #   family this is defence-in-depth policy, NOT nonce protection: extras
+      #   are additive, so the nonce source would survive an append — refusing
+      #   the family simply keeps the request channel away from the one
+      #   directive class that gates script execution. `default-src` is refused
+      #   because widening it widens every unlisted directive at once.
+      # - Tokens must be ORIGINS: `scheme://host[:port]` with an http/https
+      #   scheme and a non-empty host — no path/query/fragment/userinfo, no
+      #   whitespace, no `;`/CR/LF, no wildcards, no quotes. Keyword sources
+      #   (`'self'`, `'unsafe-inline'`, ...) and scheme sources (`data:`,
+      #   `https:`) are rejected. Accepted tokens are normalized to
+      #   `scheme://host[:port]` with a downcased host and default ports
+      #   omitted.
+      #
+      # Every dropped key/token is logged at :warn via {Otto.structured_log}
+      # with a distinct reason (`:invalid_shape`, `:refused_directive`,
+      # `:not_an_origin`) and privacy-safe request context.
+      module RequestExtras
+        # The env key the consuming app writes. Hardcoded on purpose (not
+        # configurable) — it is a cross-gem contract; see also
+        # Otto::EnvKeys::CSP::EXTRA_DIRECTIVES (require 'otto/env_keys').
+        ENV_KEY = 'otto.csp.extra_directives'
+
+        # Directives the request channel refuses to touch, wholesale. See the
+        # module docs for why (defence-in-depth for the script family — NOT
+        # nonce-stripping, since appends keep the nonce — and blast radius for
+        # default-src).
+        REFUSED_DIRECTIVES = %w[script-src script-src-elem script-src-attr default-src].freeze
+
+        # The only schemes an extra origin may carry.
+        ALLOWED_SCHEMES = %w[http https].freeze
+
+        # Characters that can never appear in an origin token: whitespace and
+        # `;`/CR/LF (directive separators), quotes (keyword sources), and `*`
+        # (wildcards). Checked before URI parsing so hostile tokens are
+        # rejected even when URI would tolerate them.
+        FORBIDDEN_CHARS = /[\s;'"*\r\n]/
+
+        module_function
+
+        # Read and sanitize the request-scoped extras from the Rack env.
+        #
+        # Never raises. Anything that fails validation is dropped and logged;
+        # whatever survives is returned.
+        #
+        # @param env [Hash] the Rack environment
+        # @return [Hash{String=>Array<String>}, nil] normalized directive name
+        #   => normalized origin tokens; nil when the env key is absent or the
+        #   value is not a Hash, possibly empty when everything was dropped
+        def from_env(env)
+          raw = env[ENV_KEY]
+          return nil if raw.nil?
+
+          unless raw.is_a?(Hash)
+            log_drop(env, directive: nil, token: raw, reason: :invalid_shape)
+            return nil
+          end
+
+          raw.each_with_object({}) do |(key, value), acc|
+            name = key.to_s.strip.downcase.tr('_', '-')
+            if name.empty?
+              log_drop(env, directive: key, token: value, reason: :invalid_shape)
+              next
+            end
+            if REFUSED_DIRECTIVES.include?(name)
+              log_drop(env, directive: name, token: value, reason: :refused_directive)
+              next
+            end
+
+            tokens = sanitize_tokens(env, name, value)
+            acc[name] = tokens unless tokens.empty?
+          end
+        end
+
+        # Sanitize one directive's token value into normalized origin strings.
+        # A String value is treated as a whitespace-separated source list (the
+        # same ergonomics as a {Policy.merge_directives} String override); an
+        # Array is taken element-wise. Anything else drops the key.
+        #
+        # @param env [Hash] the Rack environment (for log context)
+        # @param name [String] normalized directive name (for log context)
+        # @param value [String, Array<String>, Object]
+        # @return [Array<String>] surviving normalized origins (deduplicated)
+        def sanitize_tokens(env, name, value)
+          candidates =
+            case value
+            when String then value.split
+            when Array then value
+            else
+              log_drop(env, directive: name, token: value, reason: :invalid_shape)
+              return []
+            end
+
+          candidates.filter_map do |token|
+            unless token.is_a?(String)
+              log_drop(env, directive: name, token: token, reason: :invalid_shape)
+              next
+            end
+
+            normalized = normalize_origin(token)
+            if normalized.nil?
+              log_drop(env, directive: name, token: token, reason: :not_an_origin)
+              next
+            end
+            normalized
+          end.uniq
+        end
+
+        # Validate and normalize a single token as an http(s) origin.
+        #
+        # @param token [String]
+        # @return [String, nil] `scheme://host[:port]` (downcased host, default
+        #   port omitted), or nil when the token is not an acceptable origin
+        def normalize_origin(token)
+          return nil if token.empty? || token.match?(FORBIDDEN_CHARS)
+
+          uri = begin
+            URI.parse(token)
+          rescue URI::InvalidURIError
+            return nil
+          end
+
+          return nil unless uri.is_a?(URI::HTTP) # URI::HTTPS is a subclass
+
+          scheme = uri.scheme.to_s.downcase
+          return nil unless ALLOWED_SCHEMES.include?(scheme)
+          return nil if uri.host.nil? || uri.host.empty?
+          return nil if uri.userinfo
+          return nil unless uri.path.to_s.empty?
+          return nil if uri.query || uri.fragment
+
+          origin = +"#{scheme}://#{uri.host.downcase}"
+          origin << ":#{uri.port}" unless uri.port == uri.default_port
+          origin
+        end
+
+        # Log one dropped key/token at :warn with privacy-safe request context.
+        # Never :debug — drops are actionable signal, and structured_log skips
+        # :debug unless Otto.debug is on.
+        def log_drop(env, directive:, token:, reason:)
+          Otto.structured_log(
+            :warn, 'CSP request extra dropped',
+            Otto::LoggingHelpers.request_context(env).merge(
+              directive: directive&.to_s,
+              token: token.inspect.slice(0, 128),
+              reason: reason,
+            ).compact
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/otto/security/csp/request_extras.rb
+++ b/lib/otto/security/csp/request_extras.rb
@@ -149,7 +149,7 @@ class Otto
           uri = begin
             URI.parse(token)
           rescue URI::InvalidURIError
-            return nil
+            nil
           end
 
           return nil unless uri.is_a?(URI::HTTP) # URI::HTTPS is a subclass
@@ -161,7 +161,7 @@ class Otto
           return nil unless uri.path.to_s.empty?
           return nil if uri.query || uri.fragment
 
-          origin = +"#{scheme}://#{uri.host.downcase}"
+          origin = "#{scheme}://#{uri.host.downcase}"
           origin << ":#{uri.port}" unless uri.port == uri.default_port
           origin
         end
@@ -175,7 +175,7 @@ class Otto
             Otto::LoggingHelpers.request_context(env).merge(
               directive: directive&.to_s,
               token: token.inspect.slice(0, 128),
-              reason: reason,
+              reason: reason
             ).compact
           )
         end

--- a/lib/otto/security/csp/request_extras.rb
+++ b/lib/otto/security/csp/request_extras.rb
@@ -13,10 +13,13 @@ class Otto
       # env (delano/otto#243).
       #
       # This is the opt-in channel for widening CSP directives with values only
-      # known at request time: the consuming app writes a hash of directive
-      # name => additional source tokens to `env['otto.csp.extra_directives']`
-      # before the response is finalized, and the policy build folds the
-      # sanitized survivors in ADDITIVELY (see
+      # known at request time: the app enables it at boot with
+      # {Otto::Security::Config#enable_csp_request_extras!} (default off — the
+      # env key is a write surface any middleware can reach, so it does not
+      # exist until boot code says so), then a handler writes a hash of
+      # directive name => additional source tokens to
+      # `env['otto.csp.extra_directives']` before the response is finalized,
+      # and the policy build folds the sanitized survivors in ADDITIVELY (see
       # {Otto::Security::CSP::Policy.append_extra_sources}). The motivating
       # case is a multi-tenant app that must admit the resolved tenant's SSO
       # IdP origin into `form-action` — per-request data no boot-time override
@@ -55,9 +58,13 @@ class Otto
       #   port must fall in 1..65535 — URI accepts arbitrarily large all-digit
       #   ports that no browser can match.
       #
-      # Every dropped key/token is logged at :warn via {Otto.structured_log}
-      # with a distinct reason (`:invalid_shape`, `:refused_directive`,
-      # `:not_an_origin`) and privacy-safe request context.
+      # Every key/token dropped during sanitization is logged at :warn via
+      # {Otto.structured_log} with a distinct reason (`:invalid_shape`,
+      # `:refused_directive`, `:not_an_origin`) and privacy-safe request
+      # context. Entries dropped later, during the policy append (an absent
+      # directive, or a config without extras support), are logged by
+      # {Otto::Security::CSP::Writer} — the same message, `reason:
+      # :absent_directive` / `:config_without_extras_support`.
       module RequestExtras
         # The env key the consuming app writes. Hardcoded on purpose (not
         # configurable) — it is a cross-gem contract; see also

--- a/lib/otto/security/csp/writer.rb
+++ b/lib/otto/security/csp/writer.rb
@@ -100,12 +100,15 @@ class Otto
         #   and the policy string ({Otto::Security::Config#generate_nonce_csp}).
         # @param mode [Symbol] one of {MODES}.
         # @param development_mode [Boolean] use the development directive set.
-        # @param env [Hash, nil] the Rack environment. When given, any
+        # @param env [Hash, nil] the Rack environment. When given AND the
+        #   config has opted the channel in
+        #   ({Otto::Security::Config#enable_csp_request_extras!}), any
         #   request-scoped directive extras the app wrote to
         #   `env['otto.csp.extra_directives']` are sanitized
         #   ({Otto::Security::CSP::RequestExtras.from_env}) and folded
         #   ADDITIVELY into the policy. Nil (surfaces with no env in hand)
-        #   simply builds the policy without extras.
+        #   simply builds the policy without extras; without the opt-in the
+        #   env key is ignored entirely.
         # @return [Result]
         # @raise [ArgumentError] if mode is not one of {MODES}
         # @raise [FrozenError] if a write is attempted against a frozen headers hash
@@ -122,8 +125,9 @@ class Otto
         # Guarded core: returns a Result and performs the in-place write when it
         # applies. Guards are evaluated most-fundamental first so the reported
         # skip_reason is stable and meaningful. Request-scoped extras are
-        # resolved only once every guard has passed, so a skipped response never
-        # logs extras drops for a policy that was never built.
+        # resolved only once every guard has passed — so a skipped response
+        # never logs extras drops for a policy that was never built — and only
+        # when the config opted the channel in (see {.resolve_extras}).
         def self.evaluate(headers, nonce, config, mode, development_mode, env)
           return Result.skipped(:disabled, mode: mode) unless enabled?(config)
           return Result.skipped(:blank_nonce, mode: mode) if blank?(nonce)
@@ -132,7 +136,7 @@ class Otto
           existing = existing_csp(headers)
           return Result.skipped(:existing_csp, mode: mode, policy: existing) if existing && mode == :backstop
 
-          extras = env ? RequestExtras.from_env(env) : nil
+          extras = resolve_extras(config, env)
           policy = if extras
                      config.generate_nonce_csp(nonce, development_mode: development_mode,
                                                       extra_directives: extras)
@@ -146,6 +150,21 @@ class Otto
           Result.applied(policy, mode: mode, extra_directives: extras)
         end
         private_class_method :evaluate
+
+        # Resolve the request-scoped extras, gated on the boot-time opt-in.
+        # The env key is a write surface ANY middleware in the Rack stack can
+        # reach — a lower-trust position than boot code — so the channel does
+        # not exist until {Otto::Security::Config#enable_csp_request_extras!}
+        # was called: when disabled (including duck-typed configs without the
+        # predicate) the env key is ignored entirely, with no sanitize work
+        # and no logs.
+        def self.resolve_extras(config, env)
+          return nil unless env
+          return nil unless config.respond_to?(:csp_request_extras_enabled?) && config.csp_request_extras_enabled?
+
+          RequestExtras.from_env(env)
+        end
+        private_class_method :resolve_extras
 
         # In-place, key-scoped write. Delete any case-variant of the CSP key
         # (correcting a downstream SPEC violation), then write the canonical

--- a/lib/otto/security/csp/writer.rb
+++ b/lib/otto/security/csp/writer.rb
@@ -133,7 +133,6 @@ class Otto
           return Result.skipped(:existing_csp, mode: mode, policy: existing) if existing && mode == :backstop
 
           extras = env ? RequestExtras.from_env(env) : nil
-          extras = nil if extras && extras.empty?
           policy = if extras
                      config.generate_nonce_csp(nonce, development_mode: development_mode,
                                                       extra_directives: extras)

--- a/lib/otto/security/csp/writer.rb
+++ b/lib/otto/security/csp/writer.rb
@@ -201,19 +201,25 @@ class Otto
         end
         private_class_method :supports_extra_directives?
 
-        # Log each extras entry the policy build dropped as :absent_directive,
-        # once per entry, with full request context.
+        # Log each extras entry the policy build dropped, once per entry, with
+        # full request context. The reason distinguishes the two ways an entry
+        # fails to land: its directive was absent from the built policy
+        # (:absent_directive) or the directive takes no value at all, so a
+        # source could never be appended to it (:valueless_directive) — the
+        # latter is an app bug worth naming precisely, since the entry is a
+        # no-op rather than a policy gap.
         def self.log_dropped_extras(env, dropped)
           return if dropped.nil? || dropped.empty?
 
           context = Otto::LoggingHelpers.request_context(env)
           dropped.each do |name, tokens|
+            reason = Policy.valueless_directive?(name) ? :valueless_directive : :absent_directive
             Otto.structured_log(
               :warn, 'CSP request extra dropped',
               context.merge(
                 directive: name,
                 token: Array(tokens).join(' ').inspect.slice(0, 128),
-                reason: :absent_directive
+                reason: reason
               )
             )
           end

--- a/lib/otto/security/csp/writer.rb
+++ b/lib/otto/security/csp/writer.rb
@@ -165,6 +165,15 @@ class Otto
         # the signature declares it. Otherwise the historical call shape is
         # used and the extras are dropped with a single structured warn
         # (`reason: :config_without_extras_support`).
+        #
+        # Declaring the kwarg is only half the duck-config protocol: opting
+        # in means BOTH accepting `extra_directives:` AND invoking the
+        # outcome block. A config that takes the kwarg but never yields
+        # leaves the outcome unknown — its policy string is still used as
+        # returned, but no applied extras are reported
+        # ({Result#extra_directives} stays nil; never fabricated from the
+        # pre-append input) and a single structured warn
+        # (`reason: :config_outcome_not_reported`) flags the gap.
         def self.build_policy(config, nonce, development_mode, extras, env)
           return [config.generate_nonce_csp(nonce, development_mode: development_mode), nil] if extras.nil?
 
@@ -180,11 +189,22 @@ class Otto
           end
 
           applied = nil
+          reported = false
           policy = config.generate_nonce_csp(
             nonce, development_mode: development_mode, extra_directives: extras
           ) do |applied_extras, dropped_extras|
+            reported = true
             applied = applied_extras unless applied_extras.empty?
             log_dropped_extras(env, dropped_extras)
+          end
+          unless reported
+            Otto.structured_log(
+              :warn, 'CSP request extras outcome unreported',
+              Otto::LoggingHelpers.request_context(env).merge(
+                directives: extras.keys.join(' '),
+                reason: :config_outcome_not_reported
+              )
+            )
           end
           [policy, applied]
         end

--- a/lib/otto/security/csp/writer.rb
+++ b/lib/otto/security/csp/writer.rb
@@ -41,6 +41,10 @@ class Otto
         CSP_HEADER = 'content-security-policy'
         CONTENT_TYPE_HEADER = 'content-type'
 
+        # Method#parameters types that declare a keyword parameter (used by
+        # {.supports_extra_directives?}).
+        KEYWORD_PARAM_TYPES = %i[key keyreq].freeze
+
         # Emission modes. `:override` is a deliberate per-request call that
         # REPLACES any existing CSP (the caller owns this response's policy).
         # `:backstop` is a passive layer that DEFERS to an existing CSP (it only
@@ -53,8 +57,9 @@ class Otto
         # written". `policy` is the emitted policy on success, or the pre-existing
         # policy when a `:backstop` deferred to one. `skip_reason` is one of
         # `:disabled`, `:blank_nonce`, `:non_html`, `:existing_csp` when skipped,
-        # else nil. `extra_directives` carries the sanitized request-scoped
-        # extras that were folded into the policy (nil when none were).
+        # else nil. `extra_directives` carries the request-scoped extras that
+        # were ACTUALLY folded into the policy — entries dropped during the
+        # append (absent directive) are excluded — or nil when none landed.
         class Result
           # Recognized skip reasons, in the order {Writer.apply} evaluates them.
           SKIP_REASONS = %i[disabled blank_nonce non_html existing_csp].freeze
@@ -137,19 +142,83 @@ class Otto
           return Result.skipped(:existing_csp, mode: mode, policy: existing) if existing && mode == :backstop
 
           extras = resolve_extras(config, env)
-          policy = if extras
-                     config.generate_nonce_csp(nonce, development_mode: development_mode,
-                                                      extra_directives: extras)
-                   else
-                     # No-extras path keeps the historical call shape, so
-                     # duck-typed configs without the new kwarg stay compatible
-                     # (and the output stays byte-identical by construction).
-                     config.generate_nonce_csp(nonce, development_mode: development_mode)
-                   end
+          policy, applied_extras = build_policy(config, nonce, development_mode, extras, env)
           write_csp(headers, policy)
-          Result.applied(policy, mode: mode, extra_directives: extras)
+          Result.applied(policy, mode: mode, extra_directives: applied_extras)
         end
         private_class_method :evaluate
+
+        # Build the policy string, folding in the request-scoped extras when
+        # the config supports them. Returns `[policy, applied_extras]` where
+        # applied_extras is the hash of extras entries that ACTUALLY landed in
+        # the policy (nil when none did), as reported back by
+        # {Policy.append_extra_sources} through the outcome block — never the
+        # pre-append input, so {Result#extra_directives} and the debug log can
+        # only claim what happened. Entries the append dropped (absent
+        # directive) are logged HERE, the one place with the env in hand, with
+        # full request context; Policy stays a pure function of its arguments.
+        #
+        # Configs are duck-typed (see {.enabled?}): one with the pre-#243
+        # `generate_nonce_csp` signature would raise ArgumentError on the
+        # `extra_directives:` kwarg at request time — violating the extras
+        # channel's never-raises invariant — so the kwarg is passed only when
+        # the signature declares it. Otherwise the historical call shape is
+        # used and the extras are dropped with a single structured warn
+        # (`reason: :config_without_extras_support`).
+        def self.build_policy(config, nonce, development_mode, extras, env)
+          return [config.generate_nonce_csp(nonce, development_mode: development_mode), nil] if extras.nil?
+
+          unless supports_extra_directives?(config)
+            Otto.structured_log(
+              :warn, 'CSP request extras dropped',
+              Otto::LoggingHelpers.request_context(env).merge(
+                directives: extras.keys.join(' '),
+                reason: :config_without_extras_support
+              )
+            )
+            return [config.generate_nonce_csp(nonce, development_mode: development_mode), nil]
+          end
+
+          applied = nil
+          policy = config.generate_nonce_csp(
+            nonce, development_mode: development_mode, extra_directives: extras
+          ) do |applied_extras, dropped_extras|
+            applied = applied_extras unless applied_extras.empty?
+            log_dropped_extras(env, dropped_extras)
+          end
+          [policy, applied]
+        end
+        private_class_method :build_policy
+
+        # Whether the config's generate_nonce_csp declares the
+        # `extra_directives:` keyword (or accepts arbitrary keywords).
+        def self.supports_extra_directives?(config)
+          parameters = config.method(:generate_nonce_csp).parameters
+          parameters.any? { |type, name| KEYWORD_PARAM_TYPES.include?(type) && name == :extra_directives } ||
+            parameters.any? { |type, _name| type == :keyrest }
+        rescue NameError
+          false
+        end
+        private_class_method :supports_extra_directives?
+
+        # Log each extras entry the policy build dropped as :absent_directive,
+        # once per entry, with full request context.
+        def self.log_dropped_extras(env, dropped)
+          return if dropped.nil? || dropped.empty?
+
+          context = Otto::LoggingHelpers.request_context(env)
+          dropped.each do |name, tokens|
+            Otto.structured_log(
+              :warn, 'CSP request extra dropped',
+              context.merge(
+                directive: name,
+                token: Array(tokens).join(' ').inspect.slice(0, 128),
+                reason: :absent_directive
+              )
+            )
+          end
+        end
+        private_class_method :log_dropped_extras
 
         # Resolve the request-scoped extras, gated on the boot-time opt-in.
         # The env key is a write surface ANY middleware in the Rack stack can

--- a/lib/otto/security/csp/writer.rb
+++ b/lib/otto/security/csp/writer.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require_relative 'request_extras'
+
 class Otto
   module Security
     module CSP
@@ -51,23 +53,25 @@ class Otto
         # written". `policy` is the emitted policy on success, or the pre-existing
         # policy when a `:backstop` deferred to one. `skip_reason` is one of
         # `:disabled`, `:blank_nonce`, `:non_html`, `:existing_csp` when skipped,
-        # else nil.
+        # else nil. `extra_directives` carries the sanitized request-scoped
+        # extras that were folded into the policy (nil when none were).
         class Result
           # Recognized skip reasons, in the order {Writer.apply} evaluates them.
           SKIP_REASONS = %i[disabled blank_nonce non_html existing_csp].freeze
 
-          attr_reader :policy, :skip_reason, :mode
+          attr_reader :policy, :skip_reason, :mode, :extra_directives
 
-          def initialize(applied:, mode:, policy: nil, skip_reason: nil)
+          def initialize(applied:, mode:, policy: nil, skip_reason: nil, extra_directives: nil)
             @applied = applied
             @mode = mode
             @policy = policy
             @skip_reason = skip_reason
+            @extra_directives = extra_directives
           end
 
           # Build an "applied" result for a written policy.
-          def self.applied(policy, mode:)
-            new(applied: true, mode: mode, policy: policy)
+          def self.applied(policy, mode:, extra_directives: nil)
+            new(applied: true, mode: mode, policy: policy, extra_directives: extra_directives)
           end
 
           # Build a "skipped" result. `policy` carries the pre-existing policy for
@@ -96,23 +100,31 @@ class Otto
         #   and the policy string ({Otto::Security::Config#generate_nonce_csp}).
         # @param mode [Symbol] one of {MODES}.
         # @param development_mode [Boolean] use the development directive set.
+        # @param env [Hash, nil] the Rack environment. When given, any
+        #   request-scoped directive extras the app wrote to
+        #   `env['otto.csp.extra_directives']` are sanitized
+        #   ({Otto::Security::CSP::RequestExtras.from_env}) and folded
+        #   ADDITIVELY into the policy. Nil (surfaces with no env in hand)
+        #   simply builds the policy without extras.
         # @return [Result]
         # @raise [ArgumentError] if mode is not one of {MODES}
         # @raise [FrozenError] if a write is attempted against a frozen headers hash
-        def self.apply(headers, nonce, config:, mode: :override, development_mode: false)
+        def self.apply(headers, nonce, config:, mode: :override, development_mode: false, env: nil)
           unless MODES.include?(mode)
             raise ArgumentError, "mode must be one of #{MODES.join(', ')}, got #{mode.inspect}"
           end
 
-          result = evaluate(headers, nonce, config, mode, development_mode)
+          result = evaluate(headers, nonce, config, mode, development_mode, env)
           log_debug(config, result)
           result
         end
 
         # Guarded core: returns a Result and performs the in-place write when it
         # applies. Guards are evaluated most-fundamental first so the reported
-        # skip_reason is stable and meaningful.
-        def self.evaluate(headers, nonce, config, mode, development_mode)
+        # skip_reason is stable and meaningful. Request-scoped extras are
+        # resolved only once every guard has passed, so a skipped response never
+        # logs extras drops for a policy that was never built.
+        def self.evaluate(headers, nonce, config, mode, development_mode, env)
           return Result.skipped(:disabled, mode: mode) unless enabled?(config)
           return Result.skipped(:blank_nonce, mode: mode) if blank?(nonce)
           return Result.skipped(:non_html, mode: mode) unless html_response?(headers)
@@ -120,9 +132,19 @@ class Otto
           existing = existing_csp(headers)
           return Result.skipped(:existing_csp, mode: mode, policy: existing) if existing && mode == :backstop
 
-          policy = config.generate_nonce_csp(nonce, development_mode: development_mode)
+          extras = env ? RequestExtras.from_env(env) : nil
+          extras = nil if extras && extras.empty?
+          policy = if extras
+                     config.generate_nonce_csp(nonce, development_mode: development_mode,
+                                                      extra_directives: extras)
+                   else
+                     # No-extras path keeps the historical call shape, so
+                     # duck-typed configs without the new kwarg stay compatible
+                     # (and the output stays byte-identical by construction).
+                     config.generate_nonce_csp(nonce, development_mode: development_mode)
+                   end
           write_csp(headers, policy)
-          Result.applied(policy, mode: mode)
+          Result.applied(policy, mode: mode, extra_directives: extras)
         end
         private_class_method :evaluate
 
@@ -182,12 +204,18 @@ class Otto
 
         # Uniform debug observability: when the config opts into CSP debugging,
         # log the outcome — applied policy OR skip reason — so "why didn't my page
-        # get a CSP?" no longer needs a debugger.
+        # get a CSP?" no longer needs a debugger. When request-scoped extras
+        # were folded in, note which directives and how many tokens: the
+        # EmitMiddleware backstop is otherwise silent about them, so this is
+        # the observable trace that a request's extras actually landed.
         def self.log_debug(config, result)
           return unless config.respond_to?(:debug_csp?) && config.debug_csp?
           return unless defined?(Otto.logger) && Otto.logger
 
           detail = result.applied? ? "applied (#{result.mode}) #{result.policy}" : "skipped (#{result.skip_reason})"
+          if (extras = result.extra_directives)
+            detail += " extras[#{extras.keys.join(' ')}](#{extras.each_value.sum(&:length)} tokens)"
+          end
           Otto.logger.debug("[CSP] #{detail}")
         end
         private_class_method :log_debug

--- a/lib/otto/version.rb
+++ b/lib/otto/version.rb
@@ -3,5 +3,5 @@
 # frozen_string_literal: true
 
 class Otto
-  VERSION = '2.8.1'
+  VERSION = '2.9.0.pre1'
 end

--- a/spec/otto/response_csp_spec.rb
+++ b/spec/otto/response_csp_spec.rb
@@ -29,12 +29,15 @@ RSpec.describe Otto::Response do
 
     # Extras contract helper (see spec/support/csp_request_extras_examples.rb):
     # #apply_csp sees extras only through a WIRED request (request&.env), so
-    # the helper attaches one carrying the given env.
-    def emit_csp_with_env(headers:, nonce:, env:)
+    # the helper attaches one carrying the given env; the config's boot-time
+    # opt-in still gates the channel.
+    def emit_csp_with_env(headers:, nonce:, env:, extras_enabled: true)
+      config = build_config
+      config.enable_csp_request_extras! if extras_enabled
       response = described_class.new
       headers.each { |k, v| response.headers[k] = v }
       response.request = Otto::Request.new(env)
-      response.apply_csp(nonce, security_config: build_config)
+      response.apply_csp(nonce, security_config: config)
       response.headers
     end
 
@@ -74,8 +77,10 @@ RSpec.describe Otto::Response do
 
     context 'request-scoped directive extras' do
       it 'reads extras from the wired request env' do
+        config = build_config
+        config.enable_csp_request_extras!
         env = mock_rack_env(method: 'GET', path: '/')
-        env['otto.security_config'] = build_config
+        env['otto.security_config'] = config
         env['otto.csp.extra_directives'] = { 'form-action' => ['https://idp.example.com'] }
         response = described_class.new
         response.headers['content-type'] = 'text/html'

--- a/spec/otto/response_csp_spec.rb
+++ b/spec/otto/response_csp_spec.rb
@@ -27,9 +27,21 @@ RSpec.describe Otto::Response do
       response.headers
     end
 
+    # Extras contract helper (see spec/support/csp_request_extras_examples.rb):
+    # #apply_csp sees extras only through a WIRED request (request&.env), so
+    # the helper attaches one carrying the given env.
+    def emit_csp_with_env(headers:, nonce:, env:)
+      response = described_class.new
+      headers.each { |k, v| response.headers[k] = v }
+      response.request = Otto::Request.new(env)
+      response.apply_csp(nonce, security_config: build_config)
+      response.headers
+    end
+
     include_examples 'a nonce-CSP emission surface'
     include_examples 'a CSP override surface'
     include_examples 'a CSP backstop surface'
+    include_examples 'a request-extras-aware CSP surface'
 
     it 'returns the Writer::Result' do
       response = described_class.new
@@ -58,6 +70,34 @@ RSpec.describe Otto::Response do
 
       expect(response.headers).not_to have_key('content-security-policy')
       expect(result.skip_reason).to eq(:non_html)
+    end
+
+    context 'request-scoped directive extras' do
+      it 'reads extras from the wired request env' do
+        env = mock_rack_env(method: 'GET', path: '/')
+        env['otto.security_config'] = build_config
+        env['otto.csp.extra_directives'] = { 'form-action' => ['https://idp.example.com'] }
+        response = described_class.new
+        response.headers['content-type'] = 'text/html'
+        response.request = Otto::Request.new(env)
+
+        result = response.apply_csp('N')
+
+        expect(response.headers['content-security-policy'])
+          .to include("form-action 'self' https://idp.example.com;")
+        expect(result.extra_directives).to eq('form-action' => ['https://idp.example.com'])
+      end
+
+      it 'degrades silently to the base policy when no request is wired' do
+        response = described_class.new
+        response.headers['content-type'] = 'text/html'
+
+        result = response.apply_csp('N', security_config: build_config)
+
+        expect(result).to be_applied
+        expect(result.extra_directives).to be_nil
+        expect(response.headers['content-security-policy']).to include("form-action 'self';")
+      end
     end
   end
 

--- a/spec/otto/security/csp/emit_middleware_spec.rb
+++ b/spec/otto/security/csp/emit_middleware_spec.rb
@@ -24,8 +24,21 @@ RSpec.describe Otto::Security::CSP::EmitMiddleware do
     out_headers
   end
 
+  # Extras contract helper (see spec/support/csp_request_extras_examples.rb):
+  # the middleware hands its own env to the Writer, so extras placed there are
+  # picked up on the way out.
+  def emit_csp_with_env(headers:, nonce:, env:)
+    config = build_config
+    env['otto.security_config'] = config
+    env['otto.nonce'] = nonce
+    app = ->(_e) { [200, headers, []] }
+    _status, out_headers, = described_class.new(app, config).call(env)
+    out_headers
+  end
+
   include_examples 'a nonce-CSP emission surface'
   include_examples 'a CSP backstop surface'
+  include_examples 'a request-extras-aware CSP surface'
 
   let(:enabled_config) { build_config }
   let(:html_headers) { { 'content-type' => 'text/html; charset=utf-8' } }
@@ -115,6 +128,30 @@ RSpec.describe Otto::Security::CSP::EmitMiddleware do
 
       expect(headers['content-security-policy']).to include("script-src 'nonce-N';")
       expect(headers['content-security-policy']).not_to include('unsafe-inline;')
+    end
+  end
+
+  describe 'request-scoped directive extras (env["otto.csp.extra_directives"])' do
+    it 'folds extras the HANDLER wrote during the request into the backstop policy' do
+      env = { 'otto.security_config' => enabled_config, 'otto.nonce' => 'N' }
+      app = lambda do |e|
+        # The handler resolves per-request data (e.g. the tenant's IdP origin)
+        # and widens form-action for this response only.
+        e['otto.csp.extra_directives'] = { form_action: 'https://idp.tenant.example' }
+        [200, html_headers.dup, ['body']]
+      end
+      _status, headers, = described_class.new(app, enabled_config).call(env)
+
+      expect(headers['content-security-policy'])
+        .to include("form-action 'self' https://idp.tenant.example;")
+    end
+
+    it 'leaves a request without extras unchanged' do
+      env = { 'otto.security_config' => enabled_config, 'otto.nonce' => 'N' }
+      _status, headers, = call_with(env: env, headers: html_headers.dup)
+
+      expect(headers['content-security-policy']).to include("form-action 'self';")
+      expect(headers['content-security-policy']).not_to include('idp.tenant.example')
     end
   end
 

--- a/spec/otto/security/csp/emit_middleware_spec.rb
+++ b/spec/otto/security/csp/emit_middleware_spec.rb
@@ -26,9 +26,10 @@ RSpec.describe Otto::Security::CSP::EmitMiddleware do
 
   # Extras contract helper (see spec/support/csp_request_extras_examples.rb):
   # the middleware hands its own env to the Writer, so extras placed there are
-  # picked up on the way out.
-  def emit_csp_with_env(headers:, nonce:, env:)
+  # picked up on the way out — but only when the config opted the channel in.
+  def emit_csp_with_env(headers:, nonce:, env:, extras_enabled: true)
     config = build_config
+    config.enable_csp_request_extras! if extras_enabled
     env['otto.security_config'] = config
     env['otto.nonce'] = nonce
     app = ->(_e) { [200, headers, []] }
@@ -132,15 +133,21 @@ RSpec.describe Otto::Security::CSP::EmitMiddleware do
   end
 
   describe 'request-scoped directive extras (env["otto.csp.extra_directives"])' do
+    let(:extras_config) do
+      config = build_config
+      config.enable_csp_request_extras!
+      config
+    end
+
     it 'folds extras the HANDLER wrote during the request into the backstop policy' do
-      env = { 'otto.security_config' => enabled_config, 'otto.nonce' => 'N' }
+      env = { 'otto.security_config' => extras_config, 'otto.nonce' => 'N' }
       app = lambda do |e|
         # The handler resolves per-request data (e.g. the tenant's IdP origin)
         # and widens form-action for this response only.
         e['otto.csp.extra_directives'] = { form_action: 'https://idp.tenant.example' }
         [200, html_headers.dup, ['body']]
       end
-      _status, headers, = described_class.new(app, enabled_config).call(env)
+      _status, headers, = described_class.new(app, extras_config).call(env)
 
       expect(headers['content-security-policy'])
         .to include("form-action 'self' https://idp.tenant.example;")

--- a/spec/otto/security/csp/policy_spec.rb
+++ b/spec/otto/security/csp/policy_spec.rb
@@ -81,6 +81,35 @@ RSpec.describe Otto::Security::CSP::Policy do
       )
       expect(csp).to eq("#{production.sub("worker-src 'self' blob:;", "worker-src 'self' data:;")} report-uri /r;")
     end
+
+    it 'is byte-identical when extra_directives is nil or empty' do
+      expect(described_class.nonce_policy('N', extra_directives: nil)).to eq(production)
+      expect(described_class.nonce_policy('N', extra_directives: {})).to eq(production)
+    end
+
+    it 'applies extras AFTER overrides and BEFORE reporting directives' do
+      csp = described_class.nonce_policy(
+        'N', report_uri: '/r',
+             directive_overrides: { 'form-action' => "'self' https://boot.example.com" },
+             extra_directives: { 'form-action' => ['https://req.example.com'] }
+      )
+      expect(csp).to include("form-action 'self' https://boot.example.com https://req.example.com;")
+      expect(csp).to end_with('report-uri /r;')
+    end
+
+    it 'does not resurrect a directive a boot override deliberately removed' do
+      allow(Otto).to receive(:structured_log)
+
+      csp = described_class.nonce_policy(
+        'N', directive_overrides: { 'form-action' => nil },
+             extra_directives: { 'form-action' => ['https://req.example.com'] }
+      )
+
+      expect(csp).not_to include('form-action')
+      expect(Otto).to have_received(:structured_log)
+        .with(:warn, 'CSP request extra dropped',
+              hash_including(directive: 'form-action', reason: :absent_directive))
+    end
   end
 
   describe '.merge_directives' do
@@ -112,6 +141,61 @@ RSpec.describe Otto::Security::CSP::Policy do
       base = ["default-src 'none';"]
       expect { described_class.merge_directives(base, { 'media-src; script-src *' => "'self'" }) }
         .to raise_error(ArgumentError)
+    end
+  end
+
+  describe '.append_extra_sources' do
+    let(:base) { ["default-src 'none';", "form-action 'self';", "worker-src 'self' blob:;"] }
+
+    it 'returns the base set unchanged for nil/empty extras' do
+      expect(described_class.append_extra_sources(base, nil)).to eq(base)
+      expect(described_class.append_extra_sources(base, {})).to eq(base)
+    end
+
+    it 'appends extra tokens to a directive present in the built list' do
+      merged = described_class.append_extra_sources(
+        base, { 'form-action' => ['https://idp.example.com'] }
+      )
+      expect(merged).to eq(
+        ["default-src 'none';", "form-action 'self' https://idp.example.com;", "worker-src 'self' blob:;"]
+      )
+    end
+
+    it 'does not append a token the directive already carries (dedupe)' do
+      merged = described_class.append_extra_sources(
+        ["form-action 'self' https://idp.example.com;"],
+        { 'form-action' => ['https://idp.example.com', 'https://other.example.com'] }
+      )
+      expect(merged).to eq(["form-action 'self' https://idp.example.com https://other.example.com;"])
+    end
+
+    it 'drops (and logs) a directive absent from the built list instead of creating it' do
+      allow(Otto).to receive(:structured_log)
+
+      merged = described_class.append_extra_sources(
+        base, { 'media-src' => ['https://media.example.com'] }
+      )
+
+      expect(merged).to eq(base)
+      expect(Otto).to have_received(:structured_log)
+        .with(:warn, 'CSP request extra dropped',
+              hash_including(directive: 'media-src', reason: :absent_directive))
+    end
+
+    it 'leaves the directive BYTE-IDENTICAL when an entry has no surviving tokens' do
+      # The likely bug this pins: routing the merge through build_directive
+      # would collapse an empty source list into a bare "worker-src;",
+      # silently TIGHTENING the policy. The directive string must come back
+      # untouched instead.
+      merged = described_class.append_extra_sources(base, { 'worker-src' => [] })
+
+      expect(merged).to eq(base)
+      expect(merged[2]).to equal(base[2]).or eq("worker-src 'self' blob:;")
+      expect(merged[2]).not_to eq('worker-src;')
+    end
+
+    it 'skips a nil token list gracefully (defensive; sanitizer never sends one)' do
+      expect(described_class.append_extra_sources(base, { 'worker-src' => nil })).to eq(base)
     end
   end
 

--- a/spec/otto/security/csp/policy_spec.rb
+++ b/spec/otto/security/csp/policy_spec.rb
@@ -199,6 +199,18 @@ RSpec.describe Otto::Security::CSP::Policy do
     end
   end
 
+  describe '.normalize_directive_name' do
+    it 'strips, downcases, and maps underscores to hyphens' do
+      expect(described_class.normalize_directive_name(' FORM_ACTION ')).to eq('form-action')
+      expect(described_class.normalize_directive_name(:form_action)).to eq('form-action')
+      expect(described_class.normalize_directive_name('form-action')).to eq('form-action')
+    end
+
+    it 'returns an empty string for blank input' do
+      expect(described_class.normalize_directive_name('   ')).to eq('')
+    end
+  end
+
   describe '.static_policy' do
     it 'is byte-identical to the base policy when no reporting is configured' do
       expect(described_class.static_policy("default-src 'self'")).to eq("default-src 'self'")

--- a/spec/otto/security/csp/policy_spec.rb
+++ b/spec/otto/security/csp/policy_spec.rb
@@ -214,6 +214,82 @@ RSpec.describe Otto::Security::CSP::Policy do
     it 'skips a nil token list gracefully (defensive; sanitizer never sends one)' do
       expect(described_class.append_extra_sources(base, { 'worker-src' => nil })).to eq([base, {}, {}])
     end
+
+    context 'with a directive that takes no value' do
+      # A source appended to upgrade-insecure-requests makes the directive
+      # MALFORMED, and browsers discard a malformed directive wholesale — so
+      # an unguarded append would silently turn the directive OFF.
+      let(:valueless_base) do
+        ["default-src 'none';", 'upgrade-insecure-requests;', "form-action 'self';"]
+      end
+
+      Otto::Security::CSP::Policy::VALUELESS_DIRECTIVES.each do |name|
+        it "leaves #{name} byte-identical and reports the entry dropped" do
+          policy = ["default-src 'none';", "#{name};"]
+
+          merged, applied, dropped = described_class.append_extra_sources(
+            policy, { name => ['https://idp.example.com'] }
+          )
+
+          expect(merged).to eq(policy)
+          expect(merged.last).to eq("#{name};")
+          expect(merged.join(' ')).not_to include('https://idp.example.com')
+          expect(applied).to eq({})
+          expect(dropped).to eq(name => ['https://idp.example.com'])
+        end
+      end
+
+      it 'drops a symbol/underscore key form addressing a valueless directive' do
+        merged, applied, dropped = described_class.append_extra_sources(
+          valueless_base, { upgrade_insecure_requests: ['https://idp.example.com'] }
+        )
+
+        expect(merged).to eq(valueless_base)
+        expect(applied).to eq({})
+        expect(dropped).to eq(upgrade_insecure_requests: ['https://idp.example.com'])
+      end
+
+      it 'drops a mixed-case key form addressing a valueless directive' do
+        merged, applied, dropped = described_class.append_extra_sources(
+          valueless_base, { 'Upgrade-Insecure-Requests' => ['https://idp.example.com'] }
+        )
+
+        expect(merged).to eq(valueless_base)
+        expect(applied).to eq({})
+        expect(dropped).to eq('Upgrade-Insecure-Requests' => ['https://idp.example.com'])
+      end
+
+      it 'still applies the other entries in the same call (one bad key does not poison the batch)' do
+        merged, applied, dropped = described_class.append_extra_sources(
+          valueless_base,
+          {
+            'upgrade-insecure-requests' => ['https://idp.example.com'],
+            'form-action' => ['https://idp.example.com'],
+          }
+        )
+
+        expect(merged).to eq(
+          ["default-src 'none';", 'upgrade-insecure-requests;', "form-action 'self' https://idp.example.com;"]
+        )
+        expect(applied).to eq('form-action' => ['https://idp.example.com'])
+        expect(dropped).to eq('upgrade-insecure-requests' => ['https://idp.example.com'])
+      end
+    end
+  end
+
+  describe '.valueless_directive?' do
+    it 'recognizes the valueless directives in any key form' do
+      expect(described_class.valueless_directive?('upgrade-insecure-requests')).to be true
+      expect(described_class.valueless_directive?(:upgrade_insecure_requests)).to be true
+      expect(described_class.valueless_directive?(' Block-All-Mixed-Content ')).to be true
+    end
+
+    it 'leaves value-taking directives alone (scope discipline: sandbox et al. stay appendable)' do
+      expect(described_class.valueless_directive?('form-action')).to be false
+      expect(described_class.valueless_directive?('sandbox')).to be false
+      expect(described_class.valueless_directive?('trusted-types')).to be false
+      expect(described_class.valueless_directive?('require-trusted-types-for')).to be false
+    end
   end
 
   describe '.normalize_directive_name' do

--- a/spec/otto/security/csp/policy_spec.rb
+++ b/spec/otto/security/csp/policy_spec.rb
@@ -98,17 +98,26 @@ RSpec.describe Otto::Security::CSP::Policy do
     end
 
     it 'does not resurrect a directive a boot override deliberately removed' do
-      allow(Otto).to receive(:structured_log)
-
+      outcome = nil
       csp = described_class.nonce_policy(
         'N', directive_overrides: { 'form-action' => nil },
              extra_directives: { 'form-action' => ['https://req.example.com'] }
-      )
+      ) { |applied, dropped| outcome = [applied, dropped] }
 
       expect(csp).not_to include('form-action')
-      expect(Otto).to have_received(:structured_log)
-        .with(:warn, 'CSP request extra dropped',
-              hash_including(directive: 'form-action', reason: :absent_directive))
+      # Pure reporting, no logging: the dropped entry comes back through the
+      # outcome block so the caller holding the env can log it.
+      expect(outcome).to eq([{}, { 'form-action' => ['https://req.example.com'] }])
+    end
+
+    it 'yields the applied/dropped outcome without changing the returned policy' do
+      outcome = nil
+      csp = described_class.nonce_policy(
+        'N', extra_directives: { 'form-action' => ['https://req.example.com'] }
+      ) { |applied, dropped| outcome = [applied, dropped] }
+
+      expect(csp).to include("form-action 'self' https://req.example.com;")
+      expect(outcome).to eq([{ 'form-action' => ['https://req.example.com'] }, {}])
     end
   end
 
@@ -147,39 +156,44 @@ RSpec.describe Otto::Security::CSP::Policy do
   describe '.append_extra_sources' do
     let(:base) { ["default-src 'none';", "form-action 'self';", "worker-src 'self' blob:;"] }
 
-    it 'returns the base set unchanged for nil/empty extras' do
-      expect(described_class.append_extra_sources(base, nil)).to eq(base)
-      expect(described_class.append_extra_sources(base, {})).to eq(base)
+    it 'returns [base, {}, {}] unchanged for nil/empty extras' do
+      expect(described_class.append_extra_sources(base, nil)).to eq([base, {}, {}])
+      expect(described_class.append_extra_sources(base, {})).to eq([base, {}, {}])
     end
 
-    it 'appends extra tokens to a directive present in the built list' do
-      merged = described_class.append_extra_sources(
+    it 'appends extra tokens to a directive present in the built list and reports it applied' do
+      merged, applied, dropped = described_class.append_extra_sources(
         base, { 'form-action' => ['https://idp.example.com'] }
       )
       expect(merged).to eq(
         ["default-src 'none';", "form-action 'self' https://idp.example.com;", "worker-src 'self' blob:;"]
       )
+      expect(applied).to eq('form-action' => ['https://idp.example.com'])
+      expect(dropped).to eq({})
     end
 
     it 'does not append a token the directive already carries (dedupe)' do
-      merged = described_class.append_extra_sources(
+      merged, applied, = described_class.append_extra_sources(
         ["form-action 'self' https://idp.example.com;"],
         { 'form-action' => ['https://idp.example.com', 'https://other.example.com'] }
       )
       expect(merged).to eq(["form-action 'self' https://idp.example.com https://other.example.com;"])
+      # Already-present tokens still count as applied: they ARE in the policy.
+      expect(applied).to eq('form-action' => ['https://idp.example.com', 'https://other.example.com'])
     end
 
-    it 'drops (and logs) a directive absent from the built list instead of creating it' do
+    it 'drops a directive absent from the built list, reporting it — never logging' do
       allow(Otto).to receive(:structured_log)
 
-      merged = described_class.append_extra_sources(
+      merged, applied, dropped = described_class.append_extra_sources(
         base, { 'media-src' => ['https://media.example.com'] }
       )
 
       expect(merged).to eq(base)
-      expect(Otto).to have_received(:structured_log)
-        .with(:warn, 'CSP request extra dropped',
-              hash_including(directive: 'media-src', reason: :absent_directive))
+      expect(applied).to eq({})
+      expect(dropped).to eq('media-src' => ['https://media.example.com'])
+      # Pure function of its arguments: logging is the env-holding caller's job.
+      expect(Otto).not_to have_received(:structured_log)
     end
 
     it 'leaves the directive BYTE-IDENTICAL when an entry has no surviving tokens' do
@@ -187,15 +201,18 @@ RSpec.describe Otto::Security::CSP::Policy do
       # would collapse an empty source list into a bare "worker-src;",
       # silently TIGHTENING the policy. The directive string must come back
       # untouched instead.
-      merged = described_class.append_extra_sources(base, { 'worker-src' => [] })
+      merged, applied, dropped = described_class.append_extra_sources(base, { 'worker-src' => [] })
 
       expect(merged).to eq(base)
       expect(merged[2]).to equal(base[2]).or eq("worker-src 'self' blob:;")
       expect(merged[2]).not_to eq('worker-src;')
+      # An empty entry neither applies nor drops — nothing was requested.
+      expect(applied).to eq({})
+      expect(dropped).to eq({})
     end
 
     it 'skips a nil token list gracefully (defensive; sanitizer never sends one)' do
-      expect(described_class.append_extra_sources(base, { 'worker-src' => nil })).to eq(base)
+      expect(described_class.append_extra_sources(base, { 'worker-src' => nil })).to eq([base, {}, {}])
     end
   end
 

--- a/spec/otto/security/csp/request_extras_spec.rb
+++ b/spec/otto/security/csp/request_extras_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Otto::Security::CSP::RequestExtras do
   end
 
   describe 'refused directives' do
-    %w[script-src script-src-elem script-src-attr default-src].each do |name|
+    described_class::REFUSED_DIRECTIVES.each do |name|
       it "refuses #{name} wholesale (drop-and-log)" do
         expect(from_env_with(name => ['https://a.example.com'])).to be_nil
         expect_dropped(:refused_directive)
@@ -80,6 +80,11 @@ RSpec.describe Otto::Security::CSP::RequestExtras do
 
     it 'refuses a refused directive addressed via a Symbol key' do
       expect(from_env_with(script_src: ['https://a.example.com'])).to be_nil
+      expect_dropped(:refused_directive)
+    end
+
+    it 'refuses a valueless directive addressed via a Symbol/underscore key' do
+      expect(from_env_with(upgrade_insecure_requests: ['https://a.example.com'])).to be_nil
       expect_dropped(:refused_directive)
     end
   end

--- a/spec/otto/security/csp/request_extras_spec.rb
+++ b/spec/otto/security/csp/request_extras_spec.rb
@@ -53,21 +53,33 @@ RSpec.describe Otto::Security::CSP::RequestExtras do
     end
 
     it 'drops-and-logs a blank key' do
-      expect(from_env_with('  ' => ['https://a.example.com'])).to eq({})
+      expect(from_env_with('  ' => ['https://a.example.com'])).to be_nil
       expect_dropped(:invalid_shape)
+    end
+
+    it 'merges (unions) token lists when two raw keys normalize to the same directive' do
+      result = from_env_with(
+        'form_action' => ['https://a.example.com', 'https://both.example.com'],
+        'form-action' => ['https://b.example.com', 'https://both.example.com']
+      )
+
+      expect(result).to eq(
+        'form-action' => ['https://a.example.com', 'https://both.example.com', 'https://b.example.com']
+      )
+      expect_no_drops # nothing was dropped, so nothing is logged
     end
   end
 
   describe 'refused directives' do
     %w[script-src script-src-elem script-src-attr default-src].each do |name|
       it "refuses #{name} wholesale (drop-and-log)" do
-        expect(from_env_with(name => ['https://a.example.com'])).to eq({})
+        expect(from_env_with(name => ['https://a.example.com'])).to be_nil
         expect_dropped(:refused_directive)
       end
     end
 
     it 'refuses a refused directive addressed via a Symbol key' do
-      expect(from_env_with(script_src: ['https://a.example.com'])).to eq({})
+      expect(from_env_with(script_src: ['https://a.example.com'])).to be_nil
       expect_dropped(:refused_directive)
     end
   end
@@ -80,6 +92,8 @@ RSpec.describe Otto::Security::CSP::RequestExtras do
       'a default port (omitted)' => ['https://idp.example.com:443', 'https://idp.example.com'],
       'an uppercase origin (downcased)' => ['HTTPS://IDP.EXAMPLE.COM', 'https://idp.example.com'],
       'an IDN host in punycode form' => ['https://xn--mnchen-3ya.example', 'https://xn--mnchen-3ya.example'],
+      'a single trailing dot (FQDN root form, stripped)' => ['https://idp.example.com.', 'https://idp.example.com'],
+      'the highest valid port' => ['https://idp.example.com:65535', 'https://idp.example.com:65535'],
     }.each do |label, (token, normalized)|
       it "accepts #{label}" do
         expect(from_env_with('form-action' => [token])).to eq('form-action' => [normalized])
@@ -120,21 +134,29 @@ RSpec.describe Otto::Security::CSP::RequestExtras do
       ['a non-http(s) scheme', 'ftp://idp.example.com'],
       ['a schemeless host', 'idp.example.com'],
       ['an empty string', ''],
+      ['a doubled trailing dot (only ONE root dot is stripped)', 'https://idp.example.com..'],
+      ['a percent-encoding in the host (URI passes it through literally)', 'http://idp.example.com%00'],
+      ['a port beyond the TCP range', 'http://idp.example.com:99999999999999999999999'],
+      ['port zero', 'http://idp.example.com:0'],
     ].each do |label, token|
       it "rejects #{label}" do
-        expect(from_env_with('form-action' => [token])).to eq({})
+        expect(from_env_with('form-action' => [token])).to be_nil
         expect_dropped(:not_an_origin)
       end
     end
 
     it 'rejects a non-String token element' do
-      expect(from_env_with('form-action' => [42])).to eq({})
+      expect(from_env_with('form-action' => [42])).to be_nil
       expect_dropped(:invalid_shape)
     end
 
     it 'drops-and-logs a value that is neither String nor Array' do
-      expect(from_env_with('form-action' => 42)).to eq({})
+      expect(from_env_with('form-action' => 42)).to be_nil
       expect_dropped(:invalid_shape)
+    end
+
+    it 'returns nil (not an empty hash) when everything was dropped' do
+      expect(from_env_with('form-action' => ['*'], 'connect-src' => ["'self'"])).to be_nil
     end
 
     it 'keeps the surviving tokens when only some are rejected' do

--- a/spec/otto/security/csp/request_extras_spec.rb
+++ b/spec/otto/security/csp/request_extras_spec.rb
@@ -99,6 +99,12 @@ RSpec.describe Otto::Security::CSP::RequestExtras do
       'an IDN host in punycode form' => ['https://xn--mnchen-3ya.example', 'https://xn--mnchen-3ya.example'],
       'a single trailing dot (FQDN root form, stripped)' => ['https://idp.example.com.', 'https://idp.example.com'],
       'the highest valid port' => ['https://idp.example.com:65535', 'https://idp.example.com:65535'],
+      # URI::Generic#host retains the brackets for IPv6 literals ('[2001:db8::1]',
+      # not '2001:db8::1') — exactly what a CSP host-source needs. Pinned here so
+      # a future refactor to uri.hostname (which strips them) fails loudly.
+      'an IPv6 literal (brackets retained)' => ['https://[2001:db8::1]', 'https://[2001:db8::1]'],
+      'an IPv6 literal with a port (downcased, port kept)' =>
+        ['https://[2001:DB8::1]:8443', 'https://[2001:db8::1]:8443'],
     }.each do |label, (token, normalized)|
       it "accepts #{label}" do
         expect(from_env_with('form-action' => [token])).to eq('form-action' => [normalized])
@@ -128,6 +134,7 @@ RSpec.describe Otto::Security::CSP::RequestExtras do
       ['a bare wildcard', '*'],
       ['a wildcard host', 'https://*.example.com'],
       ['a path suffix', 'https://idp.example.com/login'],
+      ['a path suffix on an IPv6 literal', 'https://[2001:db8::1]/path'],
       ['a bare trailing slash (still a path)', 'https://idp.example.com/'],
       ['userinfo', 'https://user:secret@idp.example.com'],
       ['a query string', 'https://idp.example.com?next=x'],

--- a/spec/otto/security/csp/request_extras_spec.rb
+++ b/spec/otto/security/csp/request_extras_spec.rb
@@ -1,0 +1,183 @@
+# spec/otto/security/csp/request_extras_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Grammar and shape coverage for the request-scoped CSP extras sanitizer
+# (delano/otto#243). Every rejection is drop-and-log, never raise: a hostile
+# value must cost the attacker their token, not the response its policy.
+RSpec.describe Otto::Security::CSP::RequestExtras do
+  before { allow(Otto).to receive(:structured_log) }
+
+  let(:env_key) { described_class::ENV_KEY }
+
+  def from_env_with(value)
+    described_class.from_env(described_class::ENV_KEY => value)
+  end
+
+  def expect_dropped(reason)
+    expect(Otto).to have_received(:structured_log)
+      .with(:warn, 'CSP request extra dropped', hash_including(reason: reason))
+  end
+
+  def expect_no_drops
+    expect(Otto).not_to have_received(:structured_log)
+  end
+
+  describe 'env key handling' do
+    it 'returns nil (without logging) when the key is absent' do
+      expect(described_class.from_env({})).to be_nil
+      expect_no_drops
+    end
+
+    it 'drops-and-logs a non-Hash value and returns nil' do
+      expect(from_env_with('form-action https://a.example.com')).to be_nil
+      expect_dropped(:invalid_shape)
+    end
+
+    it 'exposes the hardcoded env key as public API' do
+      expect(env_key).to eq('otto.csp.extra_directives')
+    end
+  end
+
+  describe 'directive name normalization' do
+    it "treats 'FORM-ACTION', :form_action, and 'form-action' as the same directive" do
+      %w[FORM-ACTION form-action].each do |key|
+        expect(from_env_with(key => ['https://a.example.com']))
+          .to eq('form-action' => ['https://a.example.com'])
+      end
+      expect(from_env_with(form_action: ['https://a.example.com']))
+        .to eq('form-action' => ['https://a.example.com'])
+      expect_no_drops
+    end
+
+    it 'drops-and-logs a blank key' do
+      expect(from_env_with('  ' => ['https://a.example.com'])).to eq({})
+      expect_dropped(:invalid_shape)
+    end
+  end
+
+  describe 'refused directives' do
+    %w[script-src script-src-elem script-src-attr default-src].each do |name|
+      it "refuses #{name} wholesale (drop-and-log)" do
+        expect(from_env_with(name => ['https://a.example.com'])).to eq({})
+        expect_dropped(:refused_directive)
+      end
+    end
+
+    it 'refuses a refused directive addressed via a Symbol key' do
+      expect(from_env_with(script_src: ['https://a.example.com'])).to eq({})
+      expect_dropped(:refused_directive)
+    end
+  end
+
+  describe 'token grammar — accepted origins' do
+    {
+      'a plain https origin' => ['https://idp.example.com', 'https://idp.example.com'],
+      'a plain http origin' => ['http://idp.example.com', 'http://idp.example.com'],
+      'a non-default port (kept)' => ['https://idp.example.com:8443', 'https://idp.example.com:8443'],
+      'a default port (omitted)' => ['https://idp.example.com:443', 'https://idp.example.com'],
+      'an uppercase origin (downcased)' => ['HTTPS://IDP.EXAMPLE.COM', 'https://idp.example.com'],
+      'an IDN host in punycode form' => ['https://xn--mnchen-3ya.example', 'https://xn--mnchen-3ya.example'],
+    }.each do |label, (token, normalized)|
+      it "accepts #{label}" do
+        expect(from_env_with('form-action' => [token])).to eq('form-action' => [normalized])
+        expect_no_drops
+      end
+    end
+
+    it 'accepts a String value as a whitespace-separated source list' do
+      expect(from_env_with('form-action' => 'https://a.example.com https://b.example.com'))
+        .to eq('form-action' => ['https://a.example.com', 'https://b.example.com'])
+    end
+
+    it 'deduplicates tokens that normalize to the same origin' do
+      expect(from_env_with('form-action' => ['https://a.example.com', 'HTTPS://A.EXAMPLE.COM:443']))
+        .to eq('form-action' => ['https://a.example.com'])
+    end
+  end
+
+  describe 'token grammar — rejected tokens (drop-and-log, keep the rest)' do
+    [
+      ["the 'self' keyword", "'self'"],
+      ["the 'unsafe-inline' keyword", "'unsafe-inline'"],
+      ["the 'none' keyword", "'none'"],
+      ['the data: scheme source', 'data:'],
+      ['the blob: scheme source', 'blob:'],
+      ['the bare https: scheme source', 'https:'],
+      ['a bare wildcard', '*'],
+      ['a wildcard host', 'https://*.example.com'],
+      ['a path suffix', 'https://idp.example.com/login'],
+      ['a bare trailing slash (still a path)', 'https://idp.example.com/'],
+      ['userinfo', 'https://user:secret@idp.example.com'],
+      ['a query string', 'https://idp.example.com?next=x'],
+      ['a fragment', 'https://idp.example.com#top'],
+      ['embedded whitespace', 'https://idp.example .com'],
+      ['a semicolon (directive injection)', 'https://idp.example.com;script-src *'],
+      ['a carriage return', "https://idp.example.com\rx"],
+      ['a newline (header injection)', "https://idp.example.com\nscript-src *"],
+      ['a non-http(s) scheme', 'ftp://idp.example.com'],
+      ['a schemeless host', 'idp.example.com'],
+      ['an empty string', ''],
+    ].each do |label, token|
+      it "rejects #{label}" do
+        expect(from_env_with('form-action' => [token])).to eq({})
+        expect_dropped(:not_an_origin)
+      end
+    end
+
+    it 'rejects a non-String token element' do
+      expect(from_env_with('form-action' => [42])).to eq({})
+      expect_dropped(:invalid_shape)
+    end
+
+    it 'drops-and-logs a value that is neither String nor Array' do
+      expect(from_env_with('form-action' => 42)).to eq({})
+      expect_dropped(:invalid_shape)
+    end
+
+    it 'keeps the surviving tokens when only some are rejected' do
+      result = from_env_with('form-action' => ["'unsafe-inline'", 'https://ok.example.com', '*'])
+
+      expect(result).to eq('form-action' => ['https://ok.example.com'])
+      expect(Otto).to have_received(:structured_log)
+        .with(:warn, 'CSP request extra dropped', hash_including(reason: :not_an_origin))
+        .twice
+    end
+
+    it 'keeps other directives when one key is refused' do
+      result = from_env_with(
+        'script-src' => ['https://cdn.example.com'],
+        'form-action' => ['https://idp.example.com']
+      )
+      expect(result).to eq('form-action' => ['https://idp.example.com'])
+      expect_dropped(:refused_directive)
+    end
+  end
+
+  describe 'log payload' do
+    it 'includes the directive, a truncated token inspect, and request context' do
+      env = mock_rack_env(method: 'POST', path: '/signin')
+      env[env_key] = { 'form-action' => ['*'] }
+
+      described_class.from_env(env)
+
+      expect(Otto).to have_received(:structured_log).with(
+        :warn, 'CSP request extra dropped',
+        hash_including(directive: 'form-action', token: '"*"', reason: :not_an_origin,
+                       method: 'POST', path: '/signin')
+      )
+    end
+
+    it 'truncates a long token to 128 characters of inspect output' do
+      long = "https://#{'a' * 300}.example.com/evil"
+
+      from_env_with('form-action' => [long])
+
+      expect(Otto).to have_received(:structured_log) do |_level, _msg, data|
+        expect(data[:token].length).to be <= 128
+      end
+    end
+  end
+end

--- a/spec/otto/security/csp/writer_spec.rb
+++ b/spec/otto/security/csp/writer_spec.rb
@@ -109,6 +109,34 @@ RSpec.describe Otto::Security::CSP::Writer do
       expect(result).to be_applied
       expect(result.extra_directives).to be_nil
     end
+
+    it 'keeps a valueless directive intact, excludes it from the Result, and logs :valueless_directive' do
+      allow(Otto).to receive(:structured_log)
+      config = build_config
+      config.enable_csp_request_extras!
+      # How a real config carries the directive: an override with no sources.
+      config.csp_directive_overrides = { 'upgrade-insecure-requests' => [] }
+      headers = { 'content-type' => 'text/html' }
+      env = mock_rack_env(method: 'POST', path: '/signin')
+      env['otto.csp.extra_directives'] = {
+        'upgrade-insecure-requests' => ['https://idp.example.com'],
+        'form-action' => ['https://idp.example.com'],
+      }
+
+      result = described_class.apply(headers, 'N', config: config, env: env)
+
+      policy = headers['content-security-policy']
+      # Appending here would emit `upgrade-insecure-requests https://...;`,
+      # which browsers discard — silently disabling the directive.
+      expect(policy).to include('upgrade-insecure-requests;')
+      expect(policy).not_to include('upgrade-insecure-requests https')
+      expect(policy).to include("form-action 'self' https://idp.example.com;")
+      expect(result.extra_directives).to eq('form-action' => ['https://idp.example.com'])
+      expect(Otto).to have_received(:structured_log)
+        .with(:warn, 'CSP request extra dropped',
+              hash_including(directive: 'upgrade-insecure-requests', reason: :valueless_directive,
+                             method: 'POST', path: '/signin'))
+    end
   end
 
   describe 'request extras opt-in gating' do

--- a/spec/otto/security/csp/writer_spec.rb
+++ b/spec/otto/security/csp/writer_spec.rb
@@ -19,9 +19,17 @@ RSpec.describe Otto::Security::CSP::Writer do
     headers
   end
 
+  # Extras contract helper (see spec/support/csp_request_extras_examples.rb):
+  # the Writer reads extras from the env passed via its env: kwarg.
+  def emit_csp_with_env(headers:, nonce:, env:)
+    described_class.apply(headers, nonce, config: build_config, env: env)
+    headers
+  end
+
   include_examples 'a nonce-CSP emission surface'
   include_examples 'a CSP override surface'
   include_examples 'a CSP backstop surface'
+  include_examples 'a request-extras-aware CSP surface'
 
   describe '.apply return value (Result)' do
     let(:config) { build_config }

--- a/spec/otto/security/csp/writer_spec.rb
+++ b/spec/otto/security/csp/writer_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Otto::Security::CSP::Writer do
       expect(result.extra_directives).to be_nil
     end
 
-    it 'keeps a valueless directive intact, excludes it from the Result, and logs :valueless_directive' do
+    it 'keeps a valueless directive intact, excludes it from the Result, and rejects it during sanitization' do
       allow(Otto).to receive(:structured_log)
       config = build_config
       config.enable_csp_request_extras!
@@ -134,7 +134,7 @@ RSpec.describe Otto::Security::CSP::Writer do
       expect(result.extra_directives).to eq('form-action' => ['https://idp.example.com'])
       expect(Otto).to have_received(:structured_log)
         .with(:warn, 'CSP request extra dropped',
-              hash_including(directive: 'upgrade-insecure-requests', reason: :valueless_directive,
+              hash_including(directive: 'upgrade-insecure-requests', reason: :refused_directive,
                              method: 'POST', path: '/signin'))
     end
   end

--- a/spec/otto/security/csp/writer_spec.rb
+++ b/spec/otto/security/csp/writer_spec.rb
@@ -34,6 +34,83 @@ RSpec.describe Otto::Security::CSP::Writer do
   include_examples 'a CSP backstop surface'
   include_examples 'a request-extras-aware CSP surface'
 
+  describe 'request extras with a config lacking the extra_directives: kwarg' do
+    # A duck-typed config frozen at the pre-#243 generate_nonce_csp signature:
+    # passing extra_directives: to it would ArgumentError at request time.
+    let(:legacy_config) do
+      Class.new do
+        def csp_nonce_enabled? = true
+
+        def csp_request_extras_enabled? = true
+
+        def generate_nonce_csp(nonce, development_mode: false)
+          _ = development_mode
+          "script-src 'nonce-#{nonce}'; form-action 'self';"
+        end
+      end.new
+    end
+
+    it 'never raises: falls back to the legacy call shape, drops the extras, and warns once' do
+      allow(Otto).to receive(:structured_log)
+      headers = { 'content-type' => 'text/html' }
+      env = mock_rack_env(method: 'GET', path: '/legacy')
+      env['otto.csp.extra_directives'] = { 'form-action' => ['https://idp.example.com'] }
+
+      result = described_class.apply(headers, 'N', config: legacy_config, env: env)
+
+      expect(result).to be_applied
+      expect(result.extra_directives).to be_nil
+      expect(headers['content-security-policy']).to eq("script-src 'nonce-N'; form-action 'self';")
+      expect(Otto).to have_received(:structured_log)
+        .with(:warn, 'CSP request extras dropped',
+              hash_including(directives: 'form-action', reason: :config_without_extras_support,
+                             path: '/legacy'))
+        .once
+    end
+  end
+
+  describe 'request extras applied/dropped accounting' do
+    it 'excludes an absent-directive entry from Result#extra_directives and logs it with request context' do
+      allow(Otto).to receive(:structured_log)
+      config = build_config
+      config.enable_csp_request_extras!
+      config.csp_directive_overrides = { 'form-action' => nil } # boot removed it
+      headers = { 'content-type' => 'text/html' }
+      env = mock_rack_env(method: 'POST', path: '/signin')
+      env['otto.csp.extra_directives'] = {
+        'form-action' => ['https://idp.example.com'],
+        'connect-src' => ['https://api.example.com'],
+      }
+
+      result = described_class.apply(headers, 'N', config: config, env: env)
+
+      expect(result).to be_applied
+      # Only what actually landed — the form-action entry was dropped by the
+      # append (absent directive), so the Result must not claim it.
+      expect(result.extra_directives).to eq('connect-src' => ['https://api.example.com'])
+      expect(headers['content-security-policy']).not_to include('form-action')
+      expect(headers['content-security-policy']).to include('https://api.example.com')
+      expect(Otto).to have_received(:structured_log)
+        .with(:warn, 'CSP request extra dropped',
+              hash_including(directive: 'form-action', reason: :absent_directive,
+                             method: 'POST', path: '/signin'))
+    end
+
+    it 'reports nil extras when every entry was dropped by the append' do
+      allow(Otto).to receive(:structured_log)
+      config = build_config
+      config.enable_csp_request_extras!
+      config.csp_directive_overrides = { 'form-action' => nil }
+      headers = { 'content-type' => 'text/html' }
+      env = { 'otto.csp.extra_directives' => { 'form-action' => ['https://idp.example.com'] } }
+
+      result = described_class.apply(headers, 'N', config: config, env: env)
+
+      expect(result).to be_applied
+      expect(result.extra_directives).to be_nil
+    end
+  end
+
   describe 'request extras opt-in gating' do
     it 'treats a duck-typed config without the predicate as extras-disabled' do
       allow(Otto).to receive(:structured_log)

--- a/spec/otto/security/csp/writer_spec.rb
+++ b/spec/otto/security/csp/writer_spec.rb
@@ -69,6 +69,45 @@ RSpec.describe Otto::Security::CSP::Writer do
     end
   end
 
+  describe 'request extras with a config that takes the kwarg but never reports' do
+    # A duck-typed config halfway into the #243 protocol: it declares the
+    # extra_directives: kwarg (so the Writer passes the extras) but never
+    # invokes the outcome block, leaving what actually landed unknown.
+    let(:hybrid_config) do
+      Class.new do
+        def csp_nonce_enabled? = true
+
+        def csp_request_extras_enabled? = true
+
+        def generate_nonce_csp(nonce, development_mode: false, extra_directives: nil)
+          _ = development_mode
+          _ = extra_directives
+          "script-src 'nonce-#{nonce}'; form-action 'self';"
+        end
+      end.new
+    end
+
+    it 'uses the returned policy, reports no applied extras, and warns once about the unreported outcome' do
+      allow(Otto).to receive(:structured_log)
+      headers = { 'content-type' => 'text/html' }
+      env = mock_rack_env(method: 'GET', path: '/hybrid')
+      env['otto.csp.extra_directives'] = { 'form-action' => ['https://idp.example.com'] }
+
+      result = described_class.apply(headers, 'N', config: hybrid_config, env: env)
+
+      expect(result).to be_applied
+      # The outcome is unknown, not "everything applied" — the Result must
+      # never fabricate applied extras from the pre-append input.
+      expect(result.extra_directives).to be_nil
+      expect(headers['content-security-policy']).to eq("script-src 'nonce-N'; form-action 'self';")
+      expect(Otto).to have_received(:structured_log)
+        .with(:warn, 'CSP request extras outcome unreported',
+              hash_including(directives: 'form-action', reason: :config_outcome_not_reported,
+                             path: '/hybrid'))
+        .once
+    end
+  end
+
   describe 'request extras applied/dropped accounting' do
     it 'excludes an absent-directive entry from Result#extra_directives and logs it with request context' do
       allow(Otto).to receive(:structured_log)
@@ -108,6 +147,10 @@ RSpec.describe Otto::Security::CSP::Writer do
 
       expect(result).to be_applied
       expect(result.extra_directives).to be_nil
+      # The config DID report (empty applied) — the unreported-outcome warn
+      # must key off the block having run, not off applied staying nil.
+      expect(Otto).not_to have_received(:structured_log)
+        .with(:warn, 'CSP request extras outcome unreported', anything)
     end
 
     it 'keeps a valueless directive intact, excludes it from the Result, and rejects it during sanitization' do

--- a/spec/otto/security/csp/writer_spec.rb
+++ b/spec/otto/security/csp/writer_spec.rb
@@ -20,9 +20,12 @@ RSpec.describe Otto::Security::CSP::Writer do
   end
 
   # Extras contract helper (see spec/support/csp_request_extras_examples.rb):
-  # the Writer reads extras from the env passed via its env: kwarg.
-  def emit_csp_with_env(headers:, nonce:, env:)
-    described_class.apply(headers, nonce, config: build_config, env: env)
+  # the Writer reads extras from the env passed via its env: kwarg, gated on
+  # the config's boot-time opt-in.
+  def emit_csp_with_env(headers:, nonce:, env:, extras_enabled: true)
+    config = build_config
+    config.enable_csp_request_extras! if extras_enabled
+    described_class.apply(headers, nonce, config: config, env: env)
     headers
   end
 
@@ -30,6 +33,30 @@ RSpec.describe Otto::Security::CSP::Writer do
   include_examples 'a CSP override surface'
   include_examples 'a CSP backstop surface'
   include_examples 'a request-extras-aware CSP surface'
+
+  describe 'request extras opt-in gating' do
+    it 'treats a duck-typed config without the predicate as extras-disabled' do
+      allow(Otto).to receive(:structured_log)
+      duck_config = Class.new do
+        def csp_nonce_enabled? = true
+
+        def generate_nonce_csp(nonce, development_mode: false, extra_directives: nil)
+          _ = development_mode
+          _ = extra_directives
+          "script-src 'nonce-#{nonce}'; form-action 'self';"
+        end
+      end.new
+      headers = { 'content-type' => 'text/html' }
+      env = { 'otto.csp.extra_directives' => { 'form-action' => ['https://idp.example.com'] } }
+
+      result = described_class.apply(headers, 'N', config: duck_config, env: env)
+
+      expect(result).to be_applied
+      expect(result.extra_directives).to be_nil
+      expect(headers['content-security-policy']).not_to include('idp.example.com')
+      expect(Otto).not_to have_received(:structured_log)
+    end
+  end
 
   describe '.apply return value (Result)' do
     let(:config) { build_config }

--- a/spec/otto/security/csp_config_spec.rb
+++ b/spec/otto/security/csp_config_spec.rb
@@ -14,6 +14,28 @@ RSpec.describe Otto::Security::Config, 'CSP reporting' do
     end
   end
 
+  describe '#enable_csp_request_extras!' do
+    it 'is disabled by default (the request extras channel is boot-time opt-in)' do
+      expect(config.csp_request_extras_enabled?).to be false
+    end
+
+    it 'enables the channel' do
+      config.enable_csp_request_extras!
+      expect(config.csp_request_extras_enabled?).to be true
+    end
+
+    it 'raises when the configuration is frozen' do
+      config.deep_freeze!
+      expect { config.enable_csp_request_extras! }.to raise_error(FrozenError)
+    end
+
+    it 'survives a freeze when set before it' do
+      config.enable_csp_request_extras!
+      config.deep_freeze!
+      expect(config.csp_request_extras_enabled?).to be true
+    end
+  end
+
   describe '#csp_report_uri=' do
     it 'stores a stripped path' do
       config.csp_report_uri = '  /_/csp-report  '

--- a/spec/otto/security/csp_emission_integration_spec.rb
+++ b/spec/otto/security/csp_emission_integration_spec.rb
@@ -44,6 +44,14 @@ RSpec.describe 'Otto CSP emission (integration)' do
       @res['content-security-policy'] = "default-src 'self'"
       @res.write('preset')
     end
+
+    # A handler that widens form-action with request-time data via the
+    # request-scoped extras channel (delano/otto#243).
+    def with_extras
+      @req.env['otto.csp.extra_directives'] = { 'form-action' => ['https://idp.tenant.example'] }
+      @res['content-type'] = 'text/html; charset=utf-8'
+      @res.write(%(<script nonce="#{@req.csp_nonce}">1</script>))
+    end
   end
 
   let(:routes_file) do
@@ -53,6 +61,7 @@ RSpec.describe 'Otto CSP emission (integration)' do
       GET /without CspEmitApp#without_nonce
       GET /json CspEmitApp#json
       GET /preset CspEmitApp#preset_csp
+      GET /with_extras CspEmitApp#with_extras
     ROUTES
     file.flush
     file
@@ -91,6 +100,25 @@ RSpec.describe 'Otto CSP emission (integration)' do
   it 'stays silent for a non-HTML (JSON) response' do
     get '/json'
     expect(last_response.headers).not_to have_key('content-security-policy')
+  end
+
+  it 'widens the policy with extras the handler wrote (request-scoped, end to end)' do
+    get '/with_extras'
+    csp = last_response.headers['content-security-policy']
+    body_nonce = last_response.body[/nonce="([^"]+)"/, 1]
+
+    expect(csp).to include("form-action 'self' https://idp.tenant.example;")
+    expect(csp).to include("script-src 'nonce-#{body_nonce}'") # extras never touch script-src
+  end
+
+  it 'does not carry extras over to a request that wrote none' do
+    get '/with_extras'
+    get '/with'
+
+    expect(last_response.headers['content-security-policy'])
+      .to include("form-action 'self';")
+    expect(last_response.headers['content-security-policy'])
+      .not_to include('idp.tenant.example')
   end
 
   it 'defers to a CSP the route already set (never clobbers)' do

--- a/spec/otto/security/csp_emission_integration_spec.rb
+++ b/spec/otto/security/csp_emission_integration_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe 'Otto CSP emission (integration)' do
     instance = Otto.new(routes_file.path)
     instance.enable_csp_with_nonce!
     instance.enable_csp_emission!
+    instance.security_config.enable_csp_request_extras! # opt the extras channel in at boot
     instance
   end
 
@@ -109,6 +110,17 @@ RSpec.describe 'Otto CSP emission (integration)' do
 
     expect(csp).to include("form-action 'self' https://idp.tenant.example;")
     expect(csp).to include("script-src 'nonce-#{body_nonce}'") # extras never touch script-src
+  end
+
+  it 'ignores handler-written extras when the channel was not enabled at boot (default off)' do
+    plain = Otto.new(routes_file.path)
+    plain.enable_csp_with_nonce!
+    plain.enable_csp_emission!
+
+    _status, headers, = plain.call(Rack::MockRequest.env_for('/with_extras'))
+
+    expect(headers['content-security-policy']).to include("form-action 'self';")
+    expect(headers['content-security-policy']).not_to include('idp.tenant.example')
   end
 
   it 'does not carry extras over to a request that wrote none' do

--- a/spec/otto/security/csp_extras_concurrency_spec.rb
+++ b/spec/otto/security/csp_extras_concurrency_spec.rb
@@ -1,0 +1,81 @@
+# spec/otto/security/csp_extras_concurrency_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# No-bleed guarantee for request-scoped CSP extras (delano/otto#243): extras
+# live in the Rack env ONLY, so two concurrent requests through the same
+# (shared, potentially frozen) Security::Config must each get exactly their own
+# tokens. Modeled on the issue #188 pattern (route_class_otto_accessor_spec):
+# the interleaving is forced deterministically with Queue handoffs rather than
+# sleeps, and each thread's outcome is read after join.
+# Behavioural concurrency spec (not one class under test); the threads and the
+# example length are the point — deterministic interleaving needs the whole
+# choreography in one example, exactly like route_class_otto_accessor_spec.
+# rubocop:disable RSpec/DescribeClass, RSpec/ExampleLength, ThreadSafety/NewThread
+RSpec.describe 'CSP request extras under concurrent requests' do
+  it 'gives two interleaved requests exactly their own extras (no bleed)' do
+    config = Otto::Security::Config.new
+    config.enable_csp_with_nonce!
+    config.deep_freeze! # the production condition: one shared frozen config
+
+    env_a = { 'otto.csp.extra_directives' => { 'form-action' => ['https://tenant-a.example'] } }
+    env_b = { 'otto.csp.extra_directives' => { 'form-action' => ['https://tenant-b.example'] } }
+    headers_a = { 'content-type' => 'text/html' }
+    headers_b = { 'content-type' => 'text/html' }
+    result_a = nil
+    result_b = nil
+
+    # Forced order: A applies, THEN B applies (any shared per-config/class
+    # state would now carry B's extras), and only THEN does A re-apply onto a
+    # fresh response for the same request env — so leakage in either direction
+    # is observable, not timing-dependent.
+    a_applied = Queue.new
+    b_applied = Queue.new
+    headers_a2 = { 'content-type' => 'text/html' }
+    result_a2 = nil
+
+    thread_a = Thread.new do
+      begin
+        result_a = Otto::Security::CSP::Writer.apply(headers_a, 'NA', config: config, env: env_a)
+      ensure
+        a_applied.push(true) # let thread_b apply now
+      end
+
+      b_applied.pop # wait until thread_b applied (would have clobbered shared state)
+      result_a2 = Otto::Security::CSP::Writer.apply(headers_a2, 'NA', config: config, env: env_a)
+    end
+
+    thread_b = Thread.new do
+      a_applied.pop # wait until thread_a has applied
+
+      begin
+        result_b = Otto::Security::CSP::Writer.apply(headers_b, 'NB', config: config, env: env_b)
+      ensure
+        b_applied.push(true) # release thread_a to re-apply and observe
+      end
+    end
+
+    [thread_a, thread_b].each(&:join)
+    [thread_a, thread_b].each(&:value)
+
+    aggregate_failures do
+      expect(headers_a['content-security-policy']).to include('https://tenant-a.example')
+      expect(headers_a['content-security-policy']).not_to include('tenant-b')
+      expect(headers_b['content-security-policy']).to include('https://tenant-b.example')
+      expect(headers_b['content-security-policy']).not_to include('tenant-a')
+      # The re-apply AFTER b's request still sees only a's extras.
+      expect(headers_a2['content-security-policy']).to include('https://tenant-a.example')
+      expect(headers_a2['content-security-policy']).not_to include('tenant-b')
+
+      expect(result_a.extra_directives).to eq('form-action' => ['https://tenant-a.example'])
+      expect(result_b.extra_directives).to eq('form-action' => ['https://tenant-b.example'])
+      expect(result_a2.extra_directives).to eq('form-action' => ['https://tenant-a.example'])
+
+      # And nothing landed on the shared config.
+      expect(config.csp_directive_overrides).to eq({})
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass, RSpec/ExampleLength, ThreadSafety/NewThread

--- a/spec/otto/security/csp_extras_concurrency_spec.rb
+++ b/spec/otto/security/csp_extras_concurrency_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe 'CSP request extras under concurrent requests' do
   it 'gives two interleaved requests exactly their own extras (no bleed)' do
     config = Otto::Security::Config.new
     config.enable_csp_with_nonce!
+    config.enable_csp_request_extras! # boot-time opt-in, before the freeze
     config.deep_freeze! # the production condition: one shared frozen config
 
     env_a = { 'otto.csp.extra_directives' => { 'form-action' => ['https://tenant-a.example'] } }

--- a/spec/otto/security/csp_extras_frozen_spec.rb
+++ b/spec/otto/security/csp_extras_frozen_spec.rb
@@ -1,0 +1,96 @@
+# spec/otto/security/csp_extras_frozen_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tempfile'
+
+# Otto skips its lazy configuration freeze under RSpec (see Otto#call), so the
+# normal request path never exercises the extras channel against a genuinely
+# frozen config — the exact production condition. Extras live in env only and
+# must never memoize anything on the (deep-frozen) Security::Config; a mutation
+# bug here would pass the rest of the suite and FrozenError only in production.
+# This spec freezes a single instance explicitly and proves the extras path
+# still widens the policy while leaving csp_directive_overrides untouched.
+# Integration spec over a behaviour, not a class; same shape as
+# csp_reporting_frozen_spec.
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'Otto CSP request extras against a frozen configuration' do
+  include Rack::Test::Methods
+
+  # Routes-file controllers must be resolvable by name, hence a real constant
+  # (the same pattern as FrozenCspApp in csp_reporting_frozen_spec).
+  # rubocop:disable Lint/ConstantDefinitionInBlock, RSpec/LeakyConstantDeclaration
+  class FrozenCspExtrasApp
+    # Controller ivars, not spec state.
+    # rubocop:disable RSpec/InstanceVariable
+    def initialize(req, res)
+      @req = req
+      @res = res
+    end
+
+    def index
+      # Per-request data (the "tenant IdP origin") written by the handler.
+      @req.env['otto.csp.extra_directives'] = { 'form-action' => ['https://idp.tenant.example'] }
+      @res['content-type'] = 'text/html; charset=utf-8'
+      @res.write(%(<script nonce="#{@req.csp_nonce}">1</script>))
+    end
+    # rubocop:enable RSpec/InstanceVariable
+  end
+  # rubocop:enable Lint/ConstantDefinitionInBlock, RSpec/LeakyConstantDeclaration
+
+  let(:routes_file) do
+    file = Tempfile.new(['frozen_csp_extras_routes', '.txt'])
+    file.write("GET / FrozenCspExtrasApp#index\n")
+    file.flush
+    file
+  end
+
+  let(:otto) do
+    instance = Otto.new(routes_file.path)
+    instance.enable_csp_with_nonce!
+    instance.enable_csp_emission!
+    # Freeze the whole instance the way the first real request would in
+    # production (RSpec normally skips this). freeze_configuration! is private.
+    instance.send(:freeze_configuration!)
+    instance
+  end
+
+  def app
+    otto
+  end
+
+  after { routes_file.close! }
+
+  it 'freezes the security config (the precondition this spec exists for)' do
+    expect(otto.security_config.frozen?).to be true
+    expect(otto.security_config.csp_directive_overrides.frozen?).to be true
+  end
+
+  it 'widens form-action for the request without mutating the frozen config' do
+    overrides_before = otto.security_config.csp_directive_overrides
+
+    get '/'
+
+    expect(last_response.status).to eq(200)
+    expect(last_response.headers['content-security-policy'])
+      .to include("form-action 'self' https://idp.tenant.example;")
+    expect(otto.security_config.csp_directive_overrides).to equal(overrides_before)
+    expect(otto.security_config.csp_directive_overrides).to eq({})
+  end
+
+  it 'serves a second request without extras with the unwidened base policy' do
+    get '/' # a request WITH extras first, to catch any cross-request leak
+
+    env = Rack::MockRequest.env_for('/')
+    # Drive the frozen instance directly with an env whose handler extras are
+    # then discarded — but the handler always writes extras here, so instead
+    # assert the widened directive carries ONLY this request's origin exactly
+    # once (no accumulation across requests on the shared frozen config).
+    _status, headers, = otto.call(env)
+    csp = headers['content-security-policy']
+
+    expect(csp.scan('https://idp.tenant.example').length).to eq(1)
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/otto/security/csp_extras_frozen_spec.rb
+++ b/spec/otto/security/csp_extras_frozen_spec.rb
@@ -50,6 +50,9 @@ RSpec.describe 'Otto CSP request extras against a frozen configuration' do
     instance = Otto.new(routes_file.path)
     instance.enable_csp_with_nonce!
     instance.enable_csp_emission!
+    # The extras channel is boot-time opt-in — flip it on BEFORE the freeze,
+    # exactly as a production boot would.
+    instance.security_config.enable_csp_request_extras!
     # Freeze the whole instance the way the first real request would in
     # production (RSpec normally skips this). freeze_configuration! is private.
     instance.send(:freeze_configuration!)

--- a/spec/support/csp_request_extras_examples.rb
+++ b/spec/support/csp_request_extras_examples.rb
@@ -13,10 +13,14 @@
 #   include_examples 'a request-extras-aware CSP surface'
 # and defining an `emit_csp_with_env` helper with this contract:
 #
-#   emit_csp_with_env(headers:, nonce:, env:) -> Hash  # resulting response headers
+#   emit_csp_with_env(headers:, nonce:, env:, extras_enabled: true) -> Hash
+#     # resulting response headers
 #
 # The env is the hash the surface will read extras from; the helper wires it
 # however the surface requires (Writer kwarg, middleware env, wired request).
+# `extras_enabled: false` must build the config WITHOUT
+# `enable_csp_request_extras!` — the channel is boot-time opt-in, and every
+# surface must ignore the env key entirely when it is off.
 
 RSpec.shared_examples 'a request-extras-aware CSP surface' do
   let(:extras_nonce) { 'extras-nonce-3+/' }
@@ -32,6 +36,18 @@ RSpec.shared_examples 'a request-extras-aware CSP surface' do
 
     expect(headers['content-security-policy'])
       .to include("form-action 'self' https://idp.example.com;")
+  end
+
+  it 'ignores env extras entirely when the channel is not enabled (the default)' do
+    allow(Otto).to receive(:structured_log)
+    env = { 'otto.csp.extra_directives' => { 'form-action' => ['https://idp.example.com'] } }
+    headers = emit_csp_with_env(headers: extras_html.dup, nonce: extras_nonce, env: env,
+                                extras_enabled: false)
+
+    expect(headers['content-security-policy']).to eq(extras_baseline_policy)
+    expect(headers['content-security-policy']).not_to include('idp.example.com')
+    # Disabled means the channel does not exist: no sanitize work, no logs.
+    expect(Otto).not_to have_received(:structured_log)
   end
 
   it 'emits the base policy byte-identically for a request without extras' do

--- a/spec/support/csp_request_extras_examples.rb
+++ b/spec/support/csp_request_extras_examples.rb
@@ -1,0 +1,60 @@
+# spec/support/csp_request_extras_examples.rb
+#
+# frozen_string_literal: true
+
+# Contract-spec suite for the request-scoped CSP directive extras channel
+# (env['otto.csp.extra_directives'], delano/otto#243), shared by the surfaces
+# that can see a Rack env: the Writer core (env: kwarg), the EmitMiddleware
+# (its own env), and Otto::Response#apply_csp (request&.env). A SEPARATE group
+# from 'a nonce-CSP emission surface' on purpose — that group's emit_csp
+# helper contract stays untouched.
+#
+# A host example group opts in by:
+#   include_examples 'a request-extras-aware CSP surface'
+# and defining an `emit_csp_with_env` helper with this contract:
+#
+#   emit_csp_with_env(headers:, nonce:, env:) -> Hash  # resulting response headers
+#
+# The env is the hash the surface will read extras from; the helper wires it
+# however the surface requires (Writer kwarg, middleware env, wired request).
+
+RSpec.shared_examples 'a request-extras-aware CSP surface' do
+  let(:extras_nonce) { 'extras-nonce-3+/' }
+  let(:extras_html) { { 'content-type' => 'text/html; charset=utf-8' } }
+
+  def extras_baseline_policy
+    emit_csp_with_env(headers: extras_html.dup, nonce: extras_nonce, env: {})['content-security-policy']
+  end
+
+  it 'widens the named directive with a request-scoped extra origin (this request only)' do
+    env = { 'otto.csp.extra_directives' => { 'form-action' => ['https://idp.example.com'] } }
+    headers = emit_csp_with_env(headers: extras_html.dup, nonce: extras_nonce, env: env)
+
+    expect(headers['content-security-policy'])
+      .to include("form-action 'self' https://idp.example.com;")
+  end
+
+  it 'emits the base policy byte-identically for a request without extras' do
+    headers = emit_csp_with_env(headers: extras_html.dup, nonce: extras_nonce, env: {})
+    expect(headers['content-security-policy']).to eq(extras_baseline_policy)
+    expect(headers['content-security-policy']).not_to include('idp.example.com')
+  end
+
+  it 'drops hostile extras (logged, never raised) and leaves the policy byte-identical' do
+    allow(Otto).to receive(:structured_log)
+    env = {
+      'otto.csp.extra_directives' => {
+        'form-action' => ["'unsafe-inline'", '*', 'https://idp.example.com;script-src *', "https://x\n.com"],
+        'script-src' => ['https://cdn.example.com'],
+      },
+    }
+    headers = emit_csp_with_env(headers: extras_html.dup, nonce: extras_nonce, env: env)
+
+    expect(headers['content-security-policy']).to eq(extras_baseline_policy)
+    expect(Otto).to have_received(:structured_log)
+      .with(:warn, 'CSP request extra dropped', hash_including(reason: :not_an_origin))
+      .at_least(:once)
+    expect(Otto).to have_received(:structured_log)
+      .with(:warn, 'CSP request extra dropped', hash_including(reason: :refused_directive))
+  end
+end


### PR DESCRIPTION
## Summary

Implements #243: an opt-in, request-scoped channel for widening CSP directives with values only known at request time. The consuming app writes a hash of directive → additional source tokens to `env['otto.csp.extra_directives']` before the response is finalized; the CSP writer folds them **additively** into the policy at build time.

Downstream driver: onetimesecret/onetimesecret#4173 — multi-tenant installs must include the resolved tenant's SSO IdP origin in `form-action`, which is per-domain data unknown at boot.

## Design

- **Opt-in, default off.** `Otto::Security::Config#enable_csp_request_extras!` must be called at boot (before freeze). Without it, the env key is ignored entirely — the widening surface is something the app owns, not something any middleware in the stack gets for free.
- **Additive only.** Extras append tokens to directives present after the boot-override merge (`Policy.append_extra_sources`, a sibling of `merge_directives`). Extras can never remove or replace a directive, never resurrect one a boot override deliberately removed, and never *create* one (creating `form-action` where absent would tighten and break unrelated forms; both base sets already carry `form-action 'self'`). An extras entry whose tokens are all rejected leaves the base directive byte-identical.
- **Drop-and-log, never raise.** Request extras are by definition derived from request-scoped, potentially attacker-influenced data. `Otto::Security::CSP::RequestExtras.from_env` sanitizes with a narrow origins-only grammar — `scheme://host[:port]`, http/https, no path/userinfo/query/fragment, no wildcards or keyword tokens, `%`-free host, single trailing dot stripped, port range-checked 1..65535 — and drops each violation with a structured warn carrying request context. Boot-time overrides keep their raise-early behavior.
- **Refused directives:** `script-src`, `script-src-elem`, `script-src-attr` (defense-in-depth — extras append, so the nonce would survive, but the script family stays closed), and `default-src` (widening it widens every unlisted directive at once).
- **No shared state.** Extras live in the env only; nothing is memoized on the (production-frozen) `Config`. Pinned by a genuinely-frozen-config spec and a Queue-interleaved concurrency spec (no cross-request bleed — same class as the #188/#241 work).
- **Truthful observability.** `Policy.append_extra_sources` is pure and returns applied/dropped; the Writer (which holds env) does the logging and `Writer::Result#extra_directives` reports only what actually landed in the policy.
- **Graceful with legacy configs.** Duck-typed configs without the `extra_directives:` kwarg get the historical call shape plus a single warn instead of a request-time `ArgumentError`.

## Threading

`Writer.apply(headers, nonce, config:, mode:, development_mode:, env: nil)` → `Config#generate_nonce_csp(nonce, development_mode:, extra_directives:)` → `Policy.nonce_policy(..., extra_directives:)`. `EmitMiddleware` and `Response#apply_csp` pass their env (`request&.env` — a response with no wired request degrades to no extras). All additive keyword args; no positional churn.

## Review

Implemented, then run through a high-effort multi-angle review: 9 confirmed + 2 accepted findings, all fixed in the follow-up commits (kwarg guard for legacy configs, key-collision merge, boot-time opt-in, applied-vs-dropped truthfulness, host/port validator gaps, shared name normalization, dead tri-state, per-call context computation, version distinguishability).

## Version

`2.9.0.pre1` — new feature per SemVer, and the pre tag makes the branch distinguishable from the released 2.8.1 in downstream lockfiles (a released 2.8.1 lacks `Writer.apply(env:)`; a version-string collision invited a resolution mixup that would 500 every HTML response downstream). Release collects to 2.9.0.

Closes #243.
