### PR TITLE
Harden optional dependencies and document support policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,15 +28,18 @@ jobs:
       fail-fast: false
       matrix:
         # Each Ruby runs twice: once against the committed Gemfile.lock
-        # (floor of the declared version range, reproducible) and once
-        # with the lockfile removed so Bundler resolves fresh inside the
-        # gemspec's pessimistic constraints (ceiling, what a downstream
-        # user will actually hit). The unlocked cells catch upstream
-        # releases that satisfy `~> X.Y` but break Otto at load time -
+        # (the reproducible maintainer snapshot) and once with the lockfile
+        # removed so Bundler resolves currently available versions inside the
+        # gemspec constraints. Neither resolution is a patched security floor;
+        # consumers must audit their own lockfiles. The unlocked cells catch
+        # upstream releases that satisfy `~> X.Y` but break Otto at load time -
         # e.g. facets 3.2.0 shipping a self-referential
         # `require_relative 'file/write.rb'` against a file deleted in
         # the same release, the reason 2.0.2 exists.
         include:
+          # Ruby 3.2 is EOL upstream but remains a blocking compatibility
+          # target. Ruby 3.5 and 4.0 remain provisional, non-blocking targets.
+          # See docs/reference/runtime-and-dependency-security.md.
           - ruby: "3.2"
             experimental: false
             lockfile: "locked"

--- a/Gemfile
+++ b/Gemfile
@@ -18,9 +18,9 @@ end
 # bundle config set with 'optional'
 group :development, :test, optional: true do
   # Keep gems that need to be in both environments
-  gem 'json_schemer'
+  gem 'json_schemer', '~> 2.0'
   gem 'maxmind-db', '~> 1.2' # Optional geo DB reader; exercised by geo specs
-  gem 'rack-attack'
+  gem 'rack-attack', '~> 6.7'
   gem 'reek', '~> 6.5'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,6 @@ PATH
       logger (~> 1, < 2.0)
       loofah (~> 2.20)
       rack (~> 3.1, < 4.0)
-      rack-parser (~> 0.7)
-      rexml (~> 3.4)
 
 GEM
   remote: https://rubygems.org/
@@ -109,8 +107,6 @@ GEM
     rack (3.2.7)
     rack-attack (6.8.0)
       rack (>= 1.0, < 4)
-    rack-parser (0.7.0)
-      rack
     rack-test (2.2.0)
       rack (>= 1.3)
     rackup (2.3.1)
@@ -217,11 +213,11 @@ PLATFORMS
 DEPENDENCIES
   benchmark
   debug
-  json_schemer
+  json_schemer (~> 2.0)
   kramdown
   maxmind-db (~> 1.2)
   otto!
-  rack-attack
+  rack-attack (~> 6.7)
   rack-test
   rackup
   rake (~> 13.4)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ Otto apps have three files: a rackup file, a Ruby class, and a routes file. The 
 
 ## Quick start
 
-Requirements: Ruby `>= 3.2, < 4.1` and Rack `>= 3.1, < 4.0`.
+Requirements: Ruby `>= 3.2, < 4.1` and Rack `>= 3.1, < 4.0`. Ruby 3.2
+remains compatibility-tested after upstream end of life, but receives no
+interpreter security maintenance. See the [runtime and dependency security
+policy](docs/reference/runtime-and-dependency-security.md) for support tiers and
+consumer lockfile requirements.
 
 Install Otto and the Rack server CLI, then create the three files shown below:
 
@@ -97,7 +101,27 @@ app = Otto.new("./routes", {
 })
 ```
 
-Security features include CSRF protection, input validation, security headers, and trusted proxy configuration.
+Security features include CSRF protection, input validation, security headers, rate limiting, and trusted proxy configuration.
+
+### Rate limiting (`rack-attack`)
+
+Rate limiting requires `rack-attack` 6.7.0 or newer in the 6.x series. Add the
+optional dependency and mount it before Otto; `enable_rate_limiting!` configures
+rules, while `Rack::Attack` enforces them:
+
+```ruby
+# Gemfile
+gem 'rack-attack', '~> 6.7'
+
+# config.ru
+use Rack::Attack
+app = Otto.new('./routes')
+app.enable_rate_limiting!(requests_per_minute: 50)
+run app
+```
+
+Enabling rate limiting raises `Otto::OptionalDependencyError` at configuration
+time when the gem is missing or outside the supported range.
 
 ### Content Security Policy (nonce-based emission)
 
@@ -315,7 +339,7 @@ Private and localhost IPs are exempted by default for development convenience, b
 ```ruby
 otto.configure_ip_privacy(
   geo_header: 'X-Client-Country',        # trusted app header, checked first
-  geo_db_path: 'data/country.mmdb'       # offline fallback (needs the maxmind-db gem)
+  geo_db_path: 'data/country.mmdb'       # offline fallback (needs maxmind-db >= 1.2.0, < 2)
 )
 ```
 
@@ -437,6 +461,7 @@ See the [examples/](examples/) directory for more.
 ## Documentation
 
 - **[Documentation map](docs/README.md)** - Capabilities, current guides, and the documentation structure Otto is growing toward
+- **[Runtime and dependency security policy](docs/reference/runtime-and-dependency-security.md)** - Ruby compatibility, dependency-range guarantees, and consumer lockfile auditing
 - **[AGENTS.md](AGENTS.md)** - Contributor and agent guidance for Otto conventions; it is not application documentation
 - **[CHANGELOG.rst](CHANGELOG.rst)** - Version history, breaking changes, and upgrade notes
 

--- a/changelog.d/20260904_255.rst
+++ b/changelog.d/20260904_255.rst
@@ -1,0 +1,19 @@
+Changed
+-------
+
+- Supported optional dependency ranges are now enforced during configuration:
+  ``json_schemer ~> 2.0``, ``rack-attack ~> 6.7``, and ``maxmind-db ~> 1.2``.
+  (#255)
+
+Removed
+-------
+
+- Removed the unused ``rack-parser`` and ``rexml`` runtime dependencies. (#255)
+
+Security
+--------
+
+- MCP schema validation and rate limiting now fail closed when their optional
+  dependencies are unavailable. Set ``enable_validation: false`` or
+  ``enable_rate_limiting: false`` only when that protection is not required.
+  (#255)

--- a/changelog.d/20260904_255.rst
+++ b/changelog.d/20260904_255.rst
@@ -1,6 +1,9 @@
 Changed
 -------
 
+- MCP rate limiting no longer registers a second ``rack.attack`` log
+  subscriber on top of the general one, so throttled requests are logged once.
+  (#255)
 - Supported optional dependency ranges are now enforced during configuration:
   ``json_schemer ~> 2.0``, ``rack-attack ~> 6.7``, and ``maxmind-db ~> 1.2``.
   (#255)

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ the smallest complete configuration that uses it safely.
 | Request lifecycle | Rack integration, middleware ordering, helper registration, lifecycle hooks, and boot-time configuration | `guides/application-lifecycle.md` |
 | Authentication and authorization | Named authentication strategies, ordered multi-strategy fallback, terminal failures, route roles, and resource-level authorization | [Authentication](guides/authentication.md) |
 | Security | CSRF enforcement, request validation, rate limiting, security headers, CSP, error handling, and trusted proxies | `guides/security.md` |
+| Runtime and dependencies | Ruby compatibility tiers, upstream security-maintenance limits, dependency-range guarantees, and consumer lockfile auditing | [Runtime and dependency security policy](reference/runtime-and-dependency-security.md) |
 | Privacy and network identity | IP privacy profiles, privacy-safe client signals, country resolution, ASN lookup, and anonymizer classification | [Privacy](guides/privacy.md), [geo-country](guides/geo-country.md), and [enrichment](guides/enrichment.md) |
 | Internationalization | Locale configuration and request locale resolution | `guides/locales.md` |
 | Operations | Structured logging, safe error reporting, static files, and testing Otto applications | `guides/operations.md` |
@@ -27,6 +28,8 @@ the smallest complete configuration that uses it safely.
 ## Start here today
 
 - [Project README](../README.md) — installation and a minimal Rack app.
+- [Runtime and dependency security policy](reference/runtime-and-dependency-security.md)
+  — choose a maintained Ruby and keep the application's resolved bundle audited.
 - [Routing guide](guides/routing.md) — choose a handler style and response
   contract.
 - [Authentication guide](guides/authentication.md) — protect routes and separate
@@ -74,7 +77,8 @@ docs/
 │   ├── route-syntax.md
 │   ├── configuration.md
 │   ├── request-and-response.md
-│   └── errors.md
+│   ├── errors.md
+│   └── runtime-and-dependency-security.md
 ├── migrating/                        # release-specific upgrade guides
 ├── adr/                              # accepted architecture decision records
 └── maintainers/

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,7 @@ They are **not** the primary entry point for implementing an application:
 - [ADR-001: Route authentication at the handler boundary](adr/adr-001-route-authentication-at-handler-boundary.md)
 - [ADR-002: Multi-strategy authentication and authorization](adr/adr-002-multi-strategy-authentication-and-authorization.md)
 - [ADR-003: Caddy TLS route-based integration](adr/adr-003-caddy-tls-route-based-integration.md)
+- [ADR-004: Compatibility support and security maintenance](adr/adr-004-separate-compatibility-from-security-maintenance.md)
 - [Ruby `IPAddr#to_s` encoding note](guides/ipaddr-encoding-quirk.md)
 
 ## Target structure

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -6,6 +6,11 @@ without replacing the supported application documentation.
 
 ## Records
 
+- [ADR-001: Enforce route authentication at the handler boundary](adr-001-route-authentication-at-handler-boundary.md)
+- [ADR-002: Use ordered authentication strategy chains and two-layer authorization](adr-002-multi-strategy-authentication-and-authorization.md)
+- [ADR-003: Provide Caddy on-demand TLS as a route-based feature integration](adr-003-caddy-tls-route-based-integration.md)
+- [ADR-004: Separate compatibility support from security maintenance](adr-004-separate-compatibility-from-security-maintenance.md)
+
 New records use the next three-digit sequence number and describe their status,
 context, decision, and consequences. Update a record's status when a later ADR
 supersedes it; do not rewrite accepted decisions to reflect later changes.

--- a/docs/adr/adr-004-separate-compatibility-from-security-maintenance.md
+++ b/docs/adr/adr-004-separate-compatibility-from-security-maintenance.md
@@ -1,0 +1,58 @@
+# ADR-004: Separate compatibility support from security maintenance
+
+- **Status:** Accepted
+- **Date:** 2026-09-04
+
+## Context
+
+Otto declares Ruby and dependency version ranges so that applications can resolve
+a compatible bundle. Those declarations can be mistaken for security guarantees:
+a Ruby version may remain compatible with Otto after upstream security maintenance
+ends, and a gem version may satisfy Otto's dependency range after a new advisory
+makes that version unsafe.
+
+Otto's own lockfile and CI matrix test Otto's development resolution and API
+compatibility. They cannot determine or secure the final dependency graph resolved
+by every application that installs Otto. The current Ruby support matrix,
+dependency constraints, and audit procedures also change over time, so they belong
+in maintained reference documentation rather than in a historical decision record.
+
+## Decision
+
+Otto treats compatibility support as distinct from upstream security maintenance.
+Compatibility testing means that Otto is expected to work on a runtime or with a
+dependency version; it does not mean that the runtime or dependency still receives
+security fixes.
+
+The version ranges in `otto.gemspec` express API compatibility. Their lower bounds
+are not guaranteed security floors, and installation success does not certify a
+resolved bundle as free of known vulnerabilities.
+
+Applications that consume Otto own the security auditing and maintenance of their
+resolved lockfiles. Otto may constrain a known-bad version when warranted, but
+maintainer constraints and CI do not replace application-level auditing.
+
+Otto continues to test Ruby 3.2 as a compatibility target despite its upstream end
+of life. This preserves compatibility for users who still need that runtime without
+representing Ruby 3.2 as security-maintained.
+
+## Consequences
+
+- Otto can retain useful compatibility coverage without implying that it provides
+  upstream interpreter or dependency security maintenance.
+- Applications with security-maintenance requirements must select an upstream-
+  maintained Ruby, audit their complete resolved bundles, and deploy audited
+  lockfiles.
+- Dependency lower bounds remain stable compatibility baselines unless an API or
+  security issue requires a targeted constraint change.
+- Ruby 3.2 compatibility failures remain release-relevant while it is a blocking
+  target, even though applications should not infer that Ruby 3.2 receives security
+  fixes.
+- The current support matrix, compatibility ranges, audit commands, and consumer
+  procedures may change in the canonical reference without rewriting this ADR. A
+  later architectural decision may supersede this record if the policy changes.
+
+## Related documentation
+
+- [Runtime and dependency security policy](../reference/runtime-and-dependency-security.md)
+  — canonical current matrix, compatibility policy, and consumer audit procedures

--- a/docs/guides/enrichment.md
+++ b/docs/guides/enrichment.md
@@ -37,7 +37,9 @@ Both accept the same bring-your-own-reader seam as geo (`asn_db_reader:` /
 `anonymizer_db_reader:` — any object responding to `#get(ip)`; a reader
 supplied in the same call wins over a path). Bad paths raise at boot, not
 per-request. The [`maxmind-db`](https://rubygems.org/gems/maxmind-db) gem is
-required only when a `*_db_path` is configured.
+required only when a `*_db_path` is configured; Otto supports version 1.2.0 or
+newer in the 1.x series (`gem 'maxmind-db', '~> 1.2'`). Missing or incompatible
+versions raise `Otto::OptionalDependencyError` during configuration.
 
 ## ASN: which address is looked up, and why that's safe
 

--- a/docs/guides/geo-country.md
+++ b/docs/guides/geo-country.md
@@ -101,12 +101,14 @@ point.
 
 The [`maxmind-db`](https://rubygems.org/gems/maxmind-db) gem (official MaxMind
 reader, Apache-2.0, pure Ruby, zero runtime deps) is an **optional**
-dependency. Otto only `require`s it when a database is configured. Add it to
-your app when you use the database fallback:
+dependency. Otto supports version 1.2.0 or newer in the 1.x series and only
+loads it when a database path is configured. A missing or incompatible gem
+raises `Otto::OptionalDependencyError` at configuration time. Add it to your
+app when you use the database fallback:
 
 ```ruby
 # Gemfile
-gem 'maxmind-db', '~> 1.4'
+gem 'maxmind-db', '~> 1.2'
 ```
 
 ### Data file (`geo-whois-asn-country`)

--- a/docs/reference/runtime-and-dependency-security.md
+++ b/docs/reference/runtime-and-dependency-security.md
@@ -1,0 +1,86 @@
+# Runtime and dependency security policy
+
+This policy explains what Otto's Ruby and gem version declarations guarantee,
+what they do not guarantee, and what applications using Otto must do to keep a
+deployed bundle patched.
+
+## Ruby compatibility and security maintenance
+
+Otto separates **runtime compatibility** from **interpreter security
+maintenance**. A blocking compatibility target must pass Otto's test suite;
+provisional targets are exercised without blocking releases. Only the Ruby
+project can provide security maintenance for the interpreter.
+
+| Ruby version | Otto compatibility policy | CI status |
+| --- | --- | --- |
+| 3.2 | Retained as a compatibility target for now, despite upstream end of life | Blocking, with locked and freshly resolved dependencies |
+| 3.3–3.4 | Supported compatibility targets | Blocking, with locked and freshly resolved dependencies |
+| 3.5–4.0 | Accepted by the gem's Ruby version range, but compatibility remains provisional | Experimental and non-blocking, with locked and freshly resolved dependencies |
+
+Ruby 3.2 reached upstream end of life on April 1, 2026. It receives no
+interpreter security maintenance. Otto's continued compatibility testing cannot
+correct vulnerabilities in Ruby 3.2 itself. Applications with a security
+maintenance requirement should run Otto on a Ruby version that the Ruby project
+currently maintains. Check the [Ruby branch maintenance
+status](https://www.ruby-lang.org/en/downloads/branches/) when selecting a
+runtime.
+
+The `required_ruby_version` range in `otto.gemspec` controls whether RubyGems
+may install Otto. It does not mean every version in that range has the same CI
+or upstream security status. The table above is the support policy for the
+current matrix.
+
+## What dependency ranges mean
+
+The runtime dependency ranges in `otto.gemspec` express the versions Otto
+expects to be API-compatible with. Their lower bounds are compatibility
+baselines, not a promise that every allowed version is free of known
+vulnerabilities or still receives security fixes.
+
+Otto may exclude a known-bad dependency release or raise a lower bound when a
+vulnerability affects Otto users. Such a constraint is a targeted response, not
+a substitute for auditing the complete resolved dependency graph. A future
+advisory can make any previously acceptable version unsafe while it still
+satisfies the gemspec.
+
+Otto's committed `Gemfile.lock` makes maintainer development and CI resolution
+reproducible. Bundler does not use that lockfile when Otto is installed as a
+dependency of another application. Otto's locked and freshly resolved CI jobs
+test compatibility; neither job selects or certifies a secure dependency set
+for consumer applications.
+
+## Consumer lockfile policy
+
+The deployable application is responsible for the final dependency graph. An
+application using Otto should:
+
+1. Commit its `Gemfile.lock` and deploy that exact resolution.
+2. Make [`bundler-audit`](https://github.com/rubysec/bundler-audit) available
+   in application CI, then run it with an updated advisory database on every
+   lockfile change, on a scheduled weekly job, and before each production
+   deployment:
+
+   ```sh
+   bundle-audit check --update
+   ```
+
+3. Treat a relevant advisory as a release blocker. Update the affected gem and
+   re-run the application's tests and audit. For a conservative targeted
+   update, replace `GEM_NAME` with the affected gem:
+
+   ```sh
+   bundle update --conservative GEM_NAME
+   bundle-audit check --update
+   ```
+
+4. Enable an automated dependency updater, or review `bundle outdated`
+   manually at least weekly, so patched releases reach the application
+   lockfile.
+5. Audit the Ruby interpreter, operating system packages, and native libraries
+   separately. `bundler-audit` checks Ruby gems; it does not make an
+   end-of-life Ruby secure.
+
+If the patched dependency version falls outside Otto's declared range,
+applications should upgrade Otto when a compatible release is available and
+report the blocked update to the maintainers. Do not assume that a successful
+`bundle install` means the resolved bundle has no known vulnerabilities.

--- a/examples/mcp_demo/README.md
+++ b/examples/mcp_demo/README.md
@@ -22,7 +22,22 @@ routes.
 Run this example from an Otto source checkout. It requires Ruby 3.2 through
 4.0, Bundler, and the development dependencies: `rackup` is a development
 dependency in the root `Gemfile` and is not installed with the released `otto`
-gem.
+gem. MCP enables schema validation and rate limiting by default. Those features
+require `json_schemer` 2.0.0 or newer in the 2.x series and `rack-attack` 6.7.0
+or newer in the 6.x series:
+
+```ruby
+# Gemfile
+gem 'json_schemer', '~> 2.0'
+gem 'rack-attack', '~> 6.7'
+```
+
+If either enabled feature's gem is missing or incompatible, MCP setup raises
+`Otto::OptionalDependencyError` during configuration. Pass
+`enable_validation: false` or `enable_rate_limiting: false` to `enable_mcp!`, or
+alongside `mcp_enabled: true` in the `Otto.new` options, only when that protection
+is intentionally disabled. To enforce the configured limits, mount
+`Rack::Attack` before Otto in `config.ru`, as this example does.
 
 ```sh
 cd /path/to/otto

--- a/examples/mcp_demo/config.ru
+++ b/examples/mcp_demo/config.ru
@@ -14,4 +14,5 @@ app = Otto.new('routes', {
 # The `mcp_enabled: true` flag automatically sets up the /_mcp endpoint.
 # The routes file maps MCP and TOOL methods to classes.
 
+use Rack::Attack
 run app

--- a/lib/otto/core/configuration.rb
+++ b/lib/otto/core/configuration.rb
@@ -100,6 +100,9 @@ class Otto
 
         mcp_options = {}
         mcp_options[:http_endpoint] = opts[:mcp_endpoint] if opts[:mcp_endpoint]
+        %i[enable_validation enable_rate_limiting].each do |option|
+          mcp_options[option] = opts[option] if opts.key?(option)
+        end
 
         return unless opts[:mcp_http] != false # Default to true unless explicitly disabled
 

--- a/lib/otto/mcp/rate_limiting.rb
+++ b/lib/otto/mcp/rate_limiting.rb
@@ -6,19 +6,11 @@ require 'json'
 
 require_relative '../security/rate_limiting'
 
-begin
-  require 'rack/attack'
-rescue LoadError
-  # rack-attack is optional - graceful fallback
-end
-
 class Otto
   module MCP
     # Rate limiter for MCP protocol endpoints
     class RateLimiter < Otto::Security::RateLimiting
       def self.configure_rack_attack!(config = {})
-        return unless defined?(Rack::Attack)
-
         # Start with base configuration from general rate limiting
         super
 
@@ -132,15 +124,10 @@ class Otto
     # Middleware for applying rate limits to MCP protocol endpoints
     class RateLimitMiddleware < Otto::Security::RateLimitMiddleware
       def initialize(app, security_config = nil)
-        @app                    = app
-        @security_config        = security_config
-        @rate_limiter_available = defined?(Rack::Attack)
+        @app             = app
+        @security_config = security_config
 
-        if @rate_limiter_available
-          configure_mcp_rate_limiting
-        else
-          Otto.logger.warn '[MCP] rack-attack not available - rate limiting disabled'
-        end
+        configure_mcp_rate_limiting
       end
 
       private

--- a/lib/otto/mcp/rate_limiting.rb
+++ b/lib/otto/mcp/rate_limiting.rb
@@ -14,10 +14,18 @@ class Otto
         # Start with base configuration from general rate limiting
         super
 
-        # Add MCP-specific rules
+        # Add MCP-specific rules. JSON-RPC responses and [MCP] logging come from
+        # the throttled_response / log_throttled_request overrides below, which
+        # the base configuration already wires into Rack::Attack.
         configure_mcp_rules(config)
-        configure_mcp_responses
-        configure_mcp_logging
+      end
+
+      def self.mcp_endpoint(env)
+        env['otto.mcp_http_endpoint'] || '/_mcp'
+      end
+
+      def self.mcp_request?(request)
+        request.path.start_with?(mcp_endpoint(request.env))
       end
 
       def self.configure_mcp_rules(config)
@@ -25,16 +33,14 @@ class Otto
         mcp_requests_limit = config[:mcp_requests_per_minute] || 60
 
         Rack::Attack.throttle('mcp_requests', limit: mcp_requests_limit, period: 60) do |request|
-          endpoint = request.env['otto.mcp_http_endpoint'] || '/_mcp'
-          request.ip if request.path.start_with?(endpoint)
+          request.ip if mcp_request?(request)
         end
 
         # Tool calls are more expensive - 20 per minute by default
         tool_calls_limit = config[:tool_calls_per_minute] || 20
 
         Rack::Attack.throttle('mcp_tool_calls', limit: tool_calls_limit, period: 60) do |request|
-          endpoint = request.env['otto.mcp_http_endpoint'] || '/_mcp'
-          if request.path.start_with?(endpoint) && request.post?
+          if mcp_request?(request) && request.post?
             begin
               body = request.body.read
               data = JSON.parse(body)
@@ -48,76 +54,38 @@ class Otto
         end
       end
 
-      def self.configure_mcp_responses
-        # Override throttled responder to provide JSON-RPC formatted responses for MCP requests
-        Rack::Attack.throttled_responder = lambda do |request|
-          match_data = request.env['rack.attack.match_data']
-          now        = match_data[:epoch_time]
+      # JSON-RPC formatted 429 for MCP requests; the general Otto response
+      # (route response_type, then Accept header) for everything else.
+      def self.throttled_response(request)
+        return super unless mcp_request?(request)
 
-          headers = {
-            'content-type' => 'application/json',
-            'retry-after' => (match_data[:period] - (now % match_data[:period])).to_s,
-          }
+        match_data = request.env['rack.attack.match_data']
+        headers    = throttle_headers(match_data)
 
-          # Check if this is an MCP request
-          endpoint = request.env['otto.mcp_http_endpoint'] || '/_mcp'
-          if request.path.start_with?(endpoint)
-            # JSON-RPC error response for MCP
-            error_response = {
-              jsonrpc: '2.0',
-              id: nil,
-              error: {
-                code: -32_000,
-                message: 'Rate limit exceeded',
-                data: {
-                  retry_after: headers['retry-after'].to_i,
-                  limit: match_data[:limit],
-                  period: match_data[:period],
-                },
-              },
-            }
-            [429, headers, [JSON.generate(error_response)]]
-          else
-            # Use the general rate limiting response for non-MCP requests
-            # Route's response_type takes precedence over Accept header
-            route_def = request.env['otto.route_definition']
-            wants_json = (route_def&.response_type == 'json') ||
-                         request.env['HTTP_ACCEPT'].to_s.include?('application/json')
-
-            if wants_json
-              error_response = {
-                error: 'Rate limit exceeded',
-                message: 'Too many requests',
-                retry_after: headers['retry-after'].to_i,
-                limit: match_data[:limit],
-                period: match_data[:period],
-              }
-              [429, headers, [JSON.generate(error_response)]]
-            else
-              body                    = "Rate limit exceeded. Retry after #{headers['retry-after']} seconds."
-              headers['content-type'] = 'text/plain'
-              [429, headers, [body]]
-            end
-          end
-        end
+        error_response = {
+          jsonrpc: '2.0',
+          id: nil,
+          error: {
+            code: -32_000,
+            message: 'Rate limit exceeded',
+            data: {
+              retry_after: headers['retry-after'].to_i,
+              limit: match_data[:limit],
+              period: match_data[:period],
+            },
+          },
+        }
+        [429, headers, [JSON.generate(error_response)]]
       end
 
-      def self.configure_mcp_logging
-        return unless defined?(ActiveSupport::Notifications)
+      # Masked address only — see the note on the base implementation in
+      # Otto::Security::RateLimiting (issue #219).
+      def self.log_throttled_request(payload)
+        req = payload[:request]
+        return super unless mcp_request?(req)
 
-        # Masked address only — see the note on the sibling subscriber in
-        # Otto::Security::RateLimiting.configure_rack_attack! (issue #219).
-        ActiveSupport::Notifications.subscribe('rack.attack') do |_name, _start, _finish, _request_id, payload|
-          req      = payload[:request]
-          endpoint = req.env['otto.mcp_http_endpoint'] || '/_mcp'
-          ip       = Otto::LoggingHelpers.privacy_safe_ip(req.env, req.ip)
-
-          if req.path.start_with?(endpoint)
-            Otto.logger.warn "[MCP] Rate limit #{payload[:match_type]} for #{ip}: #{payload[:matched]}"
-          else
-            Otto.logger.warn "[Otto] Rate limit #{payload[:match_type]} for #{ip}: #{payload[:matched]}"
-          end
-        end
+        ip = Otto::LoggingHelpers.privacy_safe_ip(req.env, req.ip)
+        Otto.logger.warn "[MCP] Rate limit #{payload[:match_type]} for #{ip}: #{payload[:matched]}"
       end
     end
 

--- a/lib/otto/mcp/schema_validation.rb
+++ b/lib/otto/mcp/schema_validation.rb
@@ -4,11 +4,7 @@
 
 require 'json'
 
-begin
-  require 'json_schemer'
-rescue LoadError
-  # json_schemer is optional - graceful fallback
-end
+require_relative '../optional_dependency'
 
 class Otto
   module MCP
@@ -16,14 +12,24 @@ class Otto
 
     # JSON Schema validator for MCP protocol requests
     class Validator
+      JSON_SCHEMER_REQUIREMENT = '~> 2.0'
+
+      def self.ensure_available!
+        Otto::OptionalDependency.require!(
+          'json_schemer',
+          JSON_SCHEMER_REQUIREMENT,
+          require_path: 'json_schemer',
+          feature: 'MCP JSON Schema validation',
+          alternative: 'Or pass `enable_validation: false` when enabling MCP.'
+        )
+      end
+
       def initialize
-        @schemas                = {}
-        @json_schemer_available = defined?(JSONSchemer)
+        self.class.ensure_available!
+        @schemas = {}
       end
 
       def validate_request(data)
-        return true unless @json_schemer_available
-
         schema            = mcp_request_schema
         validation_errors = schema.validate(data).to_a
 
@@ -36,7 +42,7 @@ class Otto
       end
 
       def validate_tool_arguments(tool_name, arguments, schema)
-        return true unless @json_schemer_available && schema
+        return true unless schema
 
         schemer           = JSONSchemer.schema(schema)
         validation_errors = schemer.validate(arguments).to_a

--- a/lib/otto/mcp/server.rb
+++ b/lib/otto/mcp/server.rb
@@ -23,11 +23,17 @@ class Otto
       end
 
       def enable!(options = {})
+        enable_validation = options.fetch(:enable_validation, true) != false
+        enable_rate_limiting = options.fetch(:enable_rate_limiting, true) != false
+
+        Validator.ensure_available! if enable_validation
+        Otto::Security::RateLimiting.ensure_available! if enable_rate_limiting
+
         @enabled              = true
         @http_endpoint        = options.fetch(:http_endpoint, '/_mcp')
         @auth_tokens          = options[:auth_tokens] || []
-        @enable_validation    = options.fetch(:enable_validation, true)
-        @enable_rate_limiting = options.fetch(:enable_rate_limiting, true)
+        @enable_validation    = enable_validation
+        @enable_rate_limiting = enable_rate_limiting
 
         # Configure middleware
         configure_middleware(options)

--- a/lib/otto/optional_dependency.rb
+++ b/lib/otto/optional_dependency.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rubygems'
+
+class Otto
+  # Raised when an explicitly enabled feature cannot load its optional gem.
+  class OptionalDependencyError < ArgumentError; end
+
+  # Loads optional gems against the compatibility ranges Otto supports.
+  module OptionalDependency
+    module_function
+
+    def require!(gem_name, requirement, require_path:, feature:, alternative: nil)
+      version_requirement = Gem::Requirement.new(requirement)
+      guidance = "Add `gem '#{gem_name}', '#{requirement}'` to your Gemfile."
+      guidance = "#{guidance} #{alternative}" if alternative
+      installed_specs = Gem::Specification.find_all_by_name(gem_name)
+      active_spec = Gem.loaded_specs[gem_name]
+      compatible_spec = if active_spec && version_requirement.satisfied_by?(active_spec.version)
+                          active_spec
+                        else
+                          installed_specs
+                            .select { |spec| version_requirement.satisfied_by?(spec.version) }
+                            .max_by(&:version)
+                        end
+
+      unless compatible_spec
+        installed = installed_specs.map(&:version).sort.join(', ')
+        reason = installed.empty? ? 'it is not installed' : "installed version(s) #{installed} are incompatible"
+        raise OptionalDependencyError,
+              "#{feature} requires optional dependency '#{gem_name}' (#{version_requirement}), but #{reason}. #{guidance}"
+      end
+
+      load_error = begin
+        compatible_spec.activate
+        require require_path
+        nil
+      # Convert loader failures into a feature-specific configuration error.
+      # rubocop:disable-next Lint/ShadowedException
+      rescue Gem::LoadError, LoadError => e
+        e
+      end
+
+      raise_load_error!(feature, gem_name, version_requirement, guidance, load_error) if load_error
+
+      compatible_spec
+    end
+
+    def raise_load_error!(feature, gem_name, requirement, guidance, error)
+      raise OptionalDependencyError,
+            "#{feature} requires optional dependency '#{gem_name}' (#{requirement}), but it could not be " \
+            "loaded: #{error.message}. #{guidance}",
+            cause: error
+    end
+  end
+end

--- a/lib/otto/optional_dependency.rb
+++ b/lib/otto/optional_dependency.rb
@@ -36,8 +36,9 @@ class Otto
         require require_path
         nil
       # Convert loader failures into a feature-specific configuration error.
-      # rubocop:disable-next Lint/ShadowedException
-      rescue Gem::LoadError, LoadError => e
+      # Gem::LoadError (activation conflicts) is a LoadError subclass, so one
+      # rescue covers both activation and require failures.
+      rescue LoadError => e
         e
       end
 

--- a/lib/otto/privacy/config.rb
+++ b/lib/otto/privacy/config.rb
@@ -9,6 +9,7 @@ require 'digest'
 require 'concurrent'
 
 require_relative '../core/freezable'
+require_relative '../optional_dependency'
 
 class Otto
   module Privacy
@@ -30,6 +31,8 @@ class Otto
     # modules would hide the symmetry that makes them reviewable.
     class Config
       include Otto::Core::Freezable
+
+      MAXMIND_DB_REQUIREMENT = '~> 1.2'
 
       # Named privacy profiles: validated presets over the individual knobs,
       # so a deployment's observability posture is declared in one reviewable
@@ -540,14 +543,13 @@ class Otto
       def build_maxmind_reader(path, option_name: 'geo_db_path')
         raise ArgumentError, "#{option_name} is not readable: #{path.inspect}" unless File.readable?(path)
 
-        begin
-          require 'maxmind/db'
-        rescue LoadError
-          raise ArgumentError,
-                "#{option_name} is set (#{path.inspect}) but the 'maxmind-db' gem is not available. " \
-                "Add `gem 'maxmind-db'` to your Gemfile, or inject your own reader via " \
-                "configure_ip_privacy(#{option_name.sub('_path', '_reader')}: ...)."
-        end
+        Otto::OptionalDependency.require!(
+          'maxmind-db',
+          MAXMIND_DB_REQUIREMENT,
+          require_path: 'maxmind/db',
+          feature: "#{option_name} database loading",
+          alternative: "Or inject a reader with `#{option_name.sub('_path', '_reader')}:`."
+        )
 
         begin
           MaxMind::DB.new(path, mode: MaxMind::DB::MODE_MEMORY)

--- a/lib/otto/security/configurator.rb
+++ b/lib/otto/security/configurator.rb
@@ -117,6 +117,7 @@ class Otto
       def enable_rate_limiting!(options = {})
         return if middleware_enabled?(Otto::Security::Middleware::RateLimitMiddleware)
 
+        Otto::Security::RateLimiting.ensure_available!
         configure_rate_limiting(options)
         @middleware_stack.add(Otto::Security::Middleware::RateLimitMiddleware)
       end

--- a/lib/otto/security/core.rb
+++ b/lib/otto/security/core.rb
@@ -46,6 +46,7 @@ class Otto
         ensure_not_frozen!
         return if @middleware.includes?(Otto::Security::Middleware::RateLimitMiddleware)
 
+        Otto::Security::RateLimiting.ensure_available!
         @security.configure_rate_limiting(options)
         use Otto::Security::Middleware::RateLimitMiddleware
       end

--- a/lib/otto/security/middleware/rate_limit_middleware.rb
+++ b/lib/otto/security/middleware/rate_limit_middleware.rb
@@ -27,13 +27,8 @@ class Otto
         def initialize(app, security_config = nil)
           @app = app
           @security_config = security_config
-          @rate_limiter_available = defined?(Rack::Attack)
 
-          if @rate_limiter_available
-            configure_rate_limiting
-          else
-            Otto.logger.warn '[Otto] rack-attack not available - rate limiting disabled'
-          end
+          configure_rate_limiting
         end
 
         # Pass-through call - actual rate limiting handled by Rack::Attack

--- a/lib/otto/security/rate_limiter.rb
+++ b/lib/otto/security/rate_limiter.rb
@@ -52,51 +52,75 @@ class Otto
           end
         end
 
-        # Custom response for rate limited requests
-        Rack::Attack.throttled_responder = lambda do |request|
-          match_data = request.env['rack.attack.match_data']
-          now = match_data[:epoch_time]
+        configure_responses
+        configure_logging
+      end
 
-          headers = {
-            'content-type' => 'application/json',
-            'retry-after' => (match_data[:period] - (now % match_data[:period])).to_s,
-          }
+      # Rack::Attack holds a single throttled_responder and each subscriber to
+      # 'rack.attack' fires on every throttle event. Subclasses override
+      # throttled_response and log_throttled_request instead of registering
+      # their own responder or subscriber after super, so the hosting app never
+      # gets a redundant responder assignment or doubled log lines.
+      def self.configure_responses
+        Rack::Attack.throttled_responder = ->(request) { throttled_response(request) }
+      end
 
-          # Content negotiation for rate limit response
-          # Route's response_type takes precedence over Accept header
-          route_def = request.env['otto.route_definition']
-          wants_json = (route_def&.response_type == 'json') ||
-                       request.env['HTTP_ACCEPT'].to_s.include?('application/json')
-
-          if wants_json
-            error_response = {
-              error: 'Rate limit exceeded',
-              message: 'Too many requests',
-              retry_after: headers['retry-after'].to_i,
-              limit: match_data[:limit],
-              period: match_data[:period],
-            }
-            [429, headers, [JSON.generate(error_response)]]
-          else
-            body = "Rate limit exceeded. Retry after #{headers['retry-after']} seconds."
-            headers['content-type'] = 'text/plain'
-            [429, headers, [body]]
-          end
-        end
-
+      def self.configure_logging
         # Log blocked requests if ActiveSupport is available
         return unless defined?(ActiveSupport::Notifications)
 
-        # Rack::Attack is mounted by the hosting app AHEAD of Otto, so this
-        # subscriber sees the raw peer regardless of where IPPrivacyMiddleware
-        # sits in Otto's own stack. Log a masked address, never req.ip: a
-        # deployment on the default :masked profile must not write raw client
-        # IPs to its logs every time a limit trips (issue #219).
         ActiveSupport::Notifications.subscribe('rack.attack') do |_name, _start, _finish, _request_id, payload|
-          req = payload[:request]
-          ip  = Otto::LoggingHelpers.privacy_safe_ip(req.env, req.ip)
-          Otto.logger.warn "[Otto] Rate limit #{payload[:match_type]} for #{ip}: #{payload[:matched]}"
+          log_throttled_request(payload)
         end
+      end
+
+      def self.throttled_response(request)
+        match_data = request.env['rack.attack.match_data']
+        general_throttled_response(request, throttle_headers(match_data), match_data)
+      end
+
+      def self.throttle_headers(match_data)
+        now = match_data[:epoch_time]
+
+        {
+          'content-type' => 'application/json',
+          'retry-after' => (match_data[:period] - (now % match_data[:period])).to_s,
+        }
+      end
+
+      # Custom response for rate limited requests
+      def self.general_throttled_response(request, headers, match_data)
+        # Content negotiation for rate limit response
+        # Route's response_type takes precedence over Accept header
+        route_def = request.env['otto.route_definition']
+        wants_json = (route_def&.response_type == 'json') ||
+                     request.env['HTTP_ACCEPT'].to_s.include?('application/json')
+
+        if wants_json
+          error_response = {
+            error: 'Rate limit exceeded',
+            message: 'Too many requests',
+            retry_after: headers['retry-after'].to_i,
+            limit: match_data[:limit],
+            period: match_data[:period],
+          }
+          [429, headers, [JSON.generate(error_response)]]
+        else
+          body = "Rate limit exceeded. Retry after #{headers['retry-after']} seconds."
+          headers['content-type'] = 'text/plain'
+          [429, headers, [body]]
+        end
+      end
+
+      # Rack::Attack is mounted by the hosting app AHEAD of Otto, so this
+      # subscriber sees the raw peer regardless of where IPPrivacyMiddleware
+      # sits in Otto's own stack. Log a masked address, never req.ip: a
+      # deployment on the default :masked profile must not write raw client
+      # IPs to its logs every time a limit trips (issue #219).
+      def self.log_throttled_request(payload)
+        req = payload[:request]
+        ip  = Otto::LoggingHelpers.privacy_safe_ip(req.env, req.ip)
+        Otto.logger.warn "[Otto] Rate limit #{payload[:match_type]} for #{ip}: #{payload[:matched]}"
       end
     end
   end

--- a/lib/otto/security/rate_limiter.rb
+++ b/lib/otto/security/rate_limiter.rb
@@ -4,18 +4,25 @@
 
 require 'json'
 
-begin
-  require 'rack/attack'
-rescue LoadError
-  # rack-attack is optional - graceful fallback
-end
+require_relative '../optional_dependency'
 
 class Otto
   module Security
     # Rate limiting implementation using Rack::Attack
     class RateLimiting
+      RACK_ATTACK_REQUIREMENT = '~> 6.7'
+
+      def self.ensure_available!
+        Otto::OptionalDependency.require!(
+          'rack-attack',
+          RACK_ATTACK_REQUIREMENT,
+          require_path: 'rack/attack',
+          feature: 'Rate limiting'
+        )
+      end
+
       def self.configure_rack_attack!(config = {})
-        return unless defined?(Rack::Attack)
+        ensure_available!
 
         # Use provided cache store or default
         Rack::Attack.cache.store = config[:cache_store] if config[:cache_store]

--- a/otto.gemspec
+++ b/otto.gemspec
@@ -34,8 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'logger', '~> 1', '< 2.0'
 
   spec.add_dependency 'rack', '~> 3.1', '< 4.0'
-  spec.add_dependency 'rack-parser', '~> 0.7'
-  spec.add_dependency 'rexml', '~> 3.4'
 
   # Security dependencies
   spec.add_dependency 'loofah', '~> 2.20'

--- a/spec/otto/configuration_methods_spec.rb
+++ b/spec/otto/configuration_methods_spec.rb
@@ -351,6 +351,21 @@ RSpec.describe Otto, 'Configuration Methods' do
         mcp_endpoint: '/custom-mcp',
                })
     end
+
+    it 'forwards explicitly disabled optional security features' do
+      server_double = instance_double(Otto::MCP::Server)
+      allow(Otto::MCP::Server).to receive(:new).and_return(server_double)
+      expect(server_double).to receive(:enable!).with({
+                                                        enable_validation: false,
+                                                        enable_rate_limiting: false,
+                                                      })
+
+      app.send(:configure_mcp, {
+                 mcp_enabled: true,
+        enable_validation: false,
+        enable_rate_limiting: false,
+               })
+    end
   end
 
   describe '#middleware_enabled?' do

--- a/spec/otto/geo_resolver_config_spec.rb
+++ b/spec/otto/geo_resolver_config_spec.rb
@@ -89,6 +89,16 @@ RSpec.describe 'Configurable geo resolution' do
         expect { described_class.new(geo_enabled: false, geo_db_path: '/no/such/geo.mmdb') }
           .not_to raise_error
       end
+
+      it 'reports a missing or incompatible maxmind-db gem at configuration time' do
+        error = Otto::OptionalDependencyError.new(
+          "geo_db_path database loading requires optional dependency 'maxmind-db' (~> 1.2)"
+        )
+        allow(Otto::OptionalDependency).to receive(:require!).and_raise(error)
+
+        expect { described_class.new(geo_db_path: __FILE__) }
+          .to raise_error(Otto::OptionalDependencyError, /maxmind-db.*~> 1\.2/)
+      end
     end
 
     describe '.canonicalize_geo_header' do

--- a/spec/otto/mcp/rate_limiting_spec.rb
+++ b/spec/otto/mcp/rate_limiting_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe Otto::MCP, 'rate limiting features' do
         end
       end
 
-      # Configure MCP rate limiting (which overrides throttled_responder)
+      # Configure MCP rate limiting (which overrides throttled_response)
       Otto::MCP::RateLimiter.configure_rack_attack!({})
     end
 

--- a/spec/otto/mcp/rate_limiting_spec.rb
+++ b/spec/otto/mcp/rate_limiting_spec.rb
@@ -6,7 +6,9 @@ require 'spec_helper'
 
 RSpec.describe Otto::MCP, 'rate limiting features' do
   before do
-    skip 'rack-attack not available' unless defined?(Rack::Attack)
+    Otto::Security::RateLimiting.ensure_available!
+  rescue Otto::OptionalDependencyError => e
+    skip e.message
   end
 
   describe 'Otto::MCP::RateLimiter' do
@@ -89,15 +91,12 @@ RSpec.describe Otto::MCP, 'rate limiting features' do
       expect(Rack::Attack.throttles).to have_key('mcp_tool_calls')
     end
 
-    it 'logs MCP-specific warning when rack-attack not available' do
-      # Hide Rack::Attack temporarily
-      rack_attack = Object.send(:remove_const, :Rack) if defined?(Rack::Attack)
+    it 'raises a clear error when rack-attack is not available' do
+      error = Otto::OptionalDependencyError.new('Rate limiting requires rack-attack ~> 6.7')
+      allow(Otto::Security::RateLimiting).to receive(:ensure_available!).and_raise(error)
 
-      expect(Otto.logger).to receive(:warn).with(match(/\[MCP\].*rack-attack not available/))
-      Otto::MCP::RateLimitMiddleware.new(app, security_config)
-
-      # Restore Rack::Attack
-      Object.const_set(:Rack, rack_attack) if rack_attack
+      expect { Otto::MCP::RateLimitMiddleware.new(app, security_config) }
+        .to raise_error(Otto::OptionalDependencyError, /rack-attack.*~> 6\.7/)
     end
   end
 

--- a/spec/otto/mcp_schema_validation_spec.rb
+++ b/spec/otto/mcp_schema_validation_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Otto::MCP do
+  describe Otto::MCP::Validator do
+    describe '#validate_request' do
+      it 'rejects requests that do not match the MCP JSON-RPC schema' do
+        validator = described_class.new
+
+        expect { validator.validate_request('method' => 'initialize') }
+          .to raise_error(Otto::MCP::ValidationError, /Invalid MCP request/)
+      end
+
+      it 'does not initialize when JSON Schema validation is unavailable' do
+        error = Otto::OptionalDependencyError.new(
+          "MCP JSON Schema validation requires optional dependency 'json_schemer' (~> 2.0)"
+        )
+        allow(Otto::OptionalDependency).to receive(:require!).and_raise(error)
+
+        expect { described_class.new }
+          .to raise_error(Otto::OptionalDependencyError, /json_schemer.*~> 2\.0/)
+      end
+    end
+  end
+
+  describe Otto::MCP::Server do
+    subject(:server) { described_class.new(create_minimal_otto) }
+
+    describe '#enable!' do
+      it 'fails before enabling when schema validation is unavailable' do
+        error = Otto::OptionalDependencyError.new('json_schemer is unavailable')
+        allow(Otto::MCP::Validator).to receive(:ensure_available!).and_raise(error)
+
+        expect { server.enable!(enable_rate_limiting: false) }
+          .to raise_error(Otto::OptionalDependencyError, /json_schemer is unavailable/)
+        expect(server).not_to be_enabled
+      end
+
+      it 'fails before enabling when rate limiting is unavailable' do
+        error = Otto::OptionalDependencyError.new('rack-attack is unavailable')
+        allow(Otto::MCP::Validator).to receive(:ensure_available!).and_return(true)
+        allow(Otto::Security::RateLimiting).to receive(:ensure_available!).and_raise(error)
+
+        expect { server.enable! }
+          .to raise_error(Otto::OptionalDependencyError, /rack-attack is unavailable/)
+        expect(server).not_to be_enabled
+      end
+
+      it 'does not require optional security gems when both features are disabled' do
+        allow(Otto::MCP::Validator).to receive(:ensure_available!)
+        allow(Otto::Security::RateLimiting).to receive(:ensure_available!)
+
+        server.enable!(enable_validation: false, enable_rate_limiting: false)
+
+        expect(server).to be_enabled
+        expect(Otto::MCP::Validator).not_to have_received(:ensure_available!)
+        expect(Otto::Security::RateLimiting).not_to have_received(:ensure_available!)
+      end
+
+      it 'requires optional security gems unless the features are explicitly false' do
+        allow(Otto::MCP::Validator).to receive(:ensure_available!).and_call_original
+        allow(Otto::Security::RateLimiting).to receive(:ensure_available!).and_call_original
+
+        server.enable!(enable_validation: nil, enable_rate_limiting: nil)
+
+        expect(Otto::MCP::Validator).to have_received(:ensure_available!).at_least(:once)
+        expect(Otto::Security::RateLimiting).to have_received(:ensure_available!).at_least(:once)
+      end
+    end
+  end
+end

--- a/spec/otto/optional_dependency_spec.rb
+++ b/spec/otto/optional_dependency_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Otto::OptionalDependency do
+  describe '.require!' do
+    it 'reports a missing optional dependency with the feature and install requirement' do
+      allow(Gem::Specification).to receive(:find_all_by_name).with('example-gem').and_return([])
+
+      expect do
+        described_class.require!(
+          'example-gem',
+          '~> 2.0',
+          require_path: 'example/gem',
+          feature: 'Example validation'
+        )
+      end.to raise_error(Otto::OptionalDependencyError) { |error|
+        expect(error.message).to include("Example validation requires optional dependency 'example-gem' (~> 2.0)")
+        expect(error.message).to include('it is not installed')
+        expect(error.message).to include("gem 'example-gem', '~> 2.0'")
+      }
+    end
+
+    it 'reports installed versions outside the supported range' do
+      old_spec = instance_double(Gem::Specification, version: Gem::Version.new('1.9.0'))
+      allow(Gem::Specification).to receive(:find_all_by_name).with('example-gem').and_return([old_spec])
+
+      expect do
+        described_class.require!(
+          'example-gem',
+          '~> 2.0',
+          require_path: 'example/gem',
+          feature: 'Example validation'
+        )
+      end.to raise_error(Otto::OptionalDependencyError) { |error|
+        expect(error.message).to include('installed version(s) 1.9.0 are incompatible')
+      }
+    end
+
+    it 'uses an already-active compatible version instead of activating a newer installed version' do
+      active_spec = instance_double(Gem::Specification, version: Gem::Version.new('2.0.0'))
+      newer_spec = instance_double(Gem::Specification, version: Gem::Version.new('2.1.0'))
+      allow(Gem::Specification).to receive(:find_all_by_name)
+        .with('example-gem')
+        .and_return([active_spec, newer_spec])
+      allow(Gem).to receive(:loaded_specs).and_return('example-gem' => active_spec)
+      allow(described_class).to receive(:require).with('example/gem').and_return(true)
+      allow(active_spec).to receive(:activate)
+
+      result = described_class.require!(
+        'example-gem',
+        '~> 2.0',
+        require_path: 'example/gem',
+        feature: 'Example validation'
+      )
+
+      expect(result).to eq(active_spec)
+      expect(active_spec).to have_received(:activate)
+    end
+  end
+end

--- a/spec/otto/optional_dependency_spec.rb
+++ b/spec/otto/optional_dependency_spec.rb
@@ -57,5 +57,50 @@ RSpec.describe Otto::OptionalDependency do
       expect(result).to eq(active_spec)
       expect(active_spec).to have_received(:activate)
     end
+
+    it 'reports a require failure after a compatible version activates' do
+      spec = instance_double(Gem::Specification, version: Gem::Version.new('2.0.0'))
+      allow(Gem::Specification).to receive(:find_all_by_name).with('example-gem').and_return([spec])
+      allow(Gem).to receive(:loaded_specs).and_return({})
+      allow(spec).to receive(:activate)
+      allow(described_class).to receive(:require)
+        .with('example/gem')
+        .and_raise(LoadError, 'cannot load such file -- example/gem')
+
+      expect do
+        described_class.require!(
+          'example-gem',
+          '~> 2.0',
+          require_path: 'example/gem',
+          feature: 'Example validation'
+        )
+      end.to raise_error(Otto::OptionalDependencyError) { |error|
+        expect(error.message).to include("Example validation requires optional dependency 'example-gem' (~> 2.0)")
+        expect(error.message).to include('could not be loaded: cannot load such file -- example/gem')
+        expect(error.message).to include("gem 'example-gem', '~> 2.0'")
+        expect(error.cause).to be_a(LoadError)
+      }
+    end
+
+    it 'reports an activation conflict as a load failure' do
+      spec = instance_double(Gem::Specification, version: Gem::Version.new('2.0.0'))
+      allow(Gem::Specification).to receive(:find_all_by_name).with('example-gem').and_return([spec])
+      allow(Gem).to receive(:loaded_specs).and_return({})
+      allow(spec).to receive(:activate).and_raise(Gem::LoadError, 'conflicts with activated example-gem-1.0.0')
+      allow(described_class).to receive(:require)
+
+      expect do
+        described_class.require!(
+          'example-gem',
+          '~> 2.0',
+          require_path: 'example/gem',
+          feature: 'Example validation'
+        )
+      end.to raise_error(Otto::OptionalDependencyError) { |error|
+        expect(error.message).to include('could not be loaded: conflicts with activated example-gem-1.0.0')
+        expect(error.cause).to be_a(Gem::LoadError)
+      }
+      expect(described_class).not_to have_received(:require)
+    end
   end
 end

--- a/spec/otto/rate_limiting_spec.rb
+++ b/spec/otto/rate_limiting_spec.rb
@@ -301,10 +301,17 @@ RSpec.describe Otto, 'rate limiting features' do
   describe 'blocked-request logging' do
     let(:notifications) do
       Class.new do
-        attr_reader :subscriptions
+        attr_reader :subscriptions, :subscribe_calls
 
-        def initialize = (@subscriptions = {})
-        def subscribe(name, &block) = (@subscriptions[name] = block)
+        def initialize
+          @subscriptions   = {}
+          @subscribe_calls = 0
+        end
+
+        def subscribe(name, &block)
+          @subscribe_calls += 1
+          @subscriptions[name] = block
+        end
 
         def publish(name, payload)
           @subscriptions.fetch(name).call(name, nil, nil, nil, payload)
@@ -346,7 +353,7 @@ RSpec.describe Otto, 'rate limiting features' do
     end
 
     it 'masks the IP on the MCP subscriber too' do
-      Otto::MCP::RateLimiter.configure_mcp_logging
+      Otto::MCP::RateLimiter.configure_logging
 
       publish_throttle('REMOTE_ADDR' => '198.51.100.42', 'PATH_INFO' => '/_mcp')
 
@@ -356,12 +363,25 @@ RSpec.describe Otto, 'rate limiting features' do
     end
 
     it 'masks the IP on the MCP subscriber for non-MCP paths' do
-      Otto::MCP::RateLimiter.configure_mcp_logging
+      Otto::MCP::RateLimiter.configure_logging
 
       publish_throttle('REMOTE_ADDR' => '198.51.100.42', 'PATH_INFO' => '/other')
 
       expect(logged.last).to start_with('[Otto]')
       expect(logged.last).not_to include('198.51.100.42')
+    end
+
+    # MCP configuration runs the base configuration via super. It must not add
+    # a second 'rack.attack' subscriber on top of the base one, or every
+    # throttle event is logged twice.
+    it 'registers a single subscriber when MCP rate limiting is configured' do
+      Otto::MCP::RateLimiter.configure_rack_attack!({})
+
+      publish_throttle('REMOTE_ADDR' => '198.51.100.42', 'PATH_INFO' => '/_mcp')
+
+      expect(notifications.subscribe_calls).to eq(1)
+      expect(logged.size).to eq(1)
+      expect(logged.last).to start_with('[MCP]')
     end
   end
 end

--- a/spec/otto/rate_limiting_spec.rb
+++ b/spec/otto/rate_limiting_spec.rb
@@ -8,8 +8,9 @@ RSpec.describe Otto, 'rate limiting features' do
   subject(:otto) { create_minimal_otto }
 
   before do
-    # Skip rate limiting tests if rack-attack is not available
-    skip 'rack-attack not available' unless defined?(Rack::Attack)
+    Otto::Security::RateLimiting.ensure_available!
+  rescue Otto::OptionalDependencyError => e
+    skip e.message
   end
 
   describe '#enable_rate_limiting!' do
@@ -18,6 +19,16 @@ RSpec.describe Otto, 'rate limiting features' do
 
       expect(otto.middleware.includes?(Otto::Security::RateLimitMiddleware)).to be true
       expect(otto.security_config.rate_limiting_config).to be_a(Hash)
+    end
+
+    it 'fails before changing configuration when rack-attack is unavailable' do
+      error = Otto::OptionalDependencyError.new('Rate limiting requires rack-attack ~> 6.7')
+      allow(Otto::Security::RateLimiting).to receive(:ensure_available!).and_raise(error)
+
+      expect { otto.enable_rate_limiting!(requests_per_minute: 50) }
+        .to raise_error(Otto::OptionalDependencyError, /rack-attack.*~> 6\.7/)
+      expect(otto.middleware.includes?(Otto::Security::RateLimitMiddleware)).to be false
+      expect(otto.security_config.rate_limiting_config[:requests_per_minute]).not_to eq(50)
     end
 
     it 'accepts custom rate limiting options' do
@@ -139,14 +150,12 @@ RSpec.describe Otto, 'rate limiting features' do
         expect(Rack::Attack.throttles).to have_key('heavy_api')
       end
 
-      it 'skips configuration when rack-attack is not available' do
-        # Temporarily hide Rack::Attack
-        rack_attack = Object.send(:remove_const, :Rack) if defined?(Rack::Attack)
+      it 'raises a clear error when rack-attack is not available' do
+        error = Otto::OptionalDependencyError.new('Rate limiting requires rack-attack ~> 6.7')
+        allow(Otto::Security::RateLimiting).to receive(:ensure_available!).and_raise(error)
 
-        expect { Otto::Security::RateLimiting.configure_rack_attack!({}) }.not_to raise_error
-
-        # Restore Rack::Attack
-        Object.const_set(:Rack, rack_attack) if rack_attack
+        expect { Otto::Security::RateLimiting.configure_rack_attack!({}) }
+          .to raise_error(Otto::OptionalDependencyError, /rack-attack.*~> 6\.7/)
       end
     end
   end
@@ -160,15 +169,12 @@ RSpec.describe Otto, 'rate limiting features' do
       expect { middleware }.not_to raise_error
     end
 
-    it 'logs warning when rack-attack is not available' do
-      # Hide Rack::Attack temporarily
-      rack_attack = Object.send(:remove_const, :Rack) if defined?(Rack::Attack)
+    it 'raises a clear error when rack-attack is not available' do
+      error = Otto::OptionalDependencyError.new('Rate limiting requires rack-attack ~> 6.7')
+      allow(Otto::Security::RateLimiting).to receive(:ensure_available!).and_raise(error)
 
-      expect(Otto.logger).to receive(:warn).with(match(/rack-attack not available/))
-      Otto::Security::RateLimitMiddleware.new(app, security_config)
-
-      # Restore Rack::Attack
-      Object.const_set(:Rack, rack_attack) if rack_attack
+      expect { Otto::Security::RateLimitMiddleware.new(app, security_config) }
+        .to raise_error(Otto::OptionalDependencyError, /rack-attack.*~> 6\.7/)
     end
 
     it 'calls through to app when rate limiting is available' do

--- a/spec/otto/utils_spec.rb
+++ b/spec/otto/utils_spec.rb
@@ -40,21 +40,29 @@ RSpec.describe Otto::Utils do
     end
 
     it "returns increasing values for successive calls" do
+      allow(Process).to receive(:clock_gettime)
+        .with(Process::CLOCK_MONOTONIC, :microsecond)
+        .and_return(1_000_000, 1_001_000)
+
       first_time = Otto::Utils.now_in_μs
-      sleep(0.001)
       second_time = Otto::Utils.now_in_μs
 
+      expect(first_time).to eq(1_000_000)
+      expect(second_time).to eq(1_001_000)
       expect(second_time).to be > first_time
     end
 
     it "can be used to measure duration accurately" do
+      allow(Process).to receive(:clock_gettime)
+        .with(Process::CLOCK_MONOTONIC, :microsecond)
+        .and_return(2_000_000, 2_010_000)
+
       start_time = Otto::Utils.now_in_μs
-      sleep(0.01)
       end_time = Otto::Utils.now_in_μs
 
       duration = end_time - start_time
 
-      expect(duration).to be_between(8_000, 15_000)
+      expect(duration).to eq(10_000)
     end
   end
 


### PR DESCRIPTION
## Summary
- Remove unused `rack-parser` and `rexml` runtime dependencies and keep the development lockfile graph explicit.
- Fail fast with actionable errors when enabled JSON Schema, rate-limiting, or MaxMind features lack a compatible optional gem; MCP protections now require an explicit `false` to disable.
- Replace scheduler-dependent timing assertions and document Ruby 3.2 EOL compatibility, dependency-range guarantees, and consumer lockfile auditing responsibilities.

## Review guide
- Start with `lib/otto/optional_dependency.rb` and the MCP/rate-limiting call sites to review activation behavior and fail-closed semantics.
- Review `docs/reference/runtime-and-dependency-security.md` for the distinction between API compatibility ranges and patched consumer resolutions.
- Optional dependency support is constrained to `json_schemer ~> 2.0`, `rack-attack ~> 6.7`, and `maxmind-db ~> 1.2`; injected MaxMind readers remain dependency-free.

## Validation
- `bundle exec rspec`: 2250 examples, 0 failures.
- RuboCop on 17 changed Ruby files: no offenses.
- `bundle check`, workflow YAML parsing, `git diff --check`, and project diagnostics passed.
- Confirmed the runtime dependency closure excludes `rack-parser` and `rexml`.

Closes #255