### PR TITLE
Make onboarding and example guidance actionable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,37 @@
 # Otto - A Ruby Gem
 
-**Define your rack-apps in plain-text with built-in security.**
-
-> **v2.0.0-pre6 Available**: This pre-release includes major improvements to middleware management, logging, and request callback handling. See [changelog](CHANGELOG.rst) for details and upgrade notes.
+**Define Rack apps in plain text, with privacy by default and opt-in security features.**
 
 ![Otto mascot](public/img/otto.jpg "Otto - All Rack, no Pinion")
 
-Otto apps have three files: a rackup file, a Ruby class, and a routes file. The routes file is just plain text that maps URLs to Ruby methods.
+Otto apps have three files: a rackup file, a Ruby class, and a routes file. The routes file is plain text that maps URLs to Ruby methods.
 
-```bash
-$ cd myapp && ls
-config.ru app.rb routes
+## Quick start
+
+Requirements: Ruby `>= 3.2, < 4.1` and Rack `>= 3.1, < 4.0`.
+
+Install Otto and the Rack server CLI, then create the three files shown below:
+
+```sh
+gem install otto rackup
+mkdir myapp && cd myapp
+```
+
+After creating `routes`, `app.rb`, and `config.ru`, start the app and verify the response:
+
+```sh
+rackup config.ru
+# In another terminal:
+curl -i http://127.0.0.1:9292/
+# HTTP/1.1 200 OK
+# ...
+# <h1>Hello Otto</h1>
 ```
 
 ## Why Otto?
 
-- **Security by Default**: Automatic IP masking for public addresses, user agent anonymization, CSRF protection, and input validation
-- **Privacy First**: Masks public IPs, strips user agent versions, provides country-level geo-location only—no external APIs needed
+- **Privacy by Default**: Masks public IP addresses and anonymizes user agents; country-level geo-location needs no external API
+- **Opt-in Security Features**: CSRF protection, input validation, security headers, and trusted-proxy configuration
 - **Simple Routing**: Define routes in plain-text files with zero configuration overhead
 - **Built-in Authentication**: Multiple strategies including API keys, tokens, role-based access, and custom implementations
 - **Developer Friendly**: Works with any Rack server, minimal dependencies, easy testing and debugging
@@ -26,10 +41,8 @@ config.ru app.rb routes
 # routes
 
 GET   /                         App#index
-POST  /feedback                 App#receive_feedback
 GET   /product/:id              App#show_product
 GET   /robots.txt               App#robots_text
-GET   /404                      App#not_found
 ```
 
 ## Ruby Class
@@ -37,6 +50,8 @@ GET   /404                      App#not_found
 # app.rb
 
 class App
+  attr_reader :req, :res
+
   def initialize(req, res)
     @req, @res = req, res
   end
@@ -51,7 +66,7 @@ class App
   end
 
   def robots_text
-    res.header['Content-Type'] = "text/plain"
+    res.headers['content-type'] = 'text/plain'
     rules = 'User-agent: *', 'Disallow: /private/keep/out'
     res.body = rules.join($/)
   end
@@ -63,9 +78,9 @@ end
 # config.ru
 
 require 'otto'
-require 'app'
+require_relative 'app'
 
-run Otto.new("./routes")
+run Otto.new('routes')
 ```
 
 
@@ -417,16 +432,6 @@ Otto includes comprehensive examples demonstrating different features:
 
 See the [examples/](examples/) directory for more.
 
-## Requirements
-
-- Ruby 3.2+
-- Rack 3.1+
-
-## Installation
-
-```bash
-gem install otto
-```
 
 ## Documentation
 

--- a/examples/advanced_routes/README.md
+++ b/examples/advanced_routes/README.md
@@ -20,50 +20,54 @@ The example is organized to separate concerns:
 - `app.rb`: Loader that requires all controller and logic files
 - `app/controllers/`: Handler classes (`RoutesApp`, namespaced controllers)
 - `app/logic/`: Business logic classes (simple, nested, namespaced)
-- `run.rb`, `puma.rb`, `test.rb`: Alternative server/test runners
+
 
 ## Key Features Demonstrated
 
 ### Response Types
 Define how responses are formatted directly in routes:
 ```
-GET  /api/users        UserController#list      response=json
-GET  /page             PageController#show      response=view
-GET  /old-url          PageController#new-url   response=redirect
+GET  /api/users        RoutesApp#list_users      response=json
+GET  /dashboard        RoutesApp#dashboard       response=view
+GET  /login            RoutesApp#login_redirect  response=redirect
 ```
 
 ### Logic Classes
 Route to specialized classes that encapsulate business logic:
 ```
-GET  /calculate        DataProcessor   # Otto auto-instantiates and calls #process
-GET  /report           ReportGenerator # Same pattern
+GET  /logic/simple     SimpleLogic
+GET  /logic/data       DataLogic       response=json
 ```
+
+The classes in `app/logic/` expose the logic used by these routes.
 
 ### CSRF Exemption
 Mark routes that don't need CSRF tokens (APIs, webhooks):
 ```
-POST /api/webhook      WebhookHandler#receive   csrf=exempt
+POST /api/webhook      RoutesApp#webhook_handler   csrf=exempt
 ```
 
 ### Namespaced Routing
 Handle complex class hierarchies naturally:
 ```
-GET  /v2/dashboard     V2::Logic::Dashboard
-GET  /admin/panel      Admin::Panel#dashboard
+GET  /logic/v2/dashboard  V2::Logic::Dashboard  response=view
+GET  /logic/admin         Admin::Panel
 ```
 
 ### Custom Parameters
 Add arbitrary key-value pairs for flexible routing:
 ```
-GET  /admin            AdminPanel#dashboard     role=admin
+GET  /feature/flags    RoutesApp#feature_flags  feature=advanced mode=enabled
 ```
+
+These are route configuration values, not query-string parameters.
 
 ### Lambda / Inline Route Handlers (Issue #41)
 Route to a proc that you **pre-register** by name, using the `&` prefix:
 ```
 GET  /ping             &health_check            response=json
-POST /webhook          &receive_webhook         response=json csrf=exempt
-GET  /go               &to_dashboard            response=redirect
+POST /hooks/receive    &receive_webhook         response=json csrf=exempt
+GET  /go/dashboard     &to_dashboard            response=redirect
 ```
 
 The `&name` token is a plain string key looked up (O(1)) in a registry you
@@ -104,67 +108,49 @@ loading**. A route naming an unregistered handler fails with a clear
 instead of executing anything. The registered procs are, of course, trusted
 code that you wrote.
 
-Note: `csrf=exempt` is parse-and-expose parity with controller routes — the CSRF
-middleware does not enforce it for any handler kind.
+This example enables CSRF protection in `config.rb`; the `routes` file marks its API and webhook examples with `csrf=exempt`.
 
-## How to Run
+## Run it
 
-### Using rackup (recommended)
+### Prerequisites
+
+Run this example from an Otto source checkout with Ruby 3.2 through 4.0 and Bundler. `rackup` is a development dependency in the root `Gemfile`, so enable that optional group before installing the bundle.
 
 ```sh
+git clone https://github.com/delano/otto.git
+cd otto
+bundle config set with development
+bundle install
 cd examples/advanced_routes
-rackup config.ru
+bundle exec rackup config.ru
 ```
 
-### Using alternative runners
+The server listens on `http://localhost:9292`.
 
-```sh
-ruby run.rb   # Basic rackup
-ruby puma.rb  # Using puma server
-ruby test.rb  # For testing
-```
+> **Current limitation:** This checked-in example does not finish booting: `app/logic/complex/business/handler.rb` attempts to declare `Complex` as a module, which conflicts with Ruby's built-in `Complex` class. Until that source issue is fixed, `rackup` exits before listening and the checks below cannot be run. They document the routes and expected responses configured by this example.
 
-The application will be running at `http://localhost:9292`.
+### Verify routes
 
-## Testing Routes
-
-Use curl to test the different routes:
+In another terminal, run these checks against routes defined in `routes`:
 
 ```sh
 # JSON response
-curl http://localhost:9292/json/test
+curl -i http://localhost:9292/api/health
 
-# View response
-curl http://localhost:9292/view/test
+# HTML view response
+curl -i http://localhost:9292/dashboard
 
-# Logic class routing
-curl http://localhost:9292/logic/simple
+# Registered lambda handler
+curl -i http://localhost:9292/ping
 
-# Namespaced routing
-curl http://localhost:9292/logic/v2/dashboard
+# Redirect response; inspect the Location header
+curl -i http://localhost:9292/go/dashboard
 
-# Custom parameters
-curl "http://localhost:9292/custom?role=admin"
+# Route configuration values
+curl -i http://localhost:9292/feature/flags
 ```
 
-## Expected Output
-
-```
-Listening on 127.0.0.1:9292, CTRL+C to stop
-
-[JSON response]
-GET /json/test 200 OK
-Content-Type: application/json
-{"status": "success", "data": {...}}
-
-[Logic class routing]
-GET /logic/simple 200 OK
-{"processed": true, "input": "test"}
-
-[Namespaced routing]
-GET /logic/v2/dashboard 200 OK
-{"version": "2.0", "dashboard": {...}}
-```
+Expect `200` responses for the first three and last commands. `/api/health` returns JSON containing `healthy`, `/dashboard` returns HTML containing `Dashboard`, `/ping` returns JSON containing `ok`, and `/feature/flags` returns JSON containing `advanced`. `/go/dashboard` returns `302` with `Location: /dashboard`.
 
 ## File Structure Details
 
@@ -191,9 +177,9 @@ The `routes` file is extensively commented to explain each feature:
 - Review the `routes` file for syntax reference
 - Examine handler methods to see request/response patterns
 - Check logic classes for business logic encapsulation patterns
-- Explore [Authentication](../authentication_strategies/) for protecting routes
-- See [Security Features](../security_features/) for CSRF, validation, file uploads
+- Explore [Authentication](../authentication_strategies/README.md) for protecting routes
+- See [Security Features](../security_features/README.md) for CSRF, validation, and file uploads
 
 ## Further Reading
 
-- [CLAUDE.md](../../CLAUDE.md) - Comprehensive developer guidance
+- [Project README](../../README.md) - Installation and framework overview

--- a/examples/authentication_strategies/README.md
+++ b/examples/authentication_strategies/README.md
@@ -1,225 +1,66 @@
-# Otto - Authentication Strategies Example
+# Otto Authentication Strategies Example
 
-This example demonstrates Otto's flexible authentication system with multiple strategies, token validation, and role-based access control.
+This source-checkout example shows four route-level authentication strategies:
 
-## What You'll Learn
+- `authenticated` accepts `demo_token`.
+- `role:admin` accepts `admin_token`.
+- `permission:write` accepts `demo_token` or `admin_token`.
+- `api_key` accepts `demo_api_key_123`.
 
-- How to configure multiple authentication strategies
-- Token-based authentication with session validation
-- API key authentication for programmatic access
-- Role and permission-based access control
-- How to protect routes with authentication requirements
-- Handling authentication failures and redirects
+The strategies are registered in `app/auth.rb` before the application handles its first request. The protected routes are defined in `routes`.
 
-## Structure
+## Prerequisites
 
-- `config.ru`: Rack configuration that initializes Otto and loads auth strategies
-- `routes`: Application routes with authentication requirements
-- `app/auth.rb`: Authentication strategy definitions and token setup
-- `app/controllers/`: Handler classes for protected and public routes
+Run this example from an Otto source checkout. Its `config.ru` loads Otto from `../../lib`, rather than from an installed gem.
 
-## Authentication Strategies in This Example
-
-### Token-Based Auth
-Validates user tokens for web applications:
-```
-GET  /profile  HomeController#profile  auth=token
-```
-Requires: `?token=demo_token`
-
-### Admin Role Auth
-Validates admin-level access:
-```
-GET  /admin    AdminController#dashboard  auth=admin
-```
-Requires: `?token=admin_token`
-
-### Permission-Based Auth
-Validates specific permissions:
-```
-POST /edit     ArticleController#update  auth=can_write
-```
-Requires: `?token=demo_token` (with write permission)
-
-### API Key Auth
-Validates API keys for programmatic access:
-```
-GET  /api/data  ApiController#show  auth=api_key
-```
-Requires: `?api_key=demo_api_key_123`
-
-## How to Run
-
-### Using rackup (recommended)
+You need a supported Ruby version and Bundler. `rackup` is a development dependency in the root `Gemfile`, so enable the `development` group before installing dependencies:
 
 ```sh
+# From the repository root
+bundle config set with development
+bundle install
+```
+
+## Run the example
+
+```sh
+# From the repository root
 cd examples/authentication_strategies
-rackup config.ru
+bundle exec rackup config.ru
 ```
 
-### Using alternative servers
+The server listens on `http://127.0.0.1:9292` by default. Leave it running and use a second terminal for the checks below.
+
+## Verify the configured credentials
+
+The strategies read the token from the query string or the exact `Authorization` header value. The API-key strategy reads the key from the query string or `X-API-Key`:
 
 ```sh
-thin -R config.ru -p 9292 start
-puma config.ru -p 9292
+curl -i "http://127.0.0.1:9292/profile?token=demo_token"
+curl -i -H 'Authorization: demo_token' http://127.0.0.1:9292/profile
+curl -i "http://127.0.0.1:9292/api/data?api_key=demo_api_key_123"
+curl -i -H 'X-API-Key: demo_api_key_123' http://127.0.0.1:9292/api/data
 ```
 
-Open your browser and navigate to `http://localhost:9292`.
-
-## Testing Authentication
-
-### Web Browser (Token-based)
-
-Click these links or visit them directly:
-
-- **Public page**: [http://localhost:9292/](http://localhost:9292/)
-- **Authenticated user**: [http://localhost:9292/profile?token=demo_token](http://localhost:9292/profile?token=demo_token)
-- **Admin user**: [http://localhost:9292/admin?token=admin_token](http://localhost:9292/admin?token=admin_token)
-- **User with write permission**: [http://localhost:9292/edit?token=demo_token](http://localhost:9292/edit?token=demo_token)
-
-### curl Commands (API Key)
+Use an omitted or invalid credential to exercise the authentication-failure path:
 
 ```sh
-# Without API key (fails)
-curl http://localhost:9292/api/data
-
-# With API key (succeeds)
-curl "http://localhost:9292/api/data?api_key=demo_api_key_123"
+curl -i http://127.0.0.1:9292/profile
+curl -i "http://127.0.0.1:9292/api/data?api_key=invalid"
 ```
 
-### Testing Invalid Credentials
+### Current limitation
 
-Try accessing protected routes without valid credentials:
+In this checkout, `app/controllers/main_controller.rb` and `app/controllers/auth_controller.rb` define class methods, while Otto instantiates route handlers with a request and response. Requests that reach those handlers therefore fail with an argument error. The commands above document the configured credential inputs, but they cannot currently verify a successful protected response until the controllers are made compatible with the handler interface.
 
-```sh
-# No token - redirects to login or returns 401
-curl http://localhost:9292/profile
+## Files to inspect
 
-# Invalid token - returns 401
-curl "http://localhost:9292/profile?token=invalid"
+- `config.ru` creates the Otto application, enables CSRF and request validation, and registers the strategies.
+- `app/auth.rb` contains the demo credentials and strategy callbacks.
+- `routes` associates each protected route with its `auth=` requirement.
+- `app/controllers/auth_controller.rb` supplies the protected responses.
 
-# Wrong token type - returns 401
-curl "http://localhost:9292/admin?api_key=demo_api_key_123"
-```
+## Next steps
 
-## Expected Output
-
-### Successful Authentication
-```
-HTTP/1.1 200 OK
-Content-Type: text/html
-
-<h1>Welcome, alice!</h1>
-<p>This is your profile.</p>
-```
-
-### Failed Authentication
-```
-HTTP/1.1 401 Unauthorized
-Content-Type: text/plain
-
-Unauthorized
-```
-
-### Redirect to Login
-```
-HTTP/1.1 302 Found
-Location: http://localhost:9292/?login=required
-```
-
-## File Structure Details
-
-### Routes File
-- Public routes (no `auth=` requirement)
-- Protected routes with different auth strategies
-- Admin-only routes
-- API routes with API key authentication
-
-### Auth Strategies (`app/auth.rb`)
-- Token validation logic with demo tokens
-- Admin role checking
-- Permission validation (read, write, admin)
-- API key validation for programmatic access
-
-### Controllers (`app/controllers/`)
-- Welcome controller for public pages
-- Profile controller for authenticated users
-- Admin controller for admin-only pages
-- Article controller for permission-based access
-- API controller for programmatic access
-
-## Key Concepts
-
-### Strategy Registration
-Strategies are registered in `config.ru` before the first request:
-
-```ruby
-app.add_auth_strategy('token', TokenStrategy.new)
-app.add_auth_strategy('admin', AdminStrategy.new)
-app.add_auth_strategy('api_key', APIKeyStrategy.new)
-```
-
-### Route Protection
-Routes specify their auth requirement in the routes file:
-
-```
-GET  /protected  Controller#method  auth=token
-POST /admin      Controller#admin   auth=admin
-```
-
-### User Context
-After successful authentication, `req.user_context` contains user info:
-
-```ruby
-def profile
-  user_id = @req.user_context[:user_id]
-  @res.body = "Welcome, #{user_id}!"
-end
-```
-
-## Demo Credentials
-
-### Tokens
-- `demo_token` - Regular user (Alice)
-  - Permissions: read, write
-  - Roles: user
-- `admin_token` - Administrator
-  - Permissions: read, write, admin
-  - Roles: admin, user
-
-### API Keys
-- `demo_api_key_123` - Demo API access
-- Additional keys can be added to `app/auth.rb`
-
-## Customizing Authentication
-
-To add your own authentication:
-
-1. **Create a strategy class**:
-   ```ruby
-   class MyStrategy < Otto::Security::Authentication::AuthStrategy
-     def authenticate(env, requirement)
-       # Validate credentials
-       success_result(user_id: 'alice')  # or failure_result
-     end
-   end
-   ```
-
-2. **Register it in config.ru**:
-   ```ruby
-   app.add_auth_strategy('my_strategy', MyStrategy.new)
-   ```
-
-3. **Use it in routes**:
-   ```
-   GET  /protected  Controller#method  auth=my_strategy
-   ```
-
-## Next Steps
-
-- Explore [Security Features](../security_features/) for CSRF, input validation, file uploads
-- Review [Advanced Routes](../advanced_routes/) for response types and logic classes
-
-## Further Reading
-
-- [CLAUDE.md](../../CLAUDE.md#authentication-architecture) - Detailed auth documentation
+- See the [security features example](../security_features/README.md) for CSRF and request-validation configuration.
+- Read [authentication documentation](../../docs/authentication.md) for application authentication design.

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -7,67 +7,52 @@ This example demonstrates a basic Otto application with a single route that acce
 - How to define routes in plain-text format
 - Creating a basic request handler class
 - Working with Rack request and response objects
-- Running an Otto application with different servers
-- Simple form handling and redirects
+- Running an Otto application with Rackup
+- Simple form handling and validation
 
-## How to Run
+## Run it
 
-### Using rackup (recommended)
+### Prerequisites
 
-```sh
-cd examples/basic
-rackup config.ru -p 10770
-```
-
-### Using thin
+Run this example from an Otto source checkout with Ruby 3.2 through 4.0 and Bundler. `rackup` is a development dependency in the root `Gemfile`, so enable that optional group before installing the bundle.
 
 ```sh
+git clone https://github.com/delano/otto.git
+cd otto
+bundle config set with development
+bundle install
 cd examples/basic
-thin -e dev -R config.ru -p 10770 start
+bundle exec rackup config.ru -p 10770
 ```
 
-### Using puma
+The server listens on `http://localhost:10770`.
+
+> **Current limitation:** The checked-in app starts, but `GET /` currently returns `500` because `App#index` calls the undefined `otto_form_wrapper` helper. Until that source issue is fixed, the browser workflow below cannot be completed.
+
+### Verify after fixing the source issue
+
+In another terminal, confirm that the home page responds with HTML:
 
 ```sh
-cd examples/basic
-puma config.ru -p 10770
+curl -i http://localhost:10770/
 ```
 
-Open your browser and navigate to `http://localhost:10770`.
-
-## Expected Output
-
-```
-Puma starting in single threaded mode...
-* Version 3.12.0 (ruby 3.2.0-p0), codename: Llama Litter Box
-* Min threads: 0, max threads: 32
-* Environment: development
-* Listening on tcp://127.0.0.1:10770
-
-[GET request to /]
-GET /  200 OK
-
-[Submitting feedback form]
-POST /feedback  302 Found
-Location: http://localhost:10770/
-```
-
-Then visit `http://localhost:10770` and submit feedback to see it in action.
+Expect `HTTP/1.1 200` and an HTML page containing `Otto Framework`. Open the same URL in a browser, enter a message, and submit the form. The form posts to `/` (not `/feedback`) and displays either the submitted message or the validation message for an empty submission.
 
 ## File Structure
 
 * `README.md`: This file.
 * `app.rb`: Contains the application logic with two methods:
   - `index`: Displays the main page with a feedback form
-  - `receive_feedback`: Handles form submissions and redirects back home
+  - `receive_feedback`: Handles form submissions and renders the result
 * `config.ru`: The Rack configuration file that loads Otto and the application.
-* `routes`: Defines the URL routes mapping to methods in the `App` class.
+- `routes`: Maps `GET /` to `App#index` and `POST /` to `App#receive_feedback`.
 
-## Trying It Out
+## Trying it out after resolving the limitation
 
-1. **View the home page**: Open `http://localhost:10770` in your browser
-2. **Submit feedback**: Enter text in the feedback form and click Submit
-3. **Check the redirect**: You should be redirected back to the home page
+1. **View the home page**: Open `http://localhost:10770` in your browser.
+2. **Submit feedback**: Enter text in the feedback form and click **Send Feedback**.
+3. **Check the result**: The response shows the submitted message and a link back to the home page.
 
 ## Next Steps
 
@@ -77,4 +62,4 @@ Then visit `http://localhost:10770` and submit feedback to see it in action.
 
 ## Further Reading
 
-- [CLAUDE.md](../../CLAUDE.md) - Developer guidance and patterns
+- [Project README](../../README.md) - Installation and framework overview

--- a/examples/caddy_tls_demo/README.md
+++ b/examples/caddy_tls_demo/README.md
@@ -19,9 +19,15 @@ config-only on Caddy's side.
 
 ## Run it
 
+This is a source-checkout example: its Rackup file loads Otto from `../../lib`.
+From the repository root, install the optional development dependencies (which
+include `rackup`) and start the app:
+
 ```sh
+bundle config set with development
+bundle install
 cd examples/caddy_tls_demo
-rackup config.ru        # serves on http://localhost:9292
+bundle exec rackup config.ru        # serves on http://localhost:9292
 ```
 
 ## Try it

--- a/examples/lambda_handlers/README.md
+++ b/examples/lambda_handlers/README.md
@@ -89,10 +89,19 @@ anything.
 
 ## How to Run
 
+Run this example from an Otto source checkout. It requires Ruby 3.2 through
+4.0, Bundler, and the development dependencies: `rackup` is a development
+dependency in the root `Gemfile` and is not installed with the released `otto`
+gem.
+
 ```sh
+cd /path/to/otto
+bundle config set with development
+bundle install
 cd examples/lambda_handlers
-rackup config.ru -p 10780
+bundle exec rackup config.ru -p 10780
 ```
+
 
 Then, from another terminal:
 

--- a/examples/mcp_demo/README.md
+++ b/examples/mcp_demo/README.md
@@ -1,74 +1,75 @@
 # Otto MCP Demo
 
-This example demonstrates Otto's Model-Controller-Protocol (MCP) feature. MCP provides a standardized JSON-RPC 2.0 endpoint (`/_mcp`) for programmatic access to your application resources and tools.
-
-MCP is useful for building CLIs, admin interfaces, integrating with AI systems, or allowing other services to interact with your application.
+This example boots Otto's Model Context Protocol (MCP) JSON-RPC 2.0 endpoint at
+`/_mcp`. Use it to verify endpoint initialization alongside ordinary Otto web
+routes.
 
 ## What You'll Learn
 
-- How to set up an MCP endpoint for programmatic access
-- Exposing application resources via JSON-RPC 2.0
-- Securing MCP endpoints with bearer token authentication
-- Distinguishing between read-only resources and executable tools
-- Organizing methods for both web and MCP interfaces
-- How MCP integrates with your existing Otto application
+- How to enable an MCP HTTP endpoint
+- How the endpoint coexists with ordinary Otto web routes
+- How to send a JSON-RPC 2.0 `initialize` request
+- The current resource, tool, and authentication limitations described below
 
 ## Features Demonstrated
 
-- **MCP Endpoint**: Single `POST /_mcp` endpoint for all interactions
-- **Authentication**: Bearer token authentication for secure access
-- **Rate Limiting**: Built-in rate limiting to prevent abuse
-- **Resources**: Read-only data exposed via `MCP` routes
-- **Tools**: Executable actions exposed via `TOOL` routes
-- **Web Interface**: Separate web routes coexist with MCP routes
-- **JSON-RPC 2.0**: Standard protocol for all MCP interactions
+- **MCP endpoint**: A single `POST /_mcp` endpoint
+- **Web interface**: Separate web routes coexist with the MCP endpoint
+- **JSON-RPC 2.0**: `initialize`, `resources/list`, and `tools/list` requests
 
 ## How to Run
 
-### Using rackup (recommended)
+Run this example from an Otto source checkout. It requires Ruby 3.2 through
+4.0, Bundler, and the development dependencies: `rackup` is a development
+dependency in the root `Gemfile` and is not installed with the released `otto`
+gem.
 
 ```sh
+cd /path/to/otto
+bundle config set with development
+bundle install
 cd examples/mcp_demo
-rackup config.ru
+bundle exec rackup config.ru
 ```
 
-### Using thin
 
-```sh
-cd examples/mcp_demo
-thin -R config.ru -p 9292 start
-```
+The server listens at `http://localhost:9292` by default.
 
-The server will start on `http://localhost:9292`.
+- **Web interface**: Open `http://localhost:9292/`.
+- **Health check**: `curl -i http://localhost:9292/health` returns `200` and `OK`.
+- **MCP endpoint**: Send JSON-RPC 2.0 requests to `http://localhost:9292/_mcp`.
 
-- **Web interface**: Navigate to `http://localhost:9292` in your browser
-- **MCP endpoint**: Send JSON-RPC 2.0 requests to `http://localhost:9292/_mcp`
+## Current Limitations
 
-## Authentication
+The `auth_tokens`, `requests_per_minute`, and `tools_per_minute` values shown in
+`config.ru` are not forwarded to the MCP server by the current configuration
+path. Consequently, this example's endpoint does not require either displayed
+bearer token and its configured rate-limit values are not applied.
 
-All MCP requests require bearer token authentication via the `Authorization` header.
-
-Valid tokens:
-- `demo-token-123` - Standard user
-- `another-token-456` - Alternative user
+Likewise, although `routes` contains `MCP /users` and `TOOL /create_user`
+declarations, the current route-loading path does not register them. Therefore
+`resources/list` and `tools/list` both return empty arrays, and `resources/read`
+or `tools/call` for those names fails. This README documents the runnable
+endpoint behavior; do not use this example as a resource or tool integration
+template until those routes are registered.
 
 ## Interacting with the MCP Endpoint
 
 All MCP interactions use the `POST /_mcp` endpoint. Each request is a JSON-RPC 2.0 request with:
 
 - `jsonrpc`: Always `"2.0"`
-- `method`: The RPC method name (derived from route path)
+- `method`: The RPC method name
 - `id`: Request ID (for matching responses)
 - `params`: Optional parameters as an object
 
-Required headers:
-- `Authorization: Bearer <token>`
+Required header:
 - `Content-Type: application/json`
+
+`Authorization: Bearer <token>` is accepted but not enforced by the current example configuration.
 
 Example:
 ```sh
 curl -X POST http://localhost:9292/_mcp \
-  -H 'Authorization: Bearer demo-token-123' \
   -H 'Content-Type: application/json' \
   -d '{
     "jsonrpc": "2.0",
@@ -84,156 +85,50 @@ The `initialize` method is a built-in MCP method that returns information about 
 
 ```sh
 curl -X POST http://localhost:9292/_mcp \
-     -H 'Authorization: Bearer demo-token-123' \
      -H 'Content-Type: application/json' \
      -d '{"jsonrpc":"2.0","method":"initialize","id":1,"params":{}}'
 ```
 
-### Resource: List Users
+## Verification
 
-This calls the `UserAPI.mcp_list_users` method defined as an `MCP` route. The method name for the JSON-RPC call is derived from the route path (`/users` -> `users/list`).
-
-```sh
-curl -X POST http://localhost:9292/_mcp \
-     -H 'Authorization: Bearer demo-token-123' \
-     -H 'Content-Type: application/json' \
-     -d '{"jsonrpc":"2.0","method":"users/list","id":2}'
-```
-
-### Tool: Create User
-
-This calls the `UserAPI.mcp_create_user` method defined as a `TOOL` route. The method name is derived from the route path (`/create_user` -> `create_user`).
+A successful `initialize` request returns `result.protocolVersion`,
+`result.capabilities`, and `result.serverInfo` with the same request ID. To
+confirm the current registry state, run:
 
 ```sh
 curl -X POST http://localhost:9292/_mcp \
-     -H 'Authorization: Bearer demo-token-123' \
-     -H 'Content-Type: application/json' \
-     -d '{
-          "jsonrpc": "2.0",
-          "method": "create_user",
-          "id": 3,
-          "params": {
-            "name": "Charlie",
-            "email": "charlie@example.com"
-          }
-        }'
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"resources/list","id":2}'
+
+curl -X POST http://localhost:9292/_mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"tools/list","id":3}'
 ```
 
-## Expected Output
-
-### Successful Initialize Request
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "resources": [
-      {
-        "uri": "users",
-        "name": "User List",
-        "description": "List all users"
-      }
-    ],
-    "tools": [
-      {
-        "name": "create_user",
-        "description": "Create a new user",
-        "inputSchema": {
-          "type": "object",
-          "properties": {
-            "name": { "type": "string" },
-            "email": { "type": "string" }
-          }
-        }
-      }
-    ]
-  },
-  "id": 1
-}
-```
-
-### Successful Resource Request
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "users": [
-      { "id": 1, "name": "Alice", "email": "alice@example.com" },
-      { "id": 2, "name": "Bob", "email": "bob@example.com" }
-    ]
-  },
-  "id": 2
-}
-```
-
-### Successful Tool Execution
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "user": {
-      "id": 3,
-      "name": "Charlie",
-      "email": "charlie@example.com"
-    }
-  },
-  "id": 3
-}
-```
-
-### Authentication Failure
-```json
-{
-  "jsonrpc": "2.0",
-  "error": {
-    "code": -32003,
-    "message": "Unauthorized"
-  },
-  "id": 1
-}
-```
+Each request returns `"jsonrpc":"2.0"` and an empty `resources` or `tools`
+array in the current checkout.
 
 ## File Structure
 
 - `README.md`: This file
 - `app.rb`: Application logic
-  - `DemoApp`: Web interface with HTML pages
-  - `UserAPI`: MCP handlers for resources and tools
+  - `DemoApp`: Web interface and health check
+  - `UserAPI`: Intended MCP resource and tool handlers (not registered by the current route-loading path)
 - `config.ru`: Rack configuration (loads Otto, enables MCP)
 - `routes`: Route definitions for web and MCP routes
 
-## Route Types
+## Routes
 
-### Web Routes
-Regular HTTP routes for the web interface:
+The ordinary web routes in `routes` are active:
+
 ```
-GET  /            DemoApp#welcome
-GET  /users       DemoApp#list_users
+GET  /        DemoApp.index
+GET  /health  DemoApp.health
 ```
 
-### MCP Resource Routes
-Read-only resources exposed via MCP:
-```
-MCP  /users       UserAPI#mcp_list_users
-```
-- Called via: `POST /_mcp` with method `users/list`
-
-### MCP Tool Routes
-Executable operations exposed via MCP:
-```
-TOOL /create_user UserAPI#mcp_create_user
-```
-- Called via: `POST /_mcp` with method `create_user`
-
-## Understanding MCP Method Names
-
-MCP route paths are converted to method names:
-
-| Route Type | Path | Method Name | Handler |
-|-----------|------|-------------|---------|
-| MCP | `/users` | `users/list` | `mcp_list_users` |
-| MCP | `/users/:id` | `users/get` | `mcp_get_user` |
-| TOOL | `/create_user` | `create_user` | `mcp_create_user` |
-| TOOL | `/users/:id/update` | `users/update` | `mcp_update_user` |
+The file also contains `MCP /users UserAPI.mcp_list_users` and
+`TOOL /create_user UserAPI.mcp_create_user`. See [Current Limitations](#current-limitations):
+they are not registered by this checkout's route-loading path.
 
 ## Next Steps
 
@@ -244,4 +139,4 @@ MCP route paths are converted to method names:
 
 ## Further Reading
 
-- [CLAUDE.md](../../CLAUDE.md#mcp) - Detailed MCP documentation (if available)
+- [MCP implementation notes](../../docs/MCP_IMPLEMENTATION.md)

--- a/examples/security_features/README.md
+++ b/examples/security_features/README.md
@@ -1,265 +1,67 @@
 # Otto Security Features Example
 
-This example demonstrates Otto's built-in security features, showing best practices for CSRF protection, input validation, file upload handling, and security headers.
+This source-checkout example configures CSRF protection, request validation, request-size and parameter limits, trusted proxies, and response security headers. It provides forms for feedback, file-upload metadata, and profile input so you can observe those protections.
 
-## What You'll Learn
+## Prerequisites
 
-- Enabling and using CSRF protection
-- Input validation for preventing injection attacks
-- XSS prevention through output escaping
-- Secure file upload handling with filename sanitization
-- Adding security headers (CSP, HSTS, etc.)
-- Request limiting to prevent denial-of-service
-- Trusted proxy configuration for reverse proxies
-- Privacy features (IP masking, user agent anonymization)
+Run this example from an Otto source checkout. Its `config.ru` loads Otto from `../../lib`, rather than from an installed gem.
 
-## Security Features Demonstrated
-
-### CSRF Protection
-All POST/PUT/DELETE requests include CSRF tokens in forms:
-```ruby
-<form method="post">
-  <input type="hidden" name="_csrf_token" value="<%= @req.csrf_token %>">
-  <input type="text" name="message">
-</form>
-```
-
-### Input Validation
-Server-side validation of user-submitted data:
-- Length limits (max 1000 chars for messages)
-- Character restrictions (no HTML tags)
-- Required field validation
-- Type validation
-
-### XSS Prevention
-All output is properly escaped:
-```ruby
-@res.body = "<h1>#{ERB::Util.html_escape(user_input)}</h1>"
-```
-
-### Secure File Uploads
-File uploads are validated and sanitized:
-- File type checking (whitelist approach)
-- Size limits (prevent large uploads)
-- Filename sanitization (remove path traversal)
-- Safe storage location
-
-### Security Headers
-Automatic security headers are sent with responses:
-- `Content-Security-Policy` - Prevents inline scripts
-- `Strict-Transport-Security` - Enforces HTTPS
-- `X-Frame-Options` - Prevents clickjacking
-- `X-Content-Type-Options` - Prevents MIME sniffing
-
-### Request Limiting
-Configure limits to prevent DOS attacks:
-- Maximum request size
-- Maximum parameter keys
-- Maximum parameter depth
-
-### Trusted Proxies
-Configure reverse proxy IPs for X-Forwarded-For headers:
-```ruby
-app.add_trusted_proxy('10.0.0.0/8')
-app.add_trusted_proxy(/^192\.168\./)
-```
-
-### Privacy by Default
-Automatic privacy features:
-- Public IP masking (203.0.113.50 → 203.0.113.0)
-- User agent anonymization (versions stripped)
-- Country-level geo-location only
-- Private/localhost IPs NOT masked by default (configurable via `configure_ip_privacy()`)
-
-## How to Run
-
-### Using rackup (recommended)
+You need a supported Ruby version and Bundler. `rackup` is a development dependency in the root `Gemfile`, so enable the `development` group before installing dependencies:
 
 ```sh
+# From the repository root
+bundle config set with development
+bundle install
+```
+
+## Run the example
+
+```sh
+# From the repository root
 cd examples/security_features
-rackup config.ru -p 10770
+bundle exec rackup config.ru -p 10770
 ```
 
-### Using thin
+Open `http://127.0.0.1:10770/`. Keep the server running and use a second terminal for the checks below.
+
+## What this example configures
+
+`config.ru` enables CSRF protection and request validation, then sets these limits:
+
+- Maximum request size: 5 MiB
+- Maximum parameter nesting depth: 10
+- Maximum parameter keys: 50
+
+It trusts the listed loopback and private-network proxy ranges. Adjust `trusted_proxies` for a real deployment; do not copy this development-oriented list without confirming the proxies that can reach your application.
+
+Every route receives the configured headers:
+
+- `Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'`
+- `Strict-Transport-Security: max-age=31536000; includeSubDomains`
+- `X-Frame-Options: DENY`
+
+## Verify the protections
+
+Use the diagnostic route to inspect request information and the response headers. A POST without a CSRF token exercises the CSRF rejection path:
 
 ```sh
-cd examples/security_features
-thin -e dev -R config.ru -p 10770 start
+curl -i http://127.0.0.1:10770/headers
+curl -i -X POST http://127.0.0.1:10770/feedback -d 'message=test'
 ```
 
-Open your browser and navigate to `http://localhost:10770`.
+The feedback handler rejects script-like input and limits messages to 1,000 characters; profile fields have their own limits and the email field must match the example's basic format check. The upload form demonstrates filename sanitization and request handling. It displays metadata and does **not** permanently store uploaded files; it does not implement a file-type allowlist.
 
-## Testing Security Features
+### Current limitation
 
-### XSS Prevention
+The home page generates a CSRF token during its first request. Otto freezes configuration at that point, and the generated-secret warning then attempts to modify the frozen security configuration. As a result, `GET /` currently fails with `FrozenError`, so browser-based valid-form verification is unavailable until that example or the initialization sequence is corrected.
 
-Try entering `<script>alert("XSS")</script>` in form fields:
-- The script tag is rendered as text, not executed
-- You'll see it displayed as literal HTML tags
-- Browser's developer tools show escaped HTML
+## Files to inspect
 
-### Input Validation
+- `config.ru` creates the Otto application and sets the security configuration.
+- `routes` defines the form and diagnostic endpoints.
+- `app.rb` renders CSRF form fields and handles validation, escaped output, and uploaded-file metadata.
 
-Test validation rules:
-- Submit a message > 1000 characters (fails)
-- Submit special characters like `<>` (fails)
-- Submit valid text (succeeds)
+## Next steps
 
-### CSRF Protection
-
-Examine form submissions:
-- All POST forms include a `_csrf_token` hidden field
-- Each request has a unique token
-- Removing the token causes 403 Forbidden
-- Browser's developer tools show token in form data
-
-### File Uploads
-
-Test file upload security:
-- Try uploading an executable file (rejected)
-- Try uploading a legitimate image (accepted)
-- Check saved filename (sanitized, safe)
-- Verify file permissions and location
-
-### Security Headers
-
-Check response headers:
-- Open browser's Network tab in developer tools
-- Click any response to view headers
-- Look for security headers in response
-- Visit `/headers` endpoint to see all headers
-
-## Expected Output
-
-### Successful Form Submission
-```
-POST /feedback HTTP/1.1
-Content-Type: application/x-www-form-urlencoded
-
-_csrf_token=abc123...
-message=Hello+world
-
-HTTP/1.1 302 Found
-Location: http://localhost:10770/
-Content-Security-Policy: default-src 'self'
-Strict-Transport-Security: max-age=31536000
-```
-
-### Failed CSRF Validation
-```
-HTTP/1.1 403 Forbidden
-Content-Type: text/plain
-
-CSRF token validation failed
-```
-
-### Failed Input Validation
-```
-HTTP/1.1 400 Bad Request
-Content-Type: text/plain
-
-Message is too long (max 1000 characters)
-```
-
-### Security Headers Response
-```
-Content-Security-Policy: default-src 'self'
-Strict-Transport-Security: max-age=31536000
-X-Frame-Options: SAMEORIGIN
-X-Content-Type-Options: nosniff
-Referrer-Policy: strict-origin-when-cross-origin
-```
-
-## File Structure
-
-- `README.md`: This file
-- `app.rb`: Main application logic with security implementations
-  - Form validation and escaping
-  - File upload handling
-  - Header configuration
-- `config.ru`: Rack configuration with security features enabled
-- `routes`: URL routes mapped to SecureApp class methods
-
-## Key Configuration
-
-In `config.ru`:
-```ruby
-app = Otto.new("./routes")
-
-# Enable security features
-app.enable_csrf_protection!
-
-# Configure request limits
-app.security_config.request_size_limit = 1.megabyte
-app.security_config.max_parameter_keys = 100
-app.security_config.max_parameter_depth = 5
-
-# Add trusted proxies if behind reverse proxy
-app.add_trusted_proxy('10.0.0.0/8')
-
-# Security headers
-app.add_security_header('X-Custom-Header', 'value')
-```
-
-## Common Attack Scenarios
-
-### XSS Attack
-```javascript
-<img src=x onerror="alert('XSS')">
-```
-**Result**: Safely displayed as text, not executed
-
-### SQL Injection
-```sql
-'; DROP TABLE users; --
-```
-**Result**: Stored as literal text, invalid SQL
-
-### Path Traversal
-```
-../../../../../../etc/passwd
-```
-**Result**: Filename sanitized to just `etc-passwd`
-
-### Large Request
-```
-POST with 10MB body
-```
-**Result**: Rejected with 413 Payload Too Large
-
-## Best Practices Demonstrated
-
-1. **Defense in Depth**: Multiple layers of security
-2. **Input Validation**: Whitelist approach (allow only safe input)
-3. **Output Escaping**: Escape all user-controlled output
-4. **CSRF Tokens**: Unique tokens for each request
-5. **Security Headers**: Prevent common attack vectors
-6. **File Upload Safety**: Validate type and sanitize names
-7. **Request Limiting**: Prevent denial-of-service
-
-## Testing with curl
-
-```sh
-# Test CSRF protection (will fail without token)
-curl -X POST http://localhost:10770/feedback \
-  -d "message=test"
-
-# Test with valid CSRF token (get token from form first)
-curl -X POST http://localhost:10770/feedback \
-  -d "_csrf_token=<token>" \
-  -d "message=test"
-
-# Test input validation
-curl -X POST http://localhost:10770/feedback \
-  -d "message=$(python -c 'print(\"x\" * 2000)')"
-```
-
-## Next Steps
-
-- Review the application code to see implementation details
-- Explore other examples for different features
-
-## Further Reading
-
-- [CLAUDE.md](../../CLAUDE.md#security-features) - Security configuration reference
-- [IP Privacy](../../CLAUDE.md#ip-privacy-privacy-by-default) - Privacy configuration
+- See the [authentication strategies example](../authentication_strategies/README.md) for route authentication.
+- Read the [security configuration in the main README](../../README.md#security-features).

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,130 +1,49 @@
 # Otto Test Suite
 
-This directory contains RSpec tests for the Otto web router with built-in security features.
+This directory contains Otto's RSpec suite. It covers routing, request and
+response handling, privacy, security configuration and middleware,
+authentication and authorization, network-service integrations, and error
+handling.
 
-## Test Coverage
+## Set up the test bundle
 
-### ✅ Security Configuration (`security_config_spec.rb`)
-**Status: All 47 tests passing**
+From the repository root, install the development and test dependencies. The
+Gemfile marks these groups as optional, so enable them before installing:
 
-Comprehensive tests for `Otto::Security::Config` covering:
+```sh
+bundle config set with 'development test'
+bundle install
+```
 
-- **Safe Defaults**: Validates that dangerous headers (HSTS, CSP, X-Frame-Options) are disabled by default
-- **CSRF Protection**: Token generation, validation, and session binding
-- **Trusted Proxies**: IP validation and CIDR range handling
-- **Request Validation**: Size limits and parameter structure validation
-- **Header Management**: Explicit enabling of security headers
-- **Configuration Isolation**: Ensures separate Otto instances have independent configs
-- **Backward Compatibility**: Confirms safe defaults won't break existing applications
+## Run tests
 
-Key findings:
-- Otto follows security-by-default principles
-- CSRF tokens use cryptographically secure generation with session binding
-- Trusted proxy matching uses proper IPAddr CIDR containment (IPv4 + IPv6),
-  falling back to string prefix matching only for non-IP entries (e.g. '172.16.')
-- All security features must be explicitly enabled
-
-### 🔄 Otto Main Class (`otto_spec.rb`)
-**Status: 50/57 tests passing, 7 failing**
-
-Tests for core Otto functionality:
-
-- **Route Loading**: File parsing and route definition mapping
-- **Request Handling**: HTTP method routing and parameter extraction
-- **Security Integration**: Header injection and middleware management
-- **Error Handling**: 404/500 responses with secure error messages
-- **File Safety**: Path traversal prevention and ownership validation
-
-Failing tests reveal implementation details:
-- URI generation adds `?` query string even when empty
-- Literal routes store `"/"` as `""` after path cleaning
-- Locale determination uses default `"en"` when headers missing
-- File safety requires ownership validation
-
-### ⚠️ CSRF Middleware (`security_csrf_spec.rb`)
-**Status: 51/59 tests passing, 8 failing**
-
-Tests CSRF protection middleware:
-
-- **Token Injection**: HTML response modification for safe methods
-- **Token Validation**: Parameter and header-based token extraction
-- **Session Handling**: Session ID extraction from various sources
-- **Error Responses**: Proper JSON error formatting
-
-Issues identified:
-- Token injection not working in test environment
-- Helper methods returning nil values
-- May require actual Rack session setup for proper testing
-
-### ❌ Validation Middleware (`security_validation_spec.rb`)
-**Status: Not runnable due to syntax errors**
-
-Tests input validation and sanitization:
-- Syntax error with variable scoping in RSpec context
-- Needs refactoring to fix scoping issues
-
-## Running Tests
-
-### All Tests
-```bash
+```sh
+# Entire suite
 bundle exec rspec
+
+# A single file
+bundle exec rspec spec/otto/security/csp_emission_integration_spec.rb
+
+# A focused directory
+bundle exec rspec spec/otto/security
 ```
 
-### Individual Test Files
-```bash
-# Security configuration (all passing)
-bundle exec rspec spec/security_config_spec.rb
+To inspect a focused test with Otto debug logging:
 
-# Otto main functionality
-bundle exec rspec spec/otto_spec.rb
-
-# CSRF middleware
-bundle exec rspec spec/security_csrf_spec.rb
-```
-
-### With Debug Output
-```bash
+```sh
 OTTO_DEBUG=true bundle exec rspec spec/security_config_spec.rb --format documentation
 ```
 
-## Test Philosophy
+## Test conventions
 
-These tests follow the principle: **Test behavior, not implementation**.
+- Test observable behavior rather than private implementation details.
+- Use Rack::Test for full request/response coverage where appropriate.
+- Cover both route-level authentication/authorization and resource-level
+  authorization.
+- Verify configuration is complete before the first request, because Otto
+  freezes configuration after that point.
+- Exercise privacy and security boundaries, including malformed input, trusted
+  proxies, and error responses.
 
-### Debugging Features
-- Extensive `puts` statements showing actual vs expected values
-- Debug sections that reveal internal state
-- Error message validation to understand failure modes
-
-### Key Testing Insights
-
-1. **Security Defaults are Safe**: Otto won't break existing apps with dangerous defaults
-2. **Explicit Configuration**: Security features must be deliberately enabled
-3. **Implementation Details Matter**: Tests revealed several undocumented behaviors
-4. **Edge Cases Covered**: Null bytes, path traversal, malformed input handling
-
-## Areas Needing Attention
-
-1. **CSRF Implementation**: Token injection mechanism needs investigation
-2. **File Safety Tests**: Ownership validation requirements need clarification
-3. **Validation Tests**: Syntax errors need fixing
-4. **URI Generation**: Query string behavior should be documented
-
-## Test Quality Indicators
-
-- ✅ Comprehensive error condition testing
-- ✅ Security boundary validation
-- ✅ Configuration isolation verification
-- ✅ Backward compatibility assurance
-- ✅ Performance edge case handling
-- ✅ Debug output for failure analysis
-
-## Next Steps
-
-1. Fix CSRF middleware test setup issues
-2. Repair validation test syntax errors
-3. Document discovered implementation behaviors
-4. Add integration tests for complete request/response cycles
-5. Performance benchmarks for large route sets
-
-The test suite successfully validates Otto's security-first approach while uncovering implementation details that improve understanding of the system's actual behavior vs. assumed behavior.
+See [`../docs/testing-guide.md`](../docs/testing-guide.md) for guidance on
+writing tests for Otto applications.


### PR DESCRIPTION
## Summary
- Add a runnable root quick start, correct the sample Rack setup, and align supported Ruby/Rack and security-default guidance with the gemspec and implementation.
- Replace stale test-suite status claims with current Bundler setup and focused RSpec commands.
- Standardize all example READMEs on source-checkout prerequisites and bundle exec rackup, with route-backed verification commands.
- Remove stale example claims and document verified current limitations where a checked-in example cannot complete its advertised workflow.

## Review guide
- Start with README.md and spec/README.md for the project-wide onboarding and contributor changes.
- Review the example README updates for accuracy against their config.ru files, routes, and documented current limitations. No runtime behavior changes are included.

## Validation
- git diff --check passed.
- bundle exec rspec passed: 2,206 examples, 0 failures.
- Focused Rack and request checks covered the example launch paths, lambda endpoint, MCP initialization and registry behavior, and the security diagnostic and CSRF rejection paths.