### PR TITLE
Harden forwarded authority handling

### DIFF
--- a/lib/otto.rb
+++ b/lib/otto.rb
@@ -84,6 +84,7 @@ class Otto
   attr_accessor :not_found, :server_error
 
   def initialize(path = nil, opts = {})
+    constructed = false
     initialize_core_state
     initialize_options(path, opts)
     initialize_configurations(opts)
@@ -106,6 +107,13 @@ class Otto
     # but before processing requests.
     @freeze_mutex = Mutex.new
     @configuration_frozen = false
+    constructed = true
+  ensure
+    # A config that committed to a forwarding family during configure_security
+    # is held process-wide; withdraw it if construction failed afterwards
+    # (e.g. a bad routes path), or the dead app would keep vetoing other
+    # families for the life of the process.
+    Otto::Security::Config.release_rack_forwarding_family!(@security_config) if @security_config && !constructed
   end
   alias options option
 

--- a/lib/otto/core/configuration.rb
+++ b/lib/otto/core/configuration.rb
@@ -64,16 +64,16 @@ class Otto
         # and fails loud instead of being silently dropped.
         @security_config.trusted_proxy_depth = opts[:trusted_proxy_depth] unless opts[:trusted_proxy_depth].nil?
 
-        # Select the forwarded family Otto and Rack read from. Reapply the
-        # default when no option was provided so every Otto app pins Rack during
-        # construction rather than relying on Rack's process-global default.
-        # A provided-but-invalid value is still validated, not ignored.
-        trusted_proxy_header = if opts[:trusted_proxy_header].nil?
-                                 @security_config.trusted_proxy_header
-                               else
-                                 opts[:trusted_proxy_header]
-                               end
-        @security_config.trusted_proxy_header = trusted_proxy_header
+        # Select the forwarded family Otto and Rack read from. An explicit
+        # option is an operator choice that every Otto app in the process must
+        # share; with no option, align Rack with Otto's default family without
+        # staking that claim, so a no-options sub-mount never blocks a later
+        # explicit choice. A provided-but-invalid value is still validated.
+        if opts[:trusted_proxy_header].nil?
+          @security_config.apply_default_rack_forwarding_family!
+        else
+          @security_config.trusted_proxy_header = opts[:trusted_proxy_header]
+        end
 
         # Set custom security headers
         return unless opts[:security_headers]

--- a/lib/otto/core/configuration.rb
+++ b/lib/otto/core/configuration.rb
@@ -64,10 +64,16 @@ class Otto
         # and fails loud instead of being silently dropped.
         @security_config.trusted_proxy_depth = opts[:trusted_proxy_depth] unless opts[:trusted_proxy_depth].nil?
 
-        # Select the forwarded header depth mode reads from ('X-Forwarded-For',
-        # 'Forwarded', or 'Both'). Only consulted in depth mode. Same presence
-        # guard: a provided-but-invalid value is validated, not ignored.
-        @security_config.trusted_proxy_header = opts[:trusted_proxy_header] unless opts[:trusted_proxy_header].nil?
+        # Select the forwarded family Otto and Rack read from. Reapply the
+        # default when no option was provided so every Otto app pins Rack during
+        # construction rather than relying on Rack's process-global default.
+        # A provided-but-invalid value is still validated, not ignored.
+        trusted_proxy_header = if opts[:trusted_proxy_header].nil?
+                                 @security_config.trusted_proxy_header
+                               else
+                                 opts[:trusted_proxy_header]
+                               end
+        @security_config.trusted_proxy_header = trusted_proxy_header
 
         # Set custom security headers
         return unless opts[:security_headers]

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -489,6 +489,7 @@ class Otto
       # @raise [ArgumentError] on a conflict with another committed config
       # @return [void]
       def commit_rack_forwarding_family!
+        ensure_not_frozen!
         return unless proxy_trust_configured?
 
         self.class.apply_rack_forwarding_family!(self, @trusted_proxy_header)
@@ -1022,18 +1023,18 @@ class Otto
         validate_trusted_proxy_depth!(@trusted_proxy_depth)
         raise ArgumentError, FORWARDED_HEADER_CIDR_CONFLICT_MESSAGE if !default_trusted_proxy_header? && @trusted_proxies.any?
 
-        # Late-configured proxy trust (after Otto.new) commits here at the
-        # latest, so a process-wide family conflict still fails loud.
+        if @trusted_proxy_depth
+          raise ArgumentError, PROXY_MODE_CONFLICT_MESSAGE if @trusted_proxy_depth >= 1 && @trusted_proxies.any?
+
+          # Backstop for the direct path (ip_privacy_config.geo_header=) that
+          # bypasses both eager checks; the setters cover the common orders.
+          raise ArgumentError, GEO_HEADER_DEPTH_CONFLICT_MESSAGE if @trusted_proxy_depth >= 1 && @ip_privacy_config&.geo_header
+        end
+
+        # Last, so a config that fails the checks above never registers as an
+        # owner: late-configured proxy trust (after Otto.new) commits here at
+        # the latest, so a process-wide family conflict still fails loud.
         commit_rack_forwarding_family!
-        return if @trusted_proxy_depth.nil?
-
-        raise ArgumentError, PROXY_MODE_CONFLICT_MESSAGE if @trusted_proxy_depth >= 1 && @trusted_proxies.any?
-
-        # Backstop for the direct path (ip_privacy_config.geo_header=) that
-        # bypasses both eager checks; the setters cover the common orders.
-        return unless @trusted_proxy_depth >= 1 && @ip_privacy_config&.geo_header
-
-        raise ArgumentError, GEO_HEADER_DEPTH_CONFLICT_MESSAGE
       end
 
       # Parse a value into an IPAddr, returning nil for invalid / non-IP input.

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -67,11 +67,64 @@ class Otto
       # and IP resolution. Keep it aligned with Otto's configured forwarding
       # family so the two request views cannot silently disagree.
       RACK_REQUEST = ::Rack::Request
+      DEFAULT_RACK_FORWARDED_PRIORITY = RACK_REQUEST.forwarded_priority.dup.freeze
       RACK_FORWARDED_PRIORITIES = {
         'X-Forwarded-For' => [:x_forwarded].freeze,
         'Forwarded' => [:forwarded].freeze,
         'Both' => %i[forwarded x_forwarded].freeze,
       }.freeze
+      FORWARDING_FAMILY_CONFLICT_MESSAGE = <<~MSG.gsub(/\s+/, ' ').strip.freeze
+        Cannot configure trusted_proxy_header as %s because another Otto
+        application in this process already uses %s. Rack's
+        forwarded host, port, scheme, and IP policy is process-global, so every
+        Otto application in one process must use the same forwarding family.
+      MSG
+
+      class << self
+        # Register an Otto security config's forwarding family and apply it to
+        # Rack. A config may change its own choice before freezing, but all live
+        # configs in one process must agree because Rack's setting is global.
+        def apply_rack_forwarding_family!(config, header)
+          rack_forwarding_mutex.synchronize do
+            existing = nil
+            rack_forwarding_configs.each_pair do |registered_config, registered_header|
+              next if registered_config.equal?(config) || registered_header == header
+
+              existing = registered_header
+              break
+            end
+
+            if existing
+              raise ArgumentError, format(FORWARDING_FAMILY_CONFLICT_MESSAGE, header, existing)
+            end
+
+            rack_forwarding_configs[config] = header
+            RACK_REQUEST.forwarded_priority = RACK_FORWARDED_PRIORITIES.fetch(header).dup
+          end
+        end
+
+        # Clear process-global forwarding state between isolated RSpec examples.
+        #
+        # @api private
+        def reset_rack_forwarding_family_for_testing!
+          raise 'reset_rack_forwarding_family_for_testing! is only available in RSpec test environment' unless defined?(RSpec)
+
+          rack_forwarding_mutex.synchronize do
+            @rack_forwarding_configs = ObjectSpace::WeakMap.new
+            RACK_REQUEST.forwarded_priority = DEFAULT_RACK_FORWARDED_PRIORITY.dup
+          end
+        end
+
+        private
+
+        def rack_forwarding_configs
+          @rack_forwarding_configs ||= ObjectSpace::WeakMap.new
+        end
+
+        def rack_forwarding_mutex
+          @rack_forwarding_mutex ||= Mutex.new
+        end
+      end
 
       # Endpoint group name shared by the CSP `report-to` directive and the
       # `Reporting-Endpoints` response header (modern Reporting API). Browsers
@@ -330,8 +383,9 @@ class Otto
       def trusted_proxy_header=(header)
         ensure_not_frozen!
 
-        @trusted_proxy_header = canonicalize_trusted_proxy_header(header)
-        apply_rack_forwarded_priority!
+        canonical_header = canonicalize_trusted_proxy_header(header)
+        self.class.apply_rack_forwarding_family!(self, canonical_header)
+        @trusted_proxy_header = canonical_header
       end
 
       # Validate that a request size is within acceptable limits
@@ -782,13 +836,6 @@ class Otto
       # Centralizes the repeated frozen-check so every setter shares one message.
       def ensure_not_frozen!
         raise FrozenError, 'Cannot modify frozen configuration' if frozen?
-      end
-
-      # Apply Otto's forwarding-family choice to Rack's process-global request
-      # resolution. Assign a fresh array so Rack callers cannot mutate the
-      # frozen configuration constant through its public accessor.
-      def apply_rack_forwarded_priority!
-        RACK_REQUEST.forwarded_priority = RACK_FORWARDED_PRIORITIES.fetch(@trusted_proxy_header).dup
       end
 
       # Validate a candidate trusted_proxy_depth value (type and range).

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -94,9 +94,7 @@ class Otto
               break
             end
 
-            if existing
-              raise ArgumentError, format(FORWARDING_FAMILY_CONFLICT_MESSAGE, header, existing)
-            end
+            raise ArgumentError, format(FORWARDING_FAMILY_CONFLICT_MESSAGE, header, existing) if existing
 
             rack_forwarding_configs[config] = header
             RACK_REQUEST.forwarded_priority = RACK_FORWARDED_PRIORITIES.fetch(header).dup

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -73,33 +73,79 @@ class Otto
         'Forwarded' => [:forwarded].freeze,
         'Both' => %i[forwarded x_forwarded].freeze,
       }.freeze
+      DEFAULT_TRUSTED_PROXY_HEADER = 'X-Forwarded-For'
       FORWARDING_FAMILY_CONFLICT_MESSAGE = <<~MSG.gsub(/\s+/, ' ').strip.freeze
         Cannot configure trusted_proxy_header as %s because another Otto
         application in this process already uses %s. Rack's
         forwarded host, port, scheme, and IP policy is process-global, so every
         Otto application in one process must use the same forwarding family.
       MSG
+      # Error raised when a non-default trusted_proxy_header is combined with
+      # CIDR filter mode. Otto's CIDR-walk resolves the client IP from
+      # X-Forwarded-For only, while trusted_proxy_header also pins Rack's
+      # forwarding family; honoring 'Forwarded' or 'Both' there would make Rack
+      # read a header Otto ignores, recreating the disagreement the pin exists
+      # to close.
+      FORWARDED_HEADER_CIDR_CONFLICT_MESSAGE = <<~MSG.gsub(/\s+/, ' ').strip.freeze
+        Cannot configure trusted_proxy_header 'Forwarded' or 'Both' together
+        with trusted_proxies (CIDR filter mode): CIDR-walk resolves client IPs
+        from X-Forwarded-For only. Use trusted_proxy_depth (count mode) to
+        read the RFC 7239 Forwarded header.
+      MSG
+
+      # Eager so the first two concurrent Otto.new calls cannot race on
+      # creating the lock itself.
+      RACK_FORWARDING_MUTEX = Mutex.new
+      private_constant :RACK_FORWARDING_MUTEX
 
       class << self
-        # Register an Otto security config's forwarding family and apply it to
-        # Rack. A config may change its own choice before freezing, but all live
-        # configs in one process must agree because Rack's setting is global.
-        def apply_rack_forwarding_family!(config, header)
-          rack_forwarding_mutex.synchronize do
-            existing = nil
-            rack_forwarding_configs.each_pair do |registered_config, registered_header|
-              next if registered_config.equal?(config) || registered_header == header
+        # Pin Rack's process-global forwarding family to Otto's.
+        #
+        # Rack::Request.forwarded_priority is one setting per process, so two
+        # Otto applications that explicitly choose different families cannot
+        # coexist: the later explicit choice raises. A config may revise its
+        # own choice before it freezes, as long as no other explicit config
+        # has already committed to the previous family.
+        #
+        # An implicit choice (explicit: false, the default family reapplied by
+        # a bare Otto.new) never stakes a claim: it pins Rack only while no
+        # explicit choice exists, so a no-options sub-mount constructed first
+        # cannot block a later `trusted_proxy_header: 'Forwarded'` with an
+        # error naming a family nobody chose.
+        #
+        # Explicit configs are held strongly on purpose. A weak registry made
+        # the conflict check depend on whether the earlier config had been
+        # garbage collected, so boot order and GC timing decided whether the
+        # app raised.
+        #
+        # @param config [Otto::Security::Config] the config applying the family
+        # @param header [String] canonical TRUSTED_PROXY_HEADERS value
+        # @param explicit [Boolean] whether an operator chose this family
+        # @raise [ArgumentError] on an explicit conflict with another config
+        def apply_rack_forwarding_family!(config, header, explicit: true)
+          RACK_FORWARDING_MUTEX.synchronize do
+            if explicit
+              committed = rack_forwarding_family
+              if committed && committed != header &&
+                 rack_forwarding_owners.each_key.any? { |owner| !owner.equal?(config) }
+                raise ArgumentError, format(FORWARDING_FAMILY_CONFLICT_MESSAGE, header, committed)
+              end
 
-              existing = registered_header
-              break
+              rack_forwarding_owners[config] = true
+              @rack_forwarding_family = header
+            elsif rack_forwarding_family
+              # An explicit choice already governs Rack; the default defers.
+              next
             end
 
-            raise ArgumentError, format(FORWARDING_FAMILY_CONFLICT_MESSAGE, header, existing) if existing
-
-            rack_forwarding_configs[config] = header
             RACK_REQUEST.forwarded_priority = RACK_FORWARDED_PRIORITIES.fetch(header).dup
           end
         end
+
+        # The forwarding family explicitly committed for this process, or nil.
+        #
+        # @return [String, nil]
+        attr_reader :rack_forwarding_family
 
         # Clear process-global forwarding state between isolated RSpec examples.
         #
@@ -107,20 +153,18 @@ class Otto
         def reset_rack_forwarding_family_for_testing!
           raise 'reset_rack_forwarding_family_for_testing! is only available in RSpec test environment' unless defined?(RSpec)
 
-          rack_forwarding_mutex.synchronize do
-            @rack_forwarding_configs = ObjectSpace::WeakMap.new
+          RACK_FORWARDING_MUTEX.synchronize do
+            @rack_forwarding_owners = nil
+            @rack_forwarding_family = nil
             RACK_REQUEST.forwarded_priority = DEFAULT_RACK_FORWARDED_PRIORITY.dup
           end
         end
 
         private
 
-        def rack_forwarding_configs
-          @rack_forwarding_configs ||= ObjectSpace::WeakMap.new
-        end
-
-        def rack_forwarding_mutex
-          @rack_forwarding_mutex ||= Mutex.new
+        # Identity-keyed set of configs that explicitly chose the family.
+        def rack_forwarding_owners
+          @rack_forwarding_owners ||= {}.compare_by_identity
         end
       end
 
@@ -169,7 +213,7 @@ class Otto
         @trusted_proxies        = []
         @trusted_proxy_matchers = []
         @trusted_proxy_depth    = nil
-        @trusted_proxy_header   = 'X-Forwarded-For'
+        @trusted_proxy_header   = DEFAULT_TRUSTED_PROXY_HEADER
         @require_secure_cookies = false
         @security_headers       = default_security_headers
         @input_validation       = true
@@ -249,6 +293,9 @@ class Otto
         # conflict eagerly here (and in #trusted_proxy_depth=) so it surfaces at
         # configuration time, not only at freeze (which the test harness skips).
         raise ArgumentError, PROXY_MODE_CONFLICT_MESSAGE if trusted_proxy_depth_mode?
+        # Same pattern for header-then-proxies; proxies-then-header is caught
+        # in #trusted_proxy_header=.
+        raise ArgumentError, FORWARDED_HEADER_CIDR_CONFLICT_MESSAGE unless default_trusted_proxy_header?
 
         case proxy
         when String, Regexp
@@ -359,10 +406,15 @@ class Otto
         @trusted_proxy_depth = depth
       end
 
-      # Select which forwarded header depth mode counts hops from:
-      # 'X-Forwarded-For' (default), 'Forwarded' (RFC 7239), or 'Both'. Only
-      # consulted when depth mode is active (#trusted_proxy_depth_mode?);
-      # CIDR-walk always uses X-Forwarded-For / X-Real-IP / X-Client-IP.
+      # Select which forwarded header family Otto and Rack read from:
+      # 'X-Forwarded-For' (default), 'Forwarded' (RFC 7239), or 'Both'
+      # (Forwarded when present, else X-Forwarded-For).
+      #
+      # Otto consults the value in count-based depth mode
+      # (#trusted_proxy_depth_mode?) to pick the chain it counts hops from.
+      # CIDR-walk always resolves from X-Forwarded-For / X-Real-IP /
+      # X-Client-IP, so 'Forwarded' and 'Both' are rejected once trusted_proxies
+      # are configured (and vice versa in #add_trusted_proxy).
       #
       # The value is matched case-insensitively (surrounding whitespace ignored)
       # and stored in its canonical spelling, so a hand-edited config can write
@@ -372,18 +424,42 @@ class Otto
       # time instead of as subtly-wrong client IPs at request time.
       #
       # Applying this setting also pins Rack::Request.forwarded_priority to the
-      # corresponding family. Rack exposes that policy process-wide, so all
-      # Rack consumers in the process observe Otto's operator configuration.
+      # corresponding family. Rack exposes that policy process-wide, so every
+      # Otto application in one process must agree; see
+      # Config.apply_rack_forwarding_family!.
       #
       # @param header [String] one of TRUSTED_PROXY_HEADERS (case-insensitive)
       # @raise [FrozenError] if configuration is frozen
-      # @raise [ArgumentError] if header is not a recognized value
+      # @raise [ArgumentError] if header is not a recognized value, conflicts
+      #   with configured trusted_proxies, or conflicts with another Otto
+      #   application's explicit choice in this process
       def trusted_proxy_header=(header)
         ensure_not_frozen!
 
         canonical_header = canonicalize_trusted_proxy_header(header)
+        cidr_conflict = canonical_header != DEFAULT_TRUSTED_PROXY_HEADER && @trusted_proxies.any?
+        raise ArgumentError, FORWARDED_HEADER_CIDR_CONFLICT_MESSAGE if cidr_conflict
+
         self.class.apply_rack_forwarding_family!(self, canonical_header)
         @trusted_proxy_header = canonical_header
+      end
+
+      # Align Rack's forwarding family with this config's current value without
+      # treating it as an operator choice. Used by Otto.new when no
+      # trusted_proxy_header option was given, so a bare app still pins Rack to
+      # X-Forwarded-For instead of inheriting Rack's process-global default,
+      # while deferring to any explicit choice made elsewhere in the process.
+      #
+      # @return [void]
+      def apply_default_rack_forwarding_family!
+        self.class.apply_rack_forwarding_family!(self, @trusted_proxy_header, explicit: false)
+      end
+
+      # Whether trusted_proxy_header is the X-Forwarded-For default.
+      #
+      # @return [Boolean]
+      def default_trusted_proxy_header?
+        @trusted_proxy_header == DEFAULT_TRUSTED_PROXY_HEADER
       end
 
       # Validate that a request size is within acceptable limits
@@ -905,6 +981,7 @@ class Otto
       def validate_trusted_proxy_config!
         validate_trusted_proxy_header!(@trusted_proxy_header)
         validate_trusted_proxy_depth!(@trusted_proxy_depth)
+        raise ArgumentError, FORWARDED_HEADER_CIDR_CONFLICT_MESSAGE if !default_trusted_proxy_header? && @trusted_proxies.any?
         return if @trusted_proxy_depth.nil?
 
         raise ArgumentError, PROXY_MODE_CONFLICT_MESSAGE if @trusted_proxy_depth >= 1 && @trusted_proxies.any?

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -75,10 +75,11 @@ class Otto
       }.freeze
       DEFAULT_TRUSTED_PROXY_HEADER = 'X-Forwarded-For'
       FORWARDING_FAMILY_CONFLICT_MESSAGE = <<~MSG.gsub(/\s+/, ' ').strip.freeze
-        Cannot configure trusted_proxy_header as %s because another Otto
-        application in this process already uses %s. Rack's
-        forwarded host, port, scheme, and IP policy is process-global, so every
-        Otto application in one process must use the same forwarding family.
+        Cannot use forwarding family %s (trusted_proxy_header) because another
+        Otto application in this process already uses %s. Rack's forwarded
+        host, port, scheme, and IP policy is process-global, so every Otto
+        application in one process that resolves proxied requests must use the
+        same forwarding family.
       MSG
       # Error raised when a non-default trusted_proxy_header is combined with
       # CIDR filter mode. Otto's CIDR-walk resolves the client IP from
@@ -102,29 +103,34 @@ class Otto
         # Pin Rack's process-global forwarding family to Otto's.
         #
         # Rack::Request.forwarded_priority is one setting per process, so two
-        # Otto applications that explicitly choose different families cannot
-        # coexist: the later explicit choice raises. A config may revise its
-        # own choice before it freezes, as long as no other explicit config
-        # has already committed to the previous family.
+        # Otto applications that commit to different families cannot coexist:
+        # the later commitment raises. A config commits (claim: true) when the
+        # operator sets trusted_proxy_header or configures proxy trust at all
+        # (trusted_proxies or a depth): an app that resolves proxied requests
+        # from X-Forwarded-For depends on Rack reading the same family, even
+        # though it never named one. A config may revise its own commitment
+        # before it freezes, as long as no other config has committed to the
+        # previous family.
         #
-        # An implicit choice (explicit: false, the default family reapplied by
-        # a bare Otto.new) never stakes a claim: it pins Rack only while no
-        # explicit choice exists, so a no-options sub-mount constructed first
-        # cannot block a later `trusted_proxy_header: 'Forwarded'` with an
-        # error naming a family nobody chose.
+        # A config with no proxy trust and no explicit header (claim: false, a
+        # bare Otto.new) is indifferent: it pins Rack to the default only while
+        # nothing is committed and otherwise defers, so a no-options sub-mount
+        # constructed first cannot block a later `trusted_proxy_header:
+        # 'Forwarded'` with an error naming a family nobody chose.
         #
-        # Explicit configs are held strongly on purpose. A weak registry made
+        # Committed configs are held strongly on purpose. A weak registry made
         # the conflict check depend on whether the earlier config had been
         # garbage collected, so boot order and GC timing decided whether the
-        # app raised.
+        # app raised. Otto#initialize releases the claim when construction
+        # fails after the config committed (see .release_rack_forwarding_family!).
         #
         # @param config [Otto::Security::Config] the config applying the family
         # @param header [String] canonical TRUSTED_PROXY_HEADERS value
-        # @param explicit [Boolean] whether an operator chose this family
-        # @raise [ArgumentError] on an explicit conflict with another config
-        def apply_rack_forwarding_family!(config, header, explicit: true)
+        # @param claim [Boolean] whether this config depends on the family
+        # @raise [ArgumentError] on a conflict with another committed config
+        def apply_rack_forwarding_family!(config, header, claim: true)
           RACK_FORWARDING_MUTEX.synchronize do
-            if explicit
+            if claim
               committed = rack_forwarding_family
               if committed && committed != header &&
                  rack_forwarding_owners.each_key.any? { |owner| !owner.equal?(config) }
@@ -134,11 +140,24 @@ class Otto
               rack_forwarding_owners[config] = true
               @rack_forwarding_family = header
             elsif rack_forwarding_family
-              # An explicit choice already governs Rack; the default defers.
+              # A committed choice already governs Rack; the default defers.
               next
             end
 
             RACK_REQUEST.forwarded_priority = RACK_FORWARDED_PRIORITIES.fetch(header).dup
+          end
+        end
+
+        # Withdraw a config's commitment, e.g. when Otto.new fails after the
+        # config committed. Rack's priority is left as-is: it is either still
+        # backed by another owner or will be re-pinned by the next app.
+        #
+        # @param config [Otto::Security::Config]
+        # @return [void]
+        def release_rack_forwarding_family!(config)
+          RACK_FORWARDING_MUTEX.synchronize do
+            rack_forwarding_owners.delete(config)
+            @rack_forwarding_family = nil if rack_forwarding_owners.empty?
           end
         end
 
@@ -162,7 +181,7 @@ class Otto
 
         private
 
-        # Identity-keyed set of configs that explicitly chose the family.
+        # Identity-keyed set of configs committed to the family.
         def rack_forwarding_owners
           @rack_forwarding_owners ||= {}.compare_by_identity
         end
@@ -444,15 +463,35 @@ class Otto
         @trusted_proxy_header = canonical_header
       end
 
-      # Align Rack's forwarding family with this config's current value without
-      # treating it as an operator choice. Used by Otto.new when no
-      # trusted_proxy_header option was given, so a bare app still pins Rack to
-      # X-Forwarded-For instead of inheriting Rack's process-global default,
-      # while deferring to any explicit choice made elsewhere in the process.
+      # Align Rack's forwarding family with this config's current value. Used by
+      # Otto.new when no trusted_proxy_header option was given, so a bare app
+      # still pins Rack to X-Forwarded-For instead of inheriting Rack's
+      # process-global default. The pin is a commitment only when this config
+      # already depends on the family (proxy trust configured); otherwise it
+      # defers to any commitment made elsewhere in the process.
       #
+      # @raise [FrozenError] if configuration is frozen
       # @return [void]
       def apply_default_rack_forwarding_family!
-        self.class.apply_rack_forwarding_family!(self, @trusted_proxy_header, explicit: false)
+        ensure_not_frozen!
+
+        self.class.apply_rack_forwarding_family!(self, @trusted_proxy_header, claim: proxy_trust_configured?)
+      end
+
+      # Commit this config's current family process-wide once it depends on
+      # one (proxy trust configured). Not called from the trusted_proxies /
+      # depth setters themselves, so assignment order relative to
+      # trusted_proxy_header= cannot raise a spurious conflict; instead it runs
+      # at the configuration boundaries: Otto.new
+      # (#apply_default_rack_forwarding_family!), Configurator#configure, and
+      # freeze (#validate_trusted_proxy_config!). A no-op without proxy trust.
+      #
+      # @raise [ArgumentError] on a conflict with another committed config
+      # @return [void]
+      def commit_rack_forwarding_family!
+        return unless proxy_trust_configured?
+
+        self.class.apply_rack_forwarding_family!(self, @trusted_proxy_header)
       end
 
       # Whether trusted_proxy_header is the X-Forwarded-For default.
@@ -982,6 +1021,10 @@ class Otto
         validate_trusted_proxy_header!(@trusted_proxy_header)
         validate_trusted_proxy_depth!(@trusted_proxy_depth)
         raise ArgumentError, FORWARDED_HEADER_CIDR_CONFLICT_MESSAGE if !default_trusted_proxy_header? && @trusted_proxies.any?
+
+        # Late-configured proxy trust (after Otto.new) commits here at the
+        # latest, so a process-wide family conflict still fails loud.
+        commit_rack_forwarding_family!
         return if @trusted_proxy_depth.nil?
 
         raise ArgumentError, PROXY_MODE_CONFLICT_MESSAGE if @trusted_proxy_depth >= 1 && @trusted_proxies.any?

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -6,6 +6,7 @@ require 'securerandom'
 require 'digest'
 require 'openssl'
 require 'ipaddr'
+require 'rack/request'
 require_relative '../core/freezable'
 require_relative 'csp/policy'
 
@@ -61,6 +62,16 @@ class Otto
       # OneTimeSecret's site.network.trusted_proxy.header. Only consulted in
       # depth mode; CIDR-walk is unaffected.
       TRUSTED_PROXY_HEADERS = %w[X-Forwarded-For Forwarded Both].freeze
+
+      # Rack uses one process-global priority for forwarded host, port, scheme,
+      # and IP resolution. Keep it aligned with Otto's configured forwarding
+      # family so the two request views cannot silently disagree.
+      RACK_REQUEST = ::Rack::Request
+      RACK_FORWARDED_PRIORITIES = {
+        'X-Forwarded-For' => [:x_forwarded].freeze,
+        'Forwarded' => [:forwarded].freeze,
+        'Both' => %i[forwarded x_forwarded].freeze,
+      }.freeze
 
       # Endpoint group name shared by the CSP `report-to` directive and the
       # `Reporting-Endpoints` response header (modern Reporting API). Browsers
@@ -309,6 +320,10 @@ class Otto
       # header, the way a permissive default would), so a typo surfaces at config
       # time instead of as subtly-wrong client IPs at request time.
       #
+      # Applying this setting also pins Rack::Request.forwarded_priority to the
+      # corresponding family. Rack exposes that policy process-wide, so all
+      # Rack consumers in the process observe Otto's operator configuration.
+      #
       # @param header [String] one of TRUSTED_PROXY_HEADERS (case-insensitive)
       # @raise [FrozenError] if configuration is frozen
       # @raise [ArgumentError] if header is not a recognized value
@@ -316,6 +331,7 @@ class Otto
         ensure_not_frozen!
 
         @trusted_proxy_header = canonicalize_trusted_proxy_header(header)
+        apply_rack_forwarded_priority!
       end
 
       # Validate that a request size is within acceptable limits
@@ -766,6 +782,13 @@ class Otto
       # Centralizes the repeated frozen-check so every setter shares one message.
       def ensure_not_frozen!
         raise FrozenError, 'Cannot modify frozen configuration' if frozen?
+      end
+
+      # Apply Otto's forwarding-family choice to Rack's process-global request
+      # resolution. Assign a fresh array so Rack callers cannot mutate the
+      # frozen configuration constant through its public accessor.
+      def apply_rack_forwarded_priority!
+        RACK_REQUEST.forwarded_priority = RACK_FORWARDED_PRIORITIES.fetch(@trusted_proxy_header).dup
       end
 
       # Validate a candidate trusted_proxy_depth value (type and range).

--- a/lib/otto/security/configurator.rb
+++ b/lib/otto/security/configurator.rb
@@ -79,6 +79,9 @@ class Otto
         Array(trusted_proxies).each { |proxy| add_trusted_proxy(proxy) }
         self.trusted_proxy_depth = trusted_proxy_depth unless trusted_proxy_depth.nil?
         self.trusted_proxy_header = trusted_proxy_header unless trusted_proxy_header.nil?
+        # Proxy trust configured here (after Otto.new) commits the app to its
+        # forwarding family now rather than at freeze.
+        @security_config.commit_rack_forwarding_family!
         self.security_headers = security_headers unless security_headers.empty?
 
         enable_hsts! if hsts

--- a/lib/otto/security/middleware/ip_privacy_middleware.rb
+++ b/lib/otto/security/middleware/ip_privacy_middleware.rb
@@ -36,10 +36,6 @@ class Otto
       #   # env['otto.original_ip'] also contains real IP
       #
       class IPPrivacyMiddleware
-        # Initialize IP Privacy middleware
-        #
-        # @param app [#call] Rack application
-        # @param security_config [Otto::Security::Config] Security configuration
         # Forwarding metadata Rack::Request reads without consulting Otto's
         # proxy trust verdict: host (#host/#authority), scheme (#scheme/#ssl?),
         # and port (#port), from both the X-Forwarded-* family and RFC 7239
@@ -53,6 +49,10 @@ class Otto
           HTTP_X_FORWARDED_PORT
         ].freeze
 
+        # Initialize IP Privacy middleware
+        #
+        # @param app [#call] Rack application
+        # @param security_config [Otto::Security::Config] Security configuration
         def initialize(app, security_config = nil)
           @app = app
           @security_config = security_config

--- a/lib/otto/security/middleware/ip_privacy_middleware.rb
+++ b/lib/otto/security/middleware/ip_privacy_middleware.rb
@@ -40,6 +40,19 @@ class Otto
         #
         # @param app [#call] Rack application
         # @param security_config [Otto::Security::Config] Security configuration
+        # Forwarding metadata Rack::Request reads without consulting Otto's
+        # proxy trust verdict: host (#host/#authority), scheme (#scheme/#ssl?),
+        # and port (#port), from both the X-Forwarded-* family and RFC 7239
+        # Forwarded (host=, proto=, and the port inside for=).
+        UNTRUSTED_FORWARDING_METADATA_HEADERS = %w[
+          HTTP_FORWARDED
+          HTTP_X_FORWARDED_HOST
+          HTTP_X_FORWARDED_PROTO
+          HTTP_X_FORWARDED_SCHEME
+          HTTP_X_FORWARDED_SSL
+          HTTP_X_FORWARDED_PORT
+        ].freeze
+
         def initialize(app, security_config = nil)
           @app = app
           @security_config = security_config
@@ -82,10 +95,12 @@ class Otto
           via_trusted_proxy = proxy_trust_configured && trusted_proxy?(env['REMOTE_ADDR'])
           env['otto.via_trusted_proxy'] = via_trusted_proxy if proxy_trust_configured
 
-          # Forwarded authority is denied unless proxy trust is affirmative. An
-          # absent tri-state key still means "unconfigured" to downstream code,
-          # but unconfigured forwarding cannot authorize request.host.
-          sanitize_forwarded_authority(env) unless via_trusted_proxy
+          # A peer that failed configured proxy trust cannot supply forwarded
+          # host, scheme, or port either. Unconfigured trust (absent tri-state
+          # key) is left alone: the operator has asserted nothing, and the
+          # contract reserves that state for downstream heuristics (#228), so
+          # Rack keeps its own defaults there.
+          scrub_untrusted_forwarding_metadata(env) if proxy_trust_configured && !via_trusted_proxy
 
           # Same rationale, for loopback: this middleware runs outermost, so a
           # downstream middleware that must authenticate a DIRECT LOCAL CALL
@@ -395,62 +410,22 @@ class Otto
           env['otto.ip_match'] = ->(cidrs) { Otto::Utils.ip_in_cidrs?(client_ip, cidrs) }
         end
 
-        # Remove authority metadata supplied by an untrusted peer.
+        # Remove forwarding metadata supplied by a peer that failed proxy trust.
         #
-        # Rack's forwarded_authority does not consult Otto's proxy trust verdict:
-        # it accepts X-Forwarded-Host and Forwarded host= according only to the
-        # process-global forwarding-family priority. Scrub both carriers here,
-        # while the original peer trust decision is still available, so mounted
-        # Rack applications cannot receive a client-spoofed request.host.
-        def sanitize_forwarded_authority(env)
-          env.delete('HTTP_X_FORWARDED_HOST')
-
-          forwarded = env['HTTP_FORWARDED']
-          return unless forwarded
-
-          sanitized = split_forwarded_value(forwarded.to_s.tr("\r\n", ';;'), ',').filter_map do |element|
-            parameters = split_forwarded_value(element, ';').reject do |parameter|
-              parameter.strip.empty? || parameter.match?(/\A\s*host\s*=/i)
-            end
-            value = parameters.join(';')
-            value unless value.strip.empty?
-          end.join(',')
-
-          if sanitized.empty?
-            env.delete('HTTP_FORWARDED')
-          else
-            env['HTTP_FORWARDED'] = sanitized
-          end
-        end
-
-        # Split an RFC 7239 value on an unquoted delimiter, retaining quoted
-        # delimiters and backslash escapes inside parameter values.
-        def split_forwarded_value(value, delimiter)
-          fragments = [+'']
-          quoted = false
-          escaped = false
-
-          value.each_char do |character|
-            if quoted
-              fragments.last << character
-              if escaped
-                escaped = false
-              elsif character == '\\'
-                escaped = true
-              elsif character == '"'
-                quoted = false
-              end
-            elsif character == '"'
-              quoted = true
-              fragments.last << character
-            elsif character == delimiter
-              fragments << +''
-            else
-              fragments.last << character
-            end
-          end
-
-          fragments
+        # Rack honors these according only to the process-global forwarding
+        # family, so without this an untrusted client would control
+        # request.host, request.ssl?, and request.port for every mounted Rack
+        # app (Rack::Session's Secure-cookie gate reads ssl?). Delete the
+        # carriers rather than editing them: this path only runs in CIDR filter
+        # mode, where Otto never reads the Forwarded header itself, and a
+        # hand-rolled RFC 7239 parser that disagrees with Rack's on quoting
+        # (e.g. `for=a"b;host=evil`) would let a host= survive the edit.
+        # X-Forwarded-For stays, masked or not, because Otto's own resolution
+        # already ignores it from an untrusted peer.
+        #
+        # @param env [Hash] Rack environment
+        def scrub_untrusted_forwarding_metadata(env)
+          UNTRUSTED_FORWARDING_METADATA_HEADERS.each { |key| env.delete(key) }
         end
 
         # Delete forwarded IP headers outright.

--- a/lib/otto/security/middleware/ip_privacy_middleware.rb
+++ b/lib/otto/security/middleware/ip_privacy_middleware.rb
@@ -77,9 +77,15 @@ class Otto
           # forced consumers into grant-only reads (#228).
           # respond_to?: like geo_headers_trusted?, a partial/duck-typed
           # config (or nil) that cannot report trust state is "unconfigured".
-          if @security_config.respond_to?(:proxy_trust_configured?) && @security_config.proxy_trust_configured?
-            env['otto.via_trusted_proxy'] = trusted_proxy?(env['REMOTE_ADDR'])
-          end
+          proxy_trust_configured = @security_config.respond_to?(:proxy_trust_configured?) &&
+                                   @security_config.proxy_trust_configured?
+          via_trusted_proxy = proxy_trust_configured && trusted_proxy?(env['REMOTE_ADDR'])
+          env['otto.via_trusted_proxy'] = via_trusted_proxy if proxy_trust_configured
+
+          # Forwarded authority is denied unless proxy trust is affirmative. An
+          # absent tri-state key still means "unconfigured" to downstream code,
+          # but unconfigured forwarding cannot authorize request.host.
+          sanitize_forwarded_authority(env) unless via_trusted_proxy
 
           # Same rationale, for loopback: this middleware runs outermost, so a
           # downstream middleware that must authenticate a DIRECT LOCAL CALL
@@ -387,6 +393,64 @@ class Otto
         # @param client_ip [String, nil] resolved, unmasked client IP
         def install_ip_match(env, client_ip)
           env['otto.ip_match'] = ->(cidrs) { Otto::Utils.ip_in_cidrs?(client_ip, cidrs) }
+        end
+
+        # Remove authority metadata supplied by an untrusted peer.
+        #
+        # Rack's forwarded_authority does not consult Otto's proxy trust verdict:
+        # it accepts X-Forwarded-Host and Forwarded host= according only to the
+        # process-global forwarding-family priority. Scrub both carriers here,
+        # while the original peer trust decision is still available, so mounted
+        # Rack applications cannot receive a client-spoofed request.host.
+        def sanitize_forwarded_authority(env)
+          env.delete('HTTP_X_FORWARDED_HOST')
+
+          forwarded = env['HTTP_FORWARDED']
+          return unless forwarded
+
+          sanitized = split_forwarded_value(forwarded.to_s.tr("\r\n", ';;'), ',').filter_map do |element|
+            parameters = split_forwarded_value(element, ';').reject do |parameter|
+              parameter.strip.empty? || parameter.match?(/\A\s*host\s*=/i)
+            end
+            value = parameters.join(';')
+            value unless value.strip.empty?
+          end.join(',')
+
+          if sanitized.empty?
+            env.delete('HTTP_FORWARDED')
+          else
+            env['HTTP_FORWARDED'] = sanitized
+          end
+        end
+
+        # Split an RFC 7239 value on an unquoted delimiter, retaining quoted
+        # delimiters and backslash escapes inside parameter values.
+        def split_forwarded_value(value, delimiter)
+          fragments = [+'']
+          quoted = false
+          escaped = false
+
+          value.each_char do |character|
+            if quoted
+              fragments.last << character
+              if escaped
+                escaped = false
+              elsif character == '\\'
+                escaped = true
+              elsif character == '"'
+                quoted = false
+              end
+            elsif character == '"'
+              quoted = true
+              fragments.last << character
+            elsif character == delimiter
+              fragments << +''
+            else
+              fragments.last << character
+            end
+          end
+
+          fragments
         end
 
         # Delete forwarded IP headers outright.

--- a/spec/otto/initialization_spec.rb
+++ b/spec/otto/initialization_spec.rb
@@ -170,6 +170,38 @@ RSpec.describe Otto, 'initialization' do
       end.to raise_error(ArgumentError, /every Otto application in one process must use the same forwarding family/)
     end
 
+    it 'keeps rejecting the conflict after the earlier app is garbage collected' do
+      described_class.new(routes_file, trusted_proxy_depth: 1, trusted_proxy_header: 'Forwarded')
+      GC.start
+
+      expect do
+        described_class.new(nil, trusted_proxy_depth: 1, trusted_proxy_header: 'X-Forwarded-For')
+      end.to raise_error(ArgumentError, /same forwarding family/)
+    end
+
+    it 'does not let a no-options app block a later explicit family' do
+      described_class.new(routes_file)
+
+      expect do
+        described_class.new(nil, trusted_proxy_depth: 1, trusted_proxy_header: 'Forwarded')
+      end.not_to raise_error
+      expect(Rack::Request.forwarded_priority).to eq([:forwarded])
+    end
+
+    it 'leaves an explicit family pinned when a no-options app is built afterwards' do
+      described_class.new(routes_file, trusted_proxy_depth: 1, trusted_proxy_header: 'Forwarded')
+      later = described_class.new(nil)
+
+      expect(later.security_config.trusted_proxy_header).to eq('X-Forwarded-For')
+      expect(Rack::Request.forwarded_priority).to eq([:forwarded])
+    end
+
+    it 'rejects a non-default trusted_proxy_header alongside trusted_proxies' do
+      expect do
+        described_class.new(nil, trusted_proxies: ['10.0.0.0/8'], trusted_proxy_header: 'Forwarded')
+      end.to raise_error(ArgumentError, /CIDR filter mode/)
+    end
+
     it 'canonicalizes a case-insensitive trusted_proxy_header from Otto.new' do
       otto = described_class.new(routes_file, trusted_proxy_depth: 1, trusted_proxy_header: 'both')
       expect(otto.security_config.trusted_proxy_header).to eq('Both')

--- a/spec/otto/initialization_spec.rb
+++ b/spec/otto/initialization_spec.rb
@@ -224,6 +224,35 @@ RSpec.describe Otto, 'initialization' do
       end.not_to raise_error
     end
 
+    it 'keeps a surviving owner committed when another construction fails' do
+      described_class.new(routes_file, trusted_proxy_depth: 1, trusted_proxy_header: 'Forwarded')
+
+      expect do
+        described_class.new('/nonexistent/routes.txt', trusted_proxy_depth: 1, trusted_proxy_header: 'Forwarded')
+      end.to raise_error(ArgumentError, /Bad path/)
+
+      expect(Otto::Security::Config.rack_forwarding_family).to eq('Forwarded')
+      expect do
+        described_class.new(nil, trusted_proxy_depth: 1, trusted_proxy_header: 'X-Forwarded-For')
+      end.to raise_error(ArgumentError, /already uses Forwarded/)
+    end
+
+    it 'treats a depth-mode app as committed to X-Forwarded-For' do
+      described_class.new(routes_file, trusted_proxy_depth: 1)
+
+      expect do
+        described_class.new(nil, trusted_proxy_depth: 1, trusted_proxy_header: 'Forwarded')
+      end.to raise_error(ArgumentError, /already uses X-Forwarded-For/)
+    end
+
+    it 'lets the sole owner revise its family through the configurator' do
+      otto = described_class.new(routes_file, trusted_proxy_depth: 1)
+
+      expect { otto.security.configure(trusted_proxy_header: 'Forwarded') }.not_to raise_error
+      expect(otto.security_config.trusted_proxy_header).to eq('Forwarded')
+      expect(Rack::Request.forwarded_priority).to eq([:forwarded])
+    end
+
     it 'rejects a non-default trusted_proxy_header alongside trusted_proxies' do
       expect do
         described_class.new(nil, trusted_proxies: ['10.0.0.0/8'], trusted_proxy_header: 'Forwarded')

--- a/spec/otto/initialization_spec.rb
+++ b/spec/otto/initialization_spec.rb
@@ -134,9 +134,24 @@ RSpec.describe Otto, 'initialization' do
   context 'with trusted-proxy depth-header options' do
     let(:routes_file) { create_test_routes_file('test_routes_depth.txt', test_routes) }
 
-    it 'wires trusted_proxy_header through Otto.new' do
+    around do |example|
+      original_priority = Rack::Request.forwarded_priority.dup
+      example.run
+    ensure
+      Rack::Request.forwarded_priority = original_priority
+    end
+
+    it 'wires trusted_proxy_header through Otto.new and pins Rack to the same family' do
       otto = described_class.new(routes_file, trusted_proxy_depth: 1, trusted_proxy_header: 'Forwarded')
+
       expect(otto.security_config.trusted_proxy_header).to eq('Forwarded')
+      expect(Rack::Request.forwarded_priority).to eq([:forwarded])
+    end
+
+    it 'pins Rack to X-Forwarded when Otto uses the default forwarding family' do
+      described_class.new(routes_file, trusted_proxy_depth: 1)
+
+      expect(Rack::Request.forwarded_priority).to eq([:x_forwarded])
     end
 
     it 'canonicalizes a case-insensitive trusted_proxy_header from Otto.new' do

--- a/spec/otto/initialization_spec.rb
+++ b/spec/otto/initialization_spec.rb
@@ -154,6 +154,22 @@ RSpec.describe Otto, 'initialization' do
       expect(Rack::Request.forwarded_priority).to eq([:x_forwarded])
     end
 
+    it 'allows multiple Otto applications to use the same forwarding family' do
+      described_class.new(routes_file, trusted_proxy_depth: 1, trusted_proxy_header: 'Forwarded')
+
+      expect do
+        described_class.new(nil, trusted_proxy_depth: 2, trusted_proxy_header: 'Forwarded')
+      end.not_to raise_error
+    end
+
+    it 'rejects conflicting forwarding families in the same process' do
+      described_class.new(routes_file, trusted_proxy_depth: 1, trusted_proxy_header: 'Forwarded')
+
+      expect do
+        described_class.new(nil, trusted_proxy_depth: 1, trusted_proxy_header: 'X-Forwarded-For')
+      end.to raise_error(ArgumentError, /every Otto application in one process must use the same forwarding family/)
+    end
+
     it 'canonicalizes a case-insensitive trusted_proxy_header from Otto.new' do
       otto = described_class.new(routes_file, trusted_proxy_depth: 1, trusted_proxy_header: 'both')
       expect(otto.security_config.trusted_proxy_header).to eq('Both')

--- a/spec/otto/initialization_spec.rb
+++ b/spec/otto/initialization_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe Otto, 'initialization' do
 
       expect do
         described_class.new(nil, trusted_proxy_depth: 1, trusted_proxy_header: 'X-Forwarded-For')
-      end.to raise_error(ArgumentError, /every Otto application in one process must use the same forwarding family/)
+      end.to raise_error(ArgumentError, /must use the same forwarding family/)
     end
 
     it 'keeps rejecting the conflict after the earlier app is garbage collected' do
@@ -194,6 +194,34 @@ RSpec.describe Otto, 'initialization' do
 
       expect(later.security_config.trusted_proxy_header).to eq('X-Forwarded-For')
       expect(Rack::Request.forwarded_priority).to eq([:forwarded])
+    end
+
+    it 'treats a CIDR-mode app as committed to X-Forwarded-For' do
+      described_class.new(routes_file, trusted_proxies: ['10.0.0.0/8'])
+
+      expect do
+        described_class.new(nil, trusted_proxy_depth: 1, trusted_proxy_header: 'Forwarded')
+      end.to raise_error(ArgumentError, /already uses X-Forwarded-For/)
+    end
+
+    it 'rejects a CIDR-mode app once another app committed to Forwarded' do
+      described_class.new(routes_file, trusted_proxy_depth: 1, trusted_proxy_header: 'Forwarded')
+
+      expect do
+        described_class.new(nil, trusted_proxies: ['10.0.0.0/8'])
+      end.to raise_error(ArgumentError, /already uses Forwarded/)
+      expect(Rack::Request.forwarded_priority).to eq([:forwarded])
+    end
+
+    it 'releases the family claim when construction fails after committing' do
+      expect do
+        described_class.new('/nonexistent/routes.txt', trusted_proxy_depth: 1, trusted_proxy_header: 'Forwarded')
+      end.to raise_error(ArgumentError, /Bad path/)
+
+      expect(Otto::Security::Config.rack_forwarding_family).to be_nil
+      expect do
+        described_class.new(nil, trusted_proxy_depth: 1, trusted_proxy_header: 'X-Forwarded-For')
+      end.not_to raise_error
     end
 
     it 'rejects a non-default trusted_proxy_header alongside trusted_proxies' do

--- a/spec/otto/ip_privacy_spec.rb
+++ b/spec/otto/ip_privacy_spec.rb
@@ -2087,6 +2087,13 @@ RSpec.describe 'IP Privacy Features' do
     end
 
     context 'request through untrusted proxy' do
+      around do |example|
+        original_priority = Rack::Request.forwarded_priority.dup
+        example.run
+      ensure
+        Rack::Request.forwarded_priority = original_priority
+      end
+
       it 'treats untrusted proxy IP as client IP' do
         env = {
           'REMOTE_ADDR' => '198.51.100.1',  # Untrusted proxy

--- a/spec/otto/ip_privacy_spec.rb
+++ b/spec/otto/ip_privacy_spec.rb
@@ -523,12 +523,14 @@ RSpec.describe 'IP Privacy Features' do
       end
 
       context 'RFC 7239 Forwarded header masking' do
-        it 'redacts for= but preserves proto/host/by metadata' do
+        it 'redacts for= and removes untrusted authority while preserving other metadata' do
           env = { 'REMOTE_ADDR' => '203.0.113.77',
+                  'HTTP_X_FORWARDED_HOST' => 'attacker.example',
                   'HTTP_FORWARDED' => 'for=203.0.113.77;proto=https;host=example.com;by=10.0.0.1' }
           middleware.call(env)
 
-          expect(env['HTTP_FORWARDED']).to eq('for=203.0.113.0;proto=https;host=example.com;by=10.0.0.1')
+          expect(env).not_to have_key('HTTP_X_FORWARDED_HOST')
+          expect(env['HTTP_FORWARDED']).to eq('for=203.0.113.0;proto=https;by=10.0.0.1')
           expect(env['HTTP_FORWARDED']).not_to include('203.0.113.77')
         end
 
@@ -2055,6 +2057,20 @@ RSpec.describe 'IP Privacy Features' do
         # Should use X-Forwarded-For (first in priority)
         expect(env['REMOTE_ADDR']).to eq('203.0.113.0')
       end
+
+      it 'preserves forwarded authority from a trusted peer' do
+        security_config.ip_privacy_config.disable!
+        env = {
+          'REMOTE_ADDR' => '10.0.0.1',
+          'HTTP_X_FORWARDED_HOST' => 'public.example',
+          'HTTP_FORWARDED' => 'for=203.0.113.50;host=public.example;proto=https',
+        }
+
+        middleware.call(env)
+
+        expect(env['HTTP_X_FORWARDED_HOST']).to eq('public.example')
+        expect(env['HTTP_FORWARDED']).to eq('for=203.0.113.50;host=public.example;proto=https')
+      end
     end
 
     context 'request through untrusted proxy' do
@@ -2082,6 +2098,35 @@ RSpec.describe 'IP Privacy Features' do
 
         # Should use REMOTE_ADDR and ignore untrusted headers
         expect(env['REMOTE_ADDR']).to eq('203.0.113.0')
+      end
+
+      it 'removes X-Forwarded-Host and every Forwarded host parameter' do
+        security_config.ip_privacy_config.disable!
+        env = Rack::MockRequest.env_for(
+          'http://origin.example/path',
+          'REMOTE_ADDR' => '198.51.100.1',
+          'HTTP_X_FORWARDED_HOST' => 'attacker.example',
+          'HTTP_FORWARDED' => 'for=203.0.113.50;host="attacker.example:8443";proto=https, ' \
+                              'for=192.0.2.10;HOST=other.example;by=10.0.0.1'
+        )
+
+        middleware.call(env)
+
+        expect(env).not_to have_key('HTTP_X_FORWARDED_HOST')
+        expect(env['HTTP_FORWARDED'])
+          .to eq('for=203.0.113.50;proto=https, for=192.0.2.10;by=10.0.0.1')
+        expect(Rack::Request.new(env).host).to eq('origin.example')
+      end
+
+      it 'deletes Forwarded when host is its only parameter' do
+        env = {
+          'REMOTE_ADDR' => '198.51.100.1',
+          'HTTP_FORWARDED' => 'host=attacker.example',
+        }
+
+        middleware.call(env)
+
+        expect(env).not_to have_key('HTTP_FORWARDED')
       end
     end
 

--- a/spec/otto/ip_privacy_spec.rb
+++ b/spec/otto/ip_privacy_spec.rb
@@ -523,15 +523,28 @@ RSpec.describe 'IP Privacy Features' do
       end
 
       context 'RFC 7239 Forwarded header masking' do
-        it 'redacts for= and removes untrusted authority while preserving other metadata' do
+        it 'redacts for= but preserves proto/host/by metadata' do
           env = { 'REMOTE_ADDR' => '203.0.113.77',
-                  'HTTP_X_FORWARDED_HOST' => 'attacker.example',
                   'HTTP_FORWARDED' => 'for=203.0.113.77;proto=https;host=example.com;by=10.0.0.1' }
           middleware.call(env)
 
-          expect(env).not_to have_key('HTTP_X_FORWARDED_HOST')
-          expect(env['HTTP_FORWARDED']).to eq('for=203.0.113.0;proto=https;by=10.0.0.1')
+          expect(env['HTTP_FORWARDED']).to eq('for=203.0.113.0;proto=https;host=example.com;by=10.0.0.1')
           expect(env['HTTP_FORWARDED']).not_to include('203.0.113.77')
+        end
+
+        it 'leaves forwarded authority alone when proxy trust is unconfigured' do
+          # Tri-state contract (#228): with no proxy trust configured the
+          # operator asserted nothing, so Rack keeps its own defaults.
+          env = { 'REMOTE_ADDR' => '203.0.113.77',
+                  'HTTP_X_FORWARDED_HOST' => 'public.example',
+                  'HTTP_X_FORWARDED_PROTO' => 'https',
+                  'HTTP_FORWARDED' => 'for=203.0.113.77;host=example.com' }
+          middleware.call(env)
+
+          expect(env).not_to have_key('otto.via_trusted_proxy')
+          expect(env['HTTP_X_FORWARDED_HOST']).to eq('public.example')
+          expect(env['HTTP_X_FORWARDED_PROTO']).to eq('https')
+          expect(env['HTTP_FORWARDED']).to eq('for=203.0.113.0;host=example.com')
         end
 
         it 'brackets and quotes a masked IPv6 for= value (valid RFC 7239)' do
@@ -2100,33 +2113,65 @@ RSpec.describe 'IP Privacy Features' do
         expect(env['REMOTE_ADDR']).to eq('203.0.113.0')
       end
 
-      it 'removes X-Forwarded-Host and every Forwarded host parameter' do
+      it 'removes every forwarded host, scheme, and port carrier Rack reads' do
         security_config.ip_privacy_config.disable!
         env = Rack::MockRequest.env_for(
           'http://origin.example/path',
           'REMOTE_ADDR' => '198.51.100.1',
           'HTTP_X_FORWARDED_HOST' => 'attacker.example',
-          'HTTP_FORWARDED' => 'for=203.0.113.50;host="attacker.example:8443";proto=https, ' \
+          'HTTP_X_FORWARDED_PROTO' => 'https',
+          'HTTP_X_FORWARDED_SCHEME' => 'https',
+          'HTTP_X_FORWARDED_SSL' => 'on',
+          'HTTP_X_FORWARDED_PORT' => '8443',
+          'HTTP_X_FORWARDED_FOR' => '203.0.113.50',
+          'HTTP_FORWARDED' => 'for="203.0.113.50:8443";host="attacker.example:8443";proto=https, ' \
                               'for=192.0.2.10;HOST=other.example;by=10.0.0.1'
         )
 
         middleware.call(env)
 
-        expect(env).not_to have_key('HTTP_X_FORWARDED_HOST')
-        expect(env['HTTP_FORWARDED'])
-          .to eq('for=203.0.113.50;proto=https, for=192.0.2.10;by=10.0.0.1')
-        expect(Rack::Request.new(env).host).to eq('origin.example')
+        expect(env.keys).not_to include(
+          'HTTP_FORWARDED', 'HTTP_X_FORWARDED_HOST', 'HTTP_X_FORWARDED_PROTO',
+          'HTTP_X_FORWARDED_SCHEME', 'HTTP_X_FORWARDED_SSL', 'HTTP_X_FORWARDED_PORT'
+        )
+        expect(env['HTTP_X_FORWARDED_FOR']).to eq('203.0.113.50')
+        request = Rack::Request.new(env)
+        expect(request.host).to eq('origin.example')
+        expect(request.ssl?).to be(false)
+        expect(request.port).to eq(80)
       end
 
-      it 'deletes Forwarded when host is its only parameter' do
+      it 'is not fooled by quoting Rack parses differently (regression)' do
+        # Rack only enters quote mode when `"` is the first character of a
+        # value; a scrub that hand-parses quotes differently let this host
+        # survive. Deleting the carrier makes parser agreement irrelevant.
+        security_config.ip_privacy_config.disable!
+        env = Rack::MockRequest.env_for(
+          'http://origin.example/path',
+          'REMOTE_ADDR' => '198.51.100.1',
+          'HTTP_FORWARDED' => 'for=a"b;host=evil.example;proto=https'
+        )
+        Rack::Request.forwarded_priority = [:forwarded]
+
+        middleware.call(env)
+
+        request = Rack::Request.new(env)
+        expect(request.host).to eq('origin.example')
+        expect(request.ssl?).to be(false)
+      end
+
+      it 'scrubs under privacy masking as well' do
         env = {
           'REMOTE_ADDR' => '198.51.100.1',
+          'HTTP_X_FORWARDED_HOST' => 'attacker.example',
           'HTTP_FORWARDED' => 'host=attacker.example',
         }
 
         middleware.call(env)
 
         expect(env).not_to have_key('HTTP_FORWARDED')
+        expect(env).not_to have_key('HTTP_X_FORWARDED_HOST')
+        expect(env['REMOTE_ADDR']).to eq('198.51.100.0')
       end
     end
 

--- a/spec/otto/security/configurator_spec.rb
+++ b/spec/otto/security/configurator_spec.rb
@@ -117,6 +117,13 @@ RSpec.describe Otto::Security::Configurator do
       expect(security_config.trusted_proxy_header).to eq('Forwarded')
     end
 
+    it 'commits trusted_proxies configured after Otto.new to the forwarding family' do
+      Otto::Security::Config.new.trusted_proxy_header = 'Forwarded'
+
+      expect { configurator.configure(trusted_proxies: '10.0.0.0/8') }
+        .to raise_error(ArgumentError, /already uses Forwarded/)
+    end
+
     it 'leaves the forwarded header at its default when not specified' do
       configurator.configure(trusted_proxy_depth: 1)
 

--- a/spec/security_config_spec.rb
+++ b/spec/security_config_spec.rb
@@ -527,6 +527,22 @@ RSpec.describe Otto::Security::Config do
       expect { config.deep_freeze! }.to raise_error(ArgumentError, /already uses Forwarded/)
     end
 
+    it 'pins and commits a depth-mode config at freeze' do
+      config.trusted_proxy_depth = 1
+      config.deep_freeze!
+
+      expect(described_class.rack_forwarding_family).to eq('X-Forwarded-For')
+      expect(Rack::Request.forwarded_priority).to eq([:x_forwarded])
+    end
+
+    it 'does not register a config that fails freeze-time validation' do
+      config.add_trusted_proxy('10.0.0.0/8')
+      config.instance_variable_set(:@trusted_proxy_depth, 1) # bypass the eager setter
+
+      expect { config.deep_freeze! }.to raise_error(ArgumentError, /Cannot configure both/)
+      expect(described_class.rack_forwarding_family).to be_nil
+    end
+
     it 'leaves a config with no proxy trust uncommitted' do
       config.apply_default_rack_forwarding_family!
 

--- a/spec/security_config_spec.rb
+++ b/spec/security_config_spec.rb
@@ -474,6 +474,41 @@ RSpec.describe Otto::Security::Config do
       end
     end
 
+    it 'lets one config revise its own explicit choice' do
+      config.trusted_proxy_header = 'Forwarded'
+      expect { config.trusted_proxy_header = 'Both' }.not_to raise_error
+      expect(Rack::Request.forwarded_priority).to eq(%i[forwarded x_forwarded])
+    end
+
+    it 'rejects a revision once another config has committed to the family' do
+      config.trusted_proxy_header = 'Forwarded'
+      described_class.new.trusted_proxy_header = 'Forwarded'
+
+      expect { config.trusted_proxy_header = 'Both' }
+        .to raise_error(ArgumentError, /same forwarding family/)
+    end
+
+    it "rejects 'Forwarded' after trusted_proxies are configured" do
+      config.add_trusted_proxy('10.0.0.0/8')
+
+      expect { config.trusted_proxy_header = 'Forwarded' }
+        .to raise_error(ArgumentError, /CIDR filter mode/)
+      expect(config.trusted_proxy_header).to eq('X-Forwarded-For')
+    end
+
+    it "rejects trusted_proxies after 'Both' is configured" do
+      config.trusted_proxy_header = 'Both'
+
+      expect { config.add_trusted_proxy('10.0.0.0/8') }
+        .to raise_error(ArgumentError, /CIDR filter mode/)
+    end
+
+    it 'still accepts the default header alongside trusted_proxies' do
+      config.add_trusted_proxy('10.0.0.0/8')
+
+      expect { config.trusted_proxy_header = 'x-forwarded-for' }.not_to raise_error
+    end
+
     it 'maps each forwarding family to Rack forwarded_priority' do
       {
         'X-Forwarded-For' => [:x_forwarded],

--- a/spec/security_config_spec.rb
+++ b/spec/security_config_spec.rb
@@ -503,6 +503,43 @@ RSpec.describe Otto::Security::Config do
         .to raise_error(ArgumentError, /CIDR filter mode/)
     end
 
+    it 'commits a depth-mode config to its family without naming one' do
+      config.trusted_proxy_depth = 1
+      config.commit_rack_forwarding_family!
+
+      expect(described_class.rack_forwarding_family).to eq('X-Forwarded-For')
+      expect { described_class.new.trusted_proxy_header = 'Forwarded' }
+        .to raise_error(ArgumentError, /already uses X-Forwarded-For/)
+    end
+
+    it 'does not commit from the depth setter, so header order is free' do
+      described_class.new.trusted_proxy_header = 'Forwarded'
+      config.trusted_proxy_depth = 1
+
+      expect { config.trusted_proxy_header = 'Forwarded' }.not_to raise_error
+      expect { config.commit_rack_forwarding_family! }.not_to raise_error
+    end
+
+    it 'commits at freeze for trust configured after construction' do
+      described_class.new.trusted_proxy_header = 'Forwarded'
+      config.add_trusted_proxy('10.0.0.0/8')
+
+      expect { config.deep_freeze! }.to raise_error(ArgumentError, /already uses Forwarded/)
+    end
+
+    it 'leaves a config with no proxy trust uncommitted' do
+      config.apply_default_rack_forwarding_family!
+
+      expect(described_class.rack_forwarding_family).to be_nil
+      expect(Rack::Request.forwarded_priority).to eq([:x_forwarded])
+    end
+
+    it 'refuses apply_default_rack_forwarding_family! once frozen' do
+      config.deep_freeze!
+
+      expect { config.apply_default_rack_forwarding_family! }.to raise_error(FrozenError)
+    end
+
     it 'still accepts the default header alongside trusted_proxies' do
       config.add_trusted_proxy('10.0.0.0/8')
 

--- a/spec/security_config_spec.rb
+++ b/spec/security_config_spec.rb
@@ -456,6 +456,13 @@ RSpec.describe Otto::Security::Config do
   end
 
   describe 'trusted_proxy_header (depth-mode forwarded header)' do
+    around do |example|
+      original_priority = Rack::Request.forwarded_priority.dup
+      example.run
+    ensure
+      Rack::Request.forwarded_priority = original_priority
+    end
+
     it 'defaults to X-Forwarded-For' do
       expect(config.trusted_proxy_header).to eq('X-Forwarded-For')
     end
@@ -464,6 +471,17 @@ RSpec.describe Otto::Security::Config do
       %w[X-Forwarded-For Forwarded Both].each do |header|
         config.trusted_proxy_header = header
         expect(config.trusted_proxy_header).to eq(header)
+      end
+    end
+
+    it 'maps each forwarding family to Rack forwarded_priority' do
+      {
+        'X-Forwarded-For' => [:x_forwarded],
+        'Forwarded' => [:forwarded],
+        'Both' => %i[forwarded x_forwarded],
+      }.each do |header, priority|
+        config.trusted_proxy_header = header
+        expect(Rack::Request.forwarded_priority).to eq(priority)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,6 +52,7 @@ RSpec.configure do |config|
     # Reset environment variables
     ENV['RACK_ENV'] = 'test'
     ENV['OTTO_DEBUG'] = 'false' unless ENV['OTTO_DEBUG'] == 'true'
+    Otto::Security::Config.reset_rack_forwarding_family_for_testing!
 
     # Clean up any test files in spec/fixtures
     Dir.glob('spec/fixtures/test_routes_*.txt').each { |f| File.delete(f) if File.exist?(f) }


### PR DESCRIPTION
## Summary
- Pin Rack’s process-global forwarded-header priority to Otto’s configured forwarding family so host, port, scheme, and IP resolution use one policy.
- Reject conflicting forwarding families across live Otto applications and strip `X-Forwarded-Host` and RFC 7239 `host=` parameters unless the immediate peer is trusted.
- Add regression coverage for default and explicit Rack priority mapping, multi-app conflicts, and trusted versus untrusted forwarded authority.

## Review guide
- Start with `Otto::Security::Config`, especially the weakly tracked process-wide family registration and conflict handling.
- Review `IPPrivacyMiddleware#sanitize_forwarded_authority` for RFC 7239 parsing and confirm only authority metadata is removed from untrusted requests.
- Note that multiple Otto applications in one process must now choose the same forwarding family because Rack exposes this policy globally.

## Validation
- Pre-commit, pre-push, and CI checks will validate this change.