### PR TITLE
Add a resolver form to APIKeyStrategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ vendor
 .mcp.json
 .claude
 .serena
+.yardoc

--- a/changelog.d/20260904_132323_delano_256_api_key_strategy_fail_closed.rst
+++ b/changelog.d/20260904_132323_delano_256_api_key_strategy_fail_closed.rst
@@ -1,10 +1,9 @@
 Changed
 -------
 
-- ``api_keys:`` is now a required keyword on
-  ``Otto::Security::Authentication::Strategies::APIKeyStrategy``, and
-  ``APIKeyStrategy.new`` without keys raises ``ArgumentError``. To migrate, pass
-  the configured keys explicitly, e.g.
+- ``Otto::Security::Authentication::Strategies::APIKeyStrategy.new`` without a
+  key source raises ``ArgumentError``. To migrate, pass the configured keys
+  explicitly, e.g.
   ``APIKeyStrategy.new(api_keys: ENV.fetch('API_KEYS').split(','))``. (#256)
 
 - ``APIKeyStrategy`` no longer places the presented key in the authentication

--- a/changelog.d/20260904_150900_delano_api_key_strategy_resolver.rst
+++ b/changelog.d/20260904_150900_delano_api_key_strategy_resolver.rst
@@ -12,8 +12,14 @@ Added
   key as a non-empty ``String``; a ``nil`` or ``false`` return is the same
   terminal ``Invalid API key`` failure as a static mismatch, exceptions from
   the resolver propagate rather than becoming a 401 or a success, and the
-  result still carries ``api_key_fingerprint`` in its metadata while the raw
-  key never reaches the result, environment, session, or logs.
+  result still carries ``api_key_fingerprint`` in its metadata. The strategy
+  itself never places the raw key in the result; ``user`` is the resolver's
+  return value verbatim and is exposed to handlers through
+  ``env['otto.strategy_result']``, so the resolver must return the account
+  behind the key rather than an object that stores the key. A resolver that returns the presented key string itself
+  as the user raises ``ArgumentError``. Static ``api_keys:`` are copied and
+  frozen at construction, so mutating the caller's strings afterwards no
+  longer changes which credentials are accepted.
 
 - ``APIKeyStrategy.digest(key)`` returns the full SHA-256 hex digest of a key.
   The documented resolver pattern stores digests instead of raw keys and looks

--- a/changelog.d/20260904_150900_delano_api_key_strategy_resolver.rst
+++ b/changelog.d/20260904_150900_delano_api_key_strategy_resolver.rst
@@ -1,0 +1,21 @@
+Added
+-----
+
+- ``Otto::Security::Authentication::Strategies::APIKeyStrategy`` accepts a
+  resolver as an alternative to a static key list, so an application can look
+  a presented key up in a database, repository, or cache and return the
+  account behind it. Pass a block, ``APIKeyStrategy.new { |key| ... }``, or
+  any object that responds to ``#call`` as ``resolver:``, e.g.
+  ``APIKeyStrategy.new(resolver: repo.method(:find_by_key))``. Exactly one of
+  ``api_keys:``, ``resolver:``, or a block must be given; passing none or more
+  than one raises ``ArgumentError``. The resolver receives only the presented
+  key as a non-empty ``String``; a ``nil`` or ``false`` return is the same
+  terminal ``Invalid API key`` failure as a static mismatch, exceptions from
+  the resolver propagate rather than becoming a 401 or a success, and the
+  result still carries ``api_key_fingerprint`` in its metadata while the raw
+  key never reaches the result, environment, session, or logs.
+
+- ``APIKeyStrategy.digest(key)`` returns the full SHA-256 hex digest of a key.
+  The documented resolver pattern stores digests instead of raw keys and looks
+  up by ``APIKeyStrategy.digest(presented_key)``, which is constant-time by
+  construction and keeps raw credentials out of the database.

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -50,10 +50,12 @@ Otto::Security::Authentication::Strategies::APIKeyStrategy.new(
 )
 ```
 
-The authenticated result never carries the raw key. `metadata[:api_key_fingerprint]`
+The strategy never places the raw key in the result. `metadata[:api_key_fingerprint]`
 (and, for the static list, `user[:api_key_fingerprint]`) holds a truncated
 SHA-256 digest of the presented key, so audit logs can correlate requests
-without recording the credential.
+without recording the credential. With a resolver, `user` is whatever the
+resolver returns, so that guarantee covers only the strategy's own fields; see
+the rules below.
 
 ### Resolve keys from a database
 
@@ -98,9 +100,15 @@ The rules are the same in every form:
 - Exceptions from the resolver propagate. The strategy does not rescue them,
   so a database outage surfaces as an error rather than a silent 401, and can
   never become a success.
-- Whatever the resolver returns becomes `user` in the result, and
-  `api_key_fingerprint` is still set in the result metadata. The raw key never
-  reaches the result, the Rack environment, the session, or the logs.
+- Whatever the resolver returns becomes `user` in the result, verbatim, and
+  `api_key_fingerprint` is still set in the result metadata. The strategy
+  itself never places the raw key in the result, but the result is stored in
+  `env['otto.strategy_result']` and exposed to handlers, so anything the
+  application serializes or logs from it carries `user`. It is the resolver's
+  responsibility not to return an object that carries the raw key. Return the
+  account, not the `ApiKey` row that stores the key, and store digests. A
+  resolver that returns the presented key string itself as the user raises
+  `ArgumentError`.
 
 The strategy cannot make a black-box lookup constant-time. Store SHA-256
 digests rather than raw keys and look up by `APIKeyStrategy.digest(key)`, as

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -29,9 +29,10 @@ otto.add_auth_strategy(
 )
 ```
 
-`APIKeyStrategy` fails closed. Its constructor requires `api_keys:` and raises
-`ArgumentError` when the normalized key list is empty (`nil`, `[]`, or only
-blank strings), so the strategy enforces the check the example above makes
+`APIKeyStrategy` fails closed. Its constructor requires exactly one key source
+(`api_keys:`, `resolver:`, or a block; see below) and raises `ArgumentError`
+when none is given, or when an `api_keys:` list normalizes to empty (`[]` or
+only blank strings), so the strategy enforces the check the example above makes
 explicit. A request that presents a key is accepted only when that key matches a
 configured key under constant-time comparison; an empty credential is rejected.
 A presented-but-invalid key is a terminal failure, so it aborts the strategy
@@ -49,9 +50,95 @@ Otto::Security::Authentication::Strategies::APIKeyStrategy.new(
 )
 ```
 
-The authenticated result never carries the raw key. `user[:api_key_fingerprint]`
-holds a truncated SHA-256 digest of the presented key, so audit logs can
-correlate requests without recording the credential.
+The authenticated result never carries the raw key. `metadata[:api_key_fingerprint]`
+(and, for the static list, `user[:api_key_fingerprint]`) holds a truncated
+SHA-256 digest of the presented key, so audit logs can correlate requests
+without recording the credential.
+
+### Resolve keys from a database
+
+A static list is the simple default. When keys live in a database, a
+repository, or a cache, give the strategy a resolver instead. The resolver
+receives the presented key and returns the account behind it, or `nil` when
+there is none:
+
+```ruby
+APIKeyStrategy = Otto::Security::Authentication::Strategies::APIKeyStrategy
+
+otto.add_auth_strategy(
+  'api_key',
+  APIKeyStrategy.new do |presented_key|
+    ApiKey.find_by(digest: APIKeyStrategy.digest(presented_key))&.account
+  end
+)
+```
+
+Anything that responds to `#call` works as well, passed as `resolver:`:
+
+```ruby
+APIKeyStrategy.new(resolver: repo.method(:find_by_key))
+APIKeyStrategy.new(resolver: ->(key) { KeyCache.fetch(APIKeyStrategy.digest(key)) })
+```
+
+The rules are the same in every form:
+
+- Exactly one source: `api_keys:`, `resolver:`, or a block. Passing none, or
+  more than one, raises `ArgumentError`, as does a `resolver:` that does not
+  respond to `#call`.
+- The resolver receives only the presented key, as a non-empty `String`, and
+  nothing else. The blank check and the non-String rejection run before it, so
+  a missing header is still the non-terminal `No API key provided` failure and
+  the resolver is never asked about it.
+- A `nil` or `false` return is a terminal `Invalid API key` failure, identical
+  to a static mismatch. It aborts the strategy chain with a 401. Every other
+  return value is a match, including empty containers: a `where(...)` relation,
+  an empty Array from `select`, or `{}` from a cache miss is truthy and
+  authenticates every presented key. Return one record (`find_by`, `first`) or
+  `nil`.
+- Exceptions from the resolver propagate. The strategy does not rescue them,
+  so a database outage surfaces as an error rather than a silent 401, and can
+  never become a success.
+- Whatever the resolver returns becomes `user` in the result, and
+  `api_key_fingerprint` is still set in the result metadata. The raw key never
+  reaches the result, the Rack environment, the session, or the logs.
+
+The strategy cannot make a black-box lookup constant-time. Store SHA-256
+digests rather than raw keys and look up by `APIKeyStrategy.digest(key)`, as
+in the example above. The digest step is constant-time by construction, the
+lookup that follows is an exact match on a fixed-width value, and a database
+dump of high-entropy keys (generate them with `SecureRandom`, 32 bytes or
+more) does not expose usable credentials. Unsalted SHA-256 is not a password
+hash, so do not accept user-chosen keys. `APIKeyStrategy.digest(key)` returns
+the full hex digest; the fingerprint in the result is its first 12 characters.
+
+### What `APIKeyStrategy` does not provide
+
+`APIKeyStrategy` is a conventional small static-allowlist authenticator
+included as a low-dependency convenience and reference implementation. The
+fail-closed changes in #256 make that existing convenience safe by default;
+they do not establish that all Otto API-key authentication should use
+boot-loaded lists.
+
+In either form, the strategy has no native support for:
+
+- Runtime addition or immediate revocation.
+- Expiration.
+- Per-client roles or scopes.
+- Ownership and descriptive metadata.
+- Usage quotas.
+- A management API.
+- Persisted audit history.
+- Hashed verifier storage.
+
+With a static list, none of these exist: changing the set of valid keys means
+restarting the process, and every key is equal. With a resolver, the first
+four and the last become the application's key store's responsibility. The
+resolver decides whether a key is still valid, and whatever it returns is the
+`user` the handler sees, so roles, scopes, ownership, and expiry live on that
+record. Quotas, a management API, and audit history remain outside the
+strategy entirely. An application that needs them should build a custom
+`AuthStrategy` around its own key model, using `APIKeyStrategy` as the
+reference for header handling, terminal failures, and fingerprinting.
 
 A strategy implements `authenticate(env, requirement)` and returns a
 `StrategyResult`, `AuthFailure`, or `AuthorizationFailure`. Subclass
@@ -204,8 +291,9 @@ Otto includes these strategy classes as implementation starting points:
 
 - `SessionStrategy` — reads a configured key from `env['rack.session']`.
 - `APIKeyStrategy` — checks the configured header; the query parameter is opt-in
-  via `param_name:`. `api_keys:` is required and must be non-empty; a rejected
-  key is a terminal failure, and the result exposes only a key fingerprint.
+  via `param_name:`. Keys come from a non-empty `api_keys:` list, a `resolver:`
+  callable, or a block that looks the presented key up; a rejected key is a
+  terminal failure, and the result exposes only a key fingerprint.
 - `RoleStrategy` — checks session roles against allowed roles or a
   colon-qualified requirement.
 - `PermissionStrategy` — checks application-provided permission data.

--- a/docs/reference/authentication.md
+++ b/docs/reference/authentication.md
@@ -145,10 +145,58 @@ a 401 for API clients and, for HTML requests, a 302 to
 Otto ships `Otto::Security::Authentication::Strategies::APIKeyStrategy`; see
 that class for the real implementation. It reads the `X-API-Key` header only
 unless you pass `param_name: 'api_key'` to also accept the credential as a query
-or form parameter — keys in URLs are recorded by access logs, proxies, and
-browser history. Its result carries `user[:api_key_fingerprint]` (a truncated
-SHA-256 digest), never the key itself. A custom key-backed strategy follows the
-same shape:
+or form parameter; keys in URLs are recorded by access logs, proxies, and
+browser history. Its result carries `metadata[:api_key_fingerprint]` (a
+truncated SHA-256 digest), never the key itself; with a static `api_keys:` list
+`user` is a Hash carrying the same fingerprint, and with a resolver `user` is
+whatever the resolver returned.
+
+Keys come from exactly one of three sources. `api_keys:` takes a static list
+and matches under constant-time comparison. A block, or a `resolver:` that
+responds to `#call`, looks the presented key up and returns the account behind
+it:
+
+```ruby
+APIKeyStrategy = Otto::Security::Authentication::Strategies::APIKeyStrategy
+
+# Static list
+APIKeyStrategy.new(api_keys: ENV.fetch('API_KEYS').split(','))
+
+# Block resolver, looking up by digest so raw keys never touch the database
+APIKeyStrategy.new do |presented_key|
+  ApiKey.find_by(digest: APIKeyStrategy.digest(presented_key))&.account
+end
+
+# Callable resolver
+APIKeyStrategy.new(resolver: repo.method(:find_by_key))
+```
+
+Passing none of the three, or more than one, raises `ArgumentError`. The
+resolver receives only the presented key as a non-empty `String`; a missing
+credential is still the non-terminal `No API key provided` failure and never
+reaches the resolver. A `nil` or `false` return is the terminal
+`Invalid API key` failure (401), the same as a static mismatch; any other
+value, including an empty relation, Array, or Hash, is a match, so return one
+record or `nil`, not a `where(...)` relation. Exceptions from
+the resolver propagate rather than turning into a 401 or a success. The
+returned value becomes `user`, and `api_key_fingerprint` is set in the metadata
+regardless. `APIKeyStrategy.digest(key)` is the full SHA-256 hex digest; the
+fingerprint is its first 12 characters.
+
+The strategy cannot make a black-box lookup constant-time. Store SHA-256
+digests and look up by `APIKeyStrategy.digest(presented_key)`, as above.
+
+`APIKeyStrategy` is a small static-allowlist authenticator shipped as a
+low-dependency convenience and reference implementation. It has no native
+support for runtime addition or revocation, expiration, per-client roles or
+scopes, ownership or descriptive metadata, usage quotas, a management API,
+persisted audit history, or hashed verifier storage. The resolver form hands
+validity, roles, and metadata to the application's key store; the rest stay
+outside the strategy. See the
+[authentication guide](../guides/authentication.md#what-apikeystrategy-does-not-provide).
+
+A custom key-backed strategy that needs more than the resolver offers (for
+example, consulting `env`) follows the same shape:
 
 ```ruby
 class DatabaseAPIKeyStrategy < Otto::Security::Authentication::AuthStrategy
@@ -157,7 +205,8 @@ class DatabaseAPIKeyStrategy < Otto::Security::Authentication::AuthStrategy
     # No credential presented: non-terminal, so a later strategy may still run.
     return failure('Missing API key') if api_key.nil? || api_key.empty?
 
-    user = User.find_by_api_key(api_key)
+    digest = Otto::Security::Authentication::Strategies::APIKeyStrategy.digest(api_key)
+    user = User.find_by(api_key_digest: digest)
     # A credential WAS presented and rejected: terminal, fail closed with 401.
     return failure('Invalid API key', terminal: true) unless user
 

--- a/docs/reference/authentication.md
+++ b/docs/reference/authentication.md
@@ -146,10 +146,10 @@ Otto ships `Otto::Security::Authentication::Strategies::APIKeyStrategy`; see
 that class for the real implementation. It reads the `X-API-Key` header only
 unless you pass `param_name: 'api_key'` to also accept the credential as a query
 or form parameter; keys in URLs are recorded by access logs, proxies, and
-browser history. Its result carries `metadata[:api_key_fingerprint]` (a
-truncated SHA-256 digest), never the key itself; with a static `api_keys:` list
-`user` is a Hash carrying the same fingerprint, and with a resolver `user` is
-whatever the resolver returned.
+browser history. The strategy never places the raw key in the result; its own
+field is `metadata[:api_key_fingerprint]` (a truncated SHA-256 digest). With a
+static `api_keys:` list `user` is a Hash carrying the same fingerprint, and
+with a resolver `user` is whatever the resolver returned, verbatim.
 
 Keys come from exactly one of three sources. `api_keys:` takes a static list
 and matches under constant-time comparison. A block, or a `resolver:` that
@@ -180,8 +180,13 @@ value, including an empty relation, Array, or Hash, is a match, so return one
 record or `nil`, not a `where(...)` relation. Exceptions from
 the resolver propagate rather than turning into a 401 or a success. The
 returned value becomes `user`, and `api_key_fingerprint` is set in the metadata
-regardless. `APIKeyStrategy.digest(key)` is the full SHA-256 hex digest; the
-fingerprint is its first 12 characters.
+regardless. The result is stored in `env['otto.strategy_result']` and exposed
+to handlers, so anything the application serializes or logs from it carries
+`user`; the resolver must not return an object that carries the raw key:
+return the account, not the `ApiKey` row that stores the key, and store
+digests. Returning the presented key string itself as the user raises
+`ArgumentError`. `APIKeyStrategy.digest(key)` is the full SHA-256 hex digest;
+the fingerprint is its first 12 characters.
 
 The strategy cannot make a black-box lookup constant-time. Store SHA-256
 digests and look up by `APIKeyStrategy.digest(presented_key)`, as above.

--- a/lib/otto/security/authentication/route_auth_wrapper/role_authorization.rb
+++ b/lib/otto/security/authentication/route_auth_wrapper/role_authorization.rb
@@ -73,9 +73,14 @@ class Otto
           #
           # Supports multiple role sources in order of precedence:
           # 1. result.user_roles (Array)
-          # 2. result.user[:roles] (Array)
-          # 3. result.user['roles'] (Array)
+          # 2. result.user[:roles] / result.user['roles'] (Hash user)
+          # 3. result.user.roles, then result.user.role (object-backed user:
+          #    ORM model, PORO, Data/Struct); #roles must return role names
           # 4. result.metadata[:user_roles] (Array)
+          #
+          # A user object that is neither a Hash nor responds to `#roles`/`#role`
+          # contributes no roles rather than raising, so authorization yields a
+          # deny result instead of a NoMethodError.
           #
           # @param result [StrategyResult] Authentication result
           # @return [Array<String>] Array of role strings
@@ -83,10 +88,17 @@ class Otto
             # Try direct user_roles accessor (e.g., from RoleStrategy)
             return Array(result.user_roles) if result.respond_to?(:user_roles) && result.user_roles
 
-            # Try user hash/object with roles
-            if result.user
-              roles = result.user[:roles] || result.user['roles']
+            # Hash access first (unchanged behaviour), then object-backed users
+            user = result.user
+            if user.is_a?(Hash)
+              roles = user[:roles] || user['roles']
               return Array(roles) if roles
+            elsif user.respond_to?(:roles)
+              roles = user.roles
+              return Array(roles).map(&:to_s) if roles
+            elsif user.respond_to?(:role)
+              role = user.role
+              return [role.to_s] if role
             end
 
             # Try metadata

--- a/lib/otto/security/authentication/strategies/api_key_strategy.rb
+++ b/lib/otto/security/authentication/strategies/api_key_strategy.rb
@@ -43,8 +43,16 @@ class Otto
         # up by {APIKeyStrategy.digest}, which is constant-time by construction
         # and keeps raw keys out of the database.
         #
-        # The result never carries the raw key: it exposes only a short SHA-256
-        # fingerprint, so the secret does not reach env, session, or logs.
+        # The strategy never places the raw key in the result itself: the only
+        # strategy-generated field derived from the key is a short SHA-256
+        # fingerprint. With a resolver, `user` is whatever the resolver returns,
+        # verbatim; the result is stored in env['otto.strategy_result'] and
+        # exposed to handlers, so anything the application serializes or logs
+        # from it carries `user`. It is the resolver's responsibility not to
+        # return an object that holds the raw key: return the account, not the
+        # ApiKey row that stores the key, and store digests. A resolver that
+        # returns the presented key String itself as the user raises
+        # ArgumentError.
         #
         # The query/form parameter path is opt-in (`param_name:`), because keys in
         # URLs are recorded by access logs, proxies, and browser history.
@@ -118,8 +126,17 @@ class Otto
             user = @resolver.call(api_key)
             return failure('Invalid API key', terminal: true) unless user
 
-            # Identify the credential by a non-reversible fingerprint. The raw key
-            # must not reach the result, since it flows into env, session, and logs.
+            # The most likely naive misuse: `->(k) { k if keys.include?(k) }`.
+            # Fail loud before the key can reach the result and env.
+            if user.is_a?(String) && Rack::Utils.secure_compare(user, api_key)
+              raise ArgumentError,
+                    'APIKeyStrategy resolver returned the presented key as the user; ' \
+                    'return the account behind the key, not the key'
+            end
+
+            # Identify the credential by a non-reversible fingerprint. The strategy
+            # itself never places the raw key in the result; `user` is the
+            # resolver's return value, verbatim (see class docs).
             success(user: user,
                     auth_method: 'api_key',
                     api_key_fingerprint: key_fingerprint(api_key))
@@ -152,7 +169,11 @@ class Otto
           # Wrap a static key list in a resolver performing a constant-time,
           # non-short-circuiting membership check.
           def static_resolver(api_keys)
-            keys = Array(api_keys).map(&:to_s).reject(&:empty?).freeze
+            # Own frozen copies: `to_s` returns the caller's String, and the
+            # strategy only ever receives a shallow freeze from config
+            # finalization, so a caller mutating its key after boot would
+            # otherwise change which credential is accepted.
+            keys = Array(api_keys).map { |key| key.to_s.dup.freeze }.reject(&:empty?).freeze
             if keys.empty?
               raise ArgumentError,
                     'APIKeyStrategy requires at least one non-empty API key ' \

--- a/lib/otto/security/authentication/strategies/api_key_strategy.rb
+++ b/lib/otto/security/authentication/strategies/api_key_strategy.rb
@@ -12,15 +12,36 @@ class Otto
       module Strategies
         # API key authentication strategy.
         #
-        # Fails closed: at least one non-empty API key MUST be configured. A
-        # strategy with no usable keys is a misconfiguration and raises
-        # ArgumentError at construction rather than authenticating every caller.
-        # Only a constant-time match against a configured key grants success.
+        # Accepts exactly one key source: a static list (`api_keys:`), a
+        # callable (`resolver:`), or a block. A resolver receives the presented
+        # key (a non-empty String, never env) and returns the account behind it,
+        # or nil/false when the key is unknown. Any other return value, including
+        # an empty container, counts as a match: an ORM relation from `where`,
+        # an empty Array from `select`, or `{}` from a cache miss is truthy and
+        # authenticates the caller. Return exactly one record (`find_by`,
+        # `first`) or nil. The strategy never branches on mode: a static list is
+        # wrapped in a resolver internally.
         #
-        # A credential that was presented and rejected — including a non-String
-        # credential such as an array query parameter — fails TERMINALLY, so a bad
+        # Fails closed: a strategy with no source, or a static list with no
+        # non-empty key, is a misconfiguration and raises ArgumentError at
+        # construction rather than authenticating every caller. Only a truthy
+        # resolver return (for a static list: a constant-time match) grants
+        # success.
+        #
+        # A credential that was presented and rejected, including a non-String
+        # credential such as an array query parameter, fails TERMINALLY, so a bad
         # key halts the strategy chain instead of falling through to a later
         # anonymous-capable strategy. A missing credential fails non-terminally.
+        # Blank and non-String credentials are rejected before the resolver runs.
+        #
+        # Exceptions raised by a resolver propagate. A database outage must
+        # surface as an error, not as a silent 401 and never as success.
+        #
+        # Timing: the static list is compared in constant time against every
+        # configured key. A black-box lookup cannot be made constant-time by the
+        # strategy; the documented pattern is to store SHA-256 digests and look
+        # up by {APIKeyStrategy.digest}, which is constant-time by construction
+        # and keeps raw keys out of the database.
         #
         # The result never carries the raw key: it exposes only a short SHA-256
         # fingerprint, so the secret does not reach env, session, or logs.
@@ -28,26 +49,49 @@ class Otto
         # The query/form parameter path is opt-in (`param_name:`), because keys in
         # URLs are recorded by access logs, proxies, and browser history.
         #
-        # @example Header only (recommended)
+        # Scope: this is a small static-allowlist authenticator shipped as a
+        # low-dependency convenience and reference implementation. It has no
+        # native support for runtime addition or revocation, expiration, roles
+        # or scopes, key metadata, quotas, a management API, audit history, or
+        # hashed verifier storage. The resolver form delegates those concerns
+        # to the application's key store; see docs/guides/authentication.md.
+        #
+        # @example Static list, header only (recommended)
         #   APIKeyStrategy.new(api_keys: ['secret123'])
+        # @example Block resolver looking up a stored digest
+        #   APIKeyStrategy.new do |presented_key|
+        #     ApiKey.find_by(digest: APIKeyStrategy.digest(presented_key))&.account
+        #   end
+        # @example Callable resolver (anything responding to #call)
+        #   APIKeyStrategy.new(resolver: repo.method(:find_by_key))
         # @example Also accept ?api_key= (logged in URLs; prefer the header)
         #   APIKeyStrategy.new(api_keys: ['secret123'], param_name: 'api_key')
         class APIKeyStrategy < AuthStrategy
-          # @param api_keys [String, Array<String>] one or more valid API keys (required)
+          # Full SHA-256 hex digest of a key. Store this instead of the raw key
+          # and look up presented keys by their digest.
+          #
+          # @param key [String]
+          # @return [String] 64-char hex digest
+          def self.digest(key)
+            Digest::SHA256.hexdigest(key)
+          end
+
+          # @param api_keys [String, Array<String>, nil] static list of valid API keys
+          # @param resolver [#call, nil] callable receiving the presented key and
+          #   returning the account (truthy) or nil/false when unknown
           # @param header_name [String] request header carrying the key
           # @param param_name [String, nil] query/form parameter carrying the key.
           #   Defaults to nil (header only): keys placed in a URL are captured by
           #   access logs, proxies, and browser history. Pass 'api_key' to opt in.
-          # @raise [ArgumentError] if no non-empty API key is configured
-          def initialize(api_keys:, header_name: 'X-API-Key', param_name: nil)
+          # @yieldparam presented_key [String] the non-empty presented key
+          # @yieldreturn [Object, nil, false] the account behind the key, or
+          #   nil/false when the key is unknown
+          # @raise [ArgumentError] if no source, or more than one, is given
+          # @raise [ArgumentError] if resolver: does not respond to #call
+          # @raise [ArgumentError] if api_keys: contains no non-empty API key
+          def initialize(api_keys: nil, resolver: nil, header_name: 'X-API-Key', param_name: nil, &block)
             super()
-            @api_keys = Array(api_keys).map(&:to_s).reject(&:empty?).freeze
-            if @api_keys.empty?
-              raise ArgumentError,
-                    'APIKeyStrategy requires at least one non-empty API key ' \
-                    '(api_keys: was empty, nil, or contained only blank values)'
-            end
-
+            @resolver = build_resolver(api_keys, resolver, block)
             @header_name = header_name
             @param_name = param_name
           end
@@ -65,36 +109,68 @@ class Otto
             return failure('No API key provided') if api_key.nil? || (api_key.is_a?(String) && api_key.empty?)
 
             # A non-String credential (e.g. `?api_key[]=k` yields an Array) was
-            # still presented, so reject it terminally rather than coercing it
-            # into a comparison Rack::Utils.secure_compare cannot perform.
-            unless api_key.is_a?(String) && valid_api_key?(api_key)
-              # Credentials were explicitly presented and rejected: fail closed.
-              return failure('Invalid API key', terminal: true)
-            end
+            # still presented, so reject it terminally rather than handing it to
+            # the resolver. Credentials were explicitly presented and rejected:
+            # fail closed.
+            return failure('Invalid API key', terminal: true) unless api_key.is_a?(String)
+
+            # Resolver exceptions propagate deliberately (see class docs).
+            user = @resolver.call(api_key)
+            return failure('Invalid API key', terminal: true) unless user
 
             # Identify the credential by a non-reversible fingerprint. The raw key
             # must not reach the result, since it flows into env, session, and logs.
-            fingerprint = key_fingerprint(api_key)
-            success(user: { api_key_fingerprint: fingerprint },
+            success(user: user,
                     auth_method: 'api_key',
-                    api_key_fingerprint: fingerprint)
+                    api_key_fingerprint: key_fingerprint(api_key))
           end
 
           private
 
+          def build_resolver(api_keys, resolver, block)
+            sources = [api_keys, resolver, block].count { |source| !source.nil? }
+            if sources > 1
+              raise ArgumentError,
+                    'APIKeyStrategy: pass api_keys:, resolver:, or a block, not more than one'
+            end
+            # `api_keys: nil` and omitting every source are indistinguishable
+            # here, so one message covers both.
+            if sources.zero?
+              raise ArgumentError,
+                    'APIKeyStrategy requires a key source: at least one non-empty API key ' \
+                    '(api_keys:), a resolver:, or a block'
+            end
+
+            return static_resolver(api_keys) unless api_keys.nil?
+            return block if block
+
+            raise ArgumentError, 'APIKeyStrategy resolver: must respond to #call' unless resolver.respond_to?(:call)
+
+            resolver
+          end
+
+          # Wrap a static key list in a resolver performing a constant-time,
+          # non-short-circuiting membership check.
+          def static_resolver(api_keys)
+            keys = Array(api_keys).map(&:to_s).reject(&:empty?).freeze
+            if keys.empty?
+              raise ArgumentError,
+                    'APIKeyStrategy requires at least one non-empty API key ' \
+                    '(api_keys: was empty or contained only blank values)'
+            end
+
+            lambda do |presented|
+              matched = keys.reduce(false) do |acc, key|
+                Rack::Utils.secure_compare(key, presented) || acc
+              end
+              matched ? { api_key_fingerprint: key_fingerprint(presented) } : nil
+            end
+          end
+
           # Short, non-reversible identifier for a key: enough to correlate
           # requests and audit logs without exposing the credential.
           def key_fingerprint(api_key)
-            Digest::SHA256.hexdigest(api_key)[0, 12]
-          end
-
-          # Constant-time membership check over the configured API keys. Compares
-          # against every key without short-circuiting so match position/membership is
-          # not leaked via timing.
-          def valid_api_key?(api_key)
-            @api_keys.reduce(false) do |matched, key|
-              Rack::Utils.secure_compare(key, api_key) || matched
-            end
+            self.class.digest(api_key)[0, 12]
           end
         end
       end

--- a/lib/otto/security/authentication/strategy_result.rb
+++ b/lib/otto/security/authentication/strategy_result.rb
@@ -257,9 +257,30 @@ class Otto
 
         # Get all user roles as an array
         #
+        # Supports object-backed users (ORM models, POROs, Data/Struct) via
+        # `#roles` / `#role`, and Hash users via `:roles`/`'roles'` then
+        # `:role`/`'role'`. Never calls `#[]` on a non-Hash user, so a model
+        # without role support yields `[]` instead of raising. `#roles` on an
+        # object must return role names (Strings or Symbols, in any Enumerable);
+        # an association of role records is stringified as-is and matches
+        # nothing, which denies rather than grants.
+        #
         # @return [Array<String>] Array of roles (empty if none)
         def roles
           return [] unless authenticated?
+
+          # Try user model methods first, fall back to hash access for backward compatibility
+          if user.respond_to?(:roles)
+            normalized = normalize_list(user.roles)
+            return normalized unless normalized.empty?
+          end
+
+          if user.respond_to?(:role)
+            role = user.role
+            return [role.to_s] if role
+          end
+
+          return [] unless user.is_a?(Hash)
 
           roles_data = user[:roles] || user['roles']
           if roles_data.is_a?(Array)
@@ -274,13 +295,21 @@ class Otto
 
         # Get all user permissions as an array
         #
+        # Supports object-backed users via `#permissions` and Hash users via
+        # `:permissions`/`'permissions'`. Never calls `#[]` on a non-Hash user.
+        #
         # @return [Array<String>] Array of permissions (empty if none)
         def permissions
           return [] unless authenticated?
 
-          perms = user[:permissions] || user['permissions'] || []
-          perms = [perms] unless perms.is_a?(Array)
-          perms.map(&:to_s)
+          # Try user model methods first, fall back to hash access for backward compatibility
+          if user.respond_to?(:permissions)
+            normalize_list(user.permissions)
+          elsif user.is_a?(Hash)
+            normalize_list(user[:permissions] || user['permissions'])
+          else
+            []
+          end
         end
 
         # Create a string representation for debugging
@@ -331,6 +360,18 @@ class Otto
                              roles: roles,
                        permissions: permissions,
           }
+        end
+
+        private
+
+        # Coerce a roles/permissions value into an Array of Strings. Enumerables
+        # (Array, Set, an ORM relation) expand to their elements; a scalar
+        # becomes a one-element list; nil becomes [].
+        #
+        # @param value [Array, Enumerable, Object, nil]
+        # @return [Array<String>]
+        def normalize_list(value)
+          Array(value).map(&:to_s)
         end
       end
     end

--- a/spec/otto/security/authentication/route_auth_wrapper/role_authorization_spec.rb
+++ b/spec/otto/security/authentication/route_auth_wrapper/role_authorization_spec.rb
@@ -1,0 +1,166 @@
+# spec/otto/security/authentication/route_auth_wrapper/role_authorization_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Path mirrors lib/otto/security/authentication/route_auth_wrapper/, not the
+# RouteAuthWrapperComponents module name.
+RSpec.describe Otto::Security::Authentication::RouteAuthWrapperComponents::RoleAuthorization do # rubocop:disable RSpec/SpecFilePathFormat
+  subject(:authorizer) { described_class.new(route_definition) }
+
+  let(:route_definition) do
+    Otto::RouteDefinition.new('GET', '/admin', 'TestApp.admin auth=apikey role=admin')
+  end
+
+  let(:env) { { 'REQUEST_METHOD' => 'GET', 'PATH_INFO' => '/admin' } }
+
+  def result_for(user, metadata: {})
+    Otto::Security::Authentication::StrategyResult.new(
+      session: {},
+      user: user,
+      auth_method: 'apikey',
+      metadata: metadata,
+      strategy_name: 'apikey'
+    )
+  end
+
+  describe '#check' do
+    context 'with an object-backed user exposing #roles' do
+      let(:user_class) do
+        Class.new do
+          def id = 7
+          def roles = %w[admin]
+        end
+      end
+
+      it 'authorizes when a role matches' do
+        expect(authorizer.check(result_for(user_class.new), env)).to be(true)
+      end
+
+      it 'reports authorized? true' do
+        expect(authorizer.authorized?(result_for(user_class.new))).to be(true)
+      end
+    end
+
+    context 'with an object-backed user whose #roles do not match' do
+      let(:user_class) do
+        Class.new do
+          def id = 7
+          def roles = %w[viewer]
+        end
+      end
+
+      it 'returns the failure hash' do
+        expect(authorizer.check(result_for(user_class.new), env)).to eq(
+          authorized: false,
+          required: ['admin'],
+          actual: ['viewer']
+        )
+      end
+    end
+
+    context 'with an object-backed user exposing no #roles at all' do
+      let(:user_class) do
+        Class.new do
+          def id = 7
+        end
+      end
+
+      it 'denies without raising' do
+        outcome = nil
+        expect { outcome = authorizer.check(result_for(user_class.new), env) }.not_to raise_error
+        expect(outcome).to eq(authorized: false, required: ['admin'], actual: [])
+      end
+
+      it 'reports authorized? false' do
+        expect(authorizer.authorized?(result_for(user_class.new))).to be(false)
+      end
+
+      it 'still honours metadata[:user_roles]' do
+        result = result_for(user_class.new, metadata: { user_roles: ['admin'] })
+        expect(authorizer.check(result, env)).to be(true)
+      end
+    end
+
+    context 'with a Data instance user' do
+      let(:user_data) { Data.define(:id, :roles) }
+
+      it 'authorizes on matching #roles' do
+        expect(authorizer.check(result_for(user_data.new(id: 1, roles: ['admin'])), env)).to be(true)
+      end
+
+      it 'denies when #roles is nil' do
+        expect(authorizer.check(result_for(user_data.new(id: 1, roles: nil)), env))
+          .to eq(authorized: false, required: ['admin'], actual: [])
+      end
+    end
+
+    context 'with an ORM-like user responding to #[], #roles and #role' do
+      let(:user_class) do
+        Class.new do
+          def initialize(roles:, role: nil)
+            @roles = roles
+            @role = role
+          end
+
+          attr_reader :roles, :role
+
+          def id = 7
+          def [](_key) = nil
+        end
+      end
+
+      it 'authorizes on #roles, not #[]' do
+        expect(authorizer.check(result_for(user_class.new(roles: [:admin])), env)).to be(true)
+      end
+
+      it 'authorizes on a Set of roles' do
+        expect(authorizer.check(result_for(user_class.new(roles: Set['admin'])), env)).to be(true)
+      end
+
+      it 'denies on non-matching #roles even when #role would match' do
+        expect(authorizer.check(result_for(user_class.new(roles: ['viewer'], role: 'admin')), env))
+          .to eq(authorized: false, required: ['admin'], actual: ['viewer'])
+      end
+    end
+
+    context 'with an object-backed user exposing only a singular #role' do
+      let(:user_class) do
+        Class.new do
+          def id = 7
+          def role = 'admin'
+        end
+      end
+
+      it 'authorizes on #role' do
+        expect(authorizer.check(result_for(user_class.new), env)).to be(true)
+      end
+    end
+
+    context 'with a Hash user' do
+      it 'authorizes via :roles' do
+        expect(authorizer.check(result_for({ id: 1, roles: ['admin'] }), env)).to be(true)
+      end
+
+      it "authorizes via 'roles'" do
+        expect(authorizer.check(result_for({ id: 1, 'roles' => ['admin'] }), env)).to be(true)
+      end
+
+      it 'denies when roles absent' do
+        expect(authorizer.check(result_for({ id: 1 }), env))
+          .to eq(authorized: false, required: ['admin'], actual: [])
+      end
+    end
+
+    context 'without role requirements' do
+      let(:route_definition) do
+        Otto::RouteDefinition.new('GET', '/open', 'TestApp.open auth=apikey')
+      end
+
+      it 'authorizes any user, including one without #roles' do
+        expect(authorizer.check(result_for(Object.new), env)).to be(true)
+      end
+    end
+  end
+end

--- a/spec/otto/security/authentication/strategies/api_key_strategy_spec.rb
+++ b/spec/otto/security/authentication/strategies/api_key_strategy_spec.rb
@@ -134,4 +134,207 @@ RSpec.describe Otto::Security::Authentication::Strategies::APIKeyStrategy do
       expect(strategy.authenticate(env_with_header('key-one'), nil).authenticated?).to be(true)
     end
   end
+
+  describe '.digest' do
+    it 'returns the full SHA-256 hex digest of the key' do
+      expect(described_class.digest('key-one')).to eq(Digest::SHA256.hexdigest('key-one'))
+      expect(described_class.digest('key-one').length).to eq(64)
+    end
+
+    it 'prefixes the fingerprint placed in results' do
+      result = described_class.new(api_keys: ['key-one']).authenticate(env_with_header('key-one'), nil)
+      expect(described_class.digest('key-one')).to start_with(result.metadata[:api_key_fingerprint])
+    end
+  end
+
+  describe 'resolver form' do
+    let(:account) { { id: 42, name: 'acme' } }
+    let(:presented) { 'sk_live_resolver_key' }
+    let(:lookup_error) { Class.new(StandardError) }
+
+    describe 'construction' do
+      it 'rejects a resolver: that does not respond to #call' do
+        expect { described_class.new(resolver: 'not callable') }
+          .to raise_error(ArgumentError, /must respond to #call/)
+      end
+
+      it 'rejects api_keys: combined with a block' do
+        expect { described_class.new(api_keys: ['k']) { |_key| account } }
+          .to raise_error(ArgumentError, /not more than one/)
+      end
+
+      it 'rejects api_keys: combined with resolver:' do
+        expect { described_class.new(api_keys: ['k'], resolver: ->(_key) { account }) }
+          .to raise_error(ArgumentError, /not more than one/)
+      end
+
+      it 'rejects resolver: combined with a block' do
+        expect { described_class.new(resolver: ->(_key) { account }) { |_key| account } }
+          .to raise_error(ArgumentError, /not more than one/)
+      end
+
+      it 'rejects the absence of any key source' do
+        expect { described_class.new }
+          .to raise_error(ArgumentError, /requires a key source/)
+      end
+    end
+
+    describe 'block resolver' do
+      subject(:strategy) { described_class.new { |key| key == presented ? account : nil } }
+
+      it 'returns the block value as the user with a 12-char fingerprint in metadata' do
+        result = strategy.authenticate(env_with_header(presented), nil)
+        expect(result.authenticated?).to be(true)
+        expect(result.user).to eq(account)
+        expect(result.auth_method).to eq('api_key')
+        expect(result.metadata[:api_key_fingerprint]).to eq(Digest::SHA256.hexdigest(presented)[0, 12])
+        expect(result.metadata[:api_key_fingerprint].length).to eq(12)
+      end
+
+      it 'passes exactly the presented String key to the block' do
+        received = []
+        capturing = described_class.new do |*args|
+          received << args
+          account
+        end
+        capturing.authenticate(env_with_header(presented), nil)
+        expect(received).to eq([[presented]])
+        expect(received.first.first).to be_a(String)
+      end
+
+      it 'fails terminally when the block returns nil' do
+        result = strategy.authenticate(env_with_header('unknown-key'), nil)
+        expect(result).to be_a(Otto::Security::Authentication::AuthFailure)
+        expect(result.authenticated?).to be(false)
+        expect(result.terminal?).to be(true)
+        expect(result.failure_reason).to eq('Invalid API key')
+      end
+
+      it 'fails terminally when the block returns false' do
+        falsy = described_class.new { |_key| false }
+        result = falsy.authenticate(env_with_header(presented), nil)
+        expect(result).to be_a(Otto::Security::Authentication::AuthFailure)
+        expect(result.terminal?).to be(true)
+        expect(result.failure_reason).to eq('Invalid API key')
+      end
+
+      it 'treats any non-nil, non-false return as a match, including empty containers' do
+        # Pins the truthy contract: a resolver built on `where`/`select` or a
+        # cache returning {} on miss authenticates every key. Return nil on miss.
+        [[], {}, '', 0].each do |value|
+          permissive = described_class.new { |_key| value }
+          result = permissive.authenticate(env_with_header(presented), nil)
+          expect(result.authenticated?).to be(true), "expected #{value.inspect} to authenticate"
+          expect(result.user).to eq(value)
+        end
+      end
+
+      it 'propagates exceptions raised by the resolver' do
+        error_class = lookup_error
+        raising = described_class.new { |_key| raise error_class, 'db down' }
+        expect { raising.authenticate(env_with_header(presented), nil) }
+          .to raise_error(error_class, 'db down')
+      end
+
+      it 'does not call the block for a blank header and fails non-terminally' do
+        called = false
+        strict = described_class.new do |_key|
+          called = true
+          account
+        end
+        result = strict.authenticate(env_with_header(''), nil)
+        expect(called).to be(false)
+        expect(result.authenticated?).to be(false)
+        expect(result.terminal?).to be(false)
+        expect(result.failure_reason).to eq('No API key provided')
+      end
+
+      it 'does not call the block for a missing header' do
+        called = false
+        strict = described_class.new do |_key|
+          called = true
+          account
+        end
+        result = strict.authenticate({}, nil)
+        expect(called).to be(false)
+        expect(result.failure_reason).to eq('No API key provided')
+      end
+
+      it 'does not call the block for an array-valued query parameter and fails terminally' do
+        called = false
+        opted_in = described_class.new(param_name: 'api_key') do |_key|
+          called = true
+          account
+        end
+        env = Rack::MockRequest.env_for("/?api_key[]=#{presented}")
+        result = opted_in.authenticate(env, nil)
+        expect(called).to be(false)
+        expect(result.authenticated?).to be(false)
+        expect(result.terminal?).to be(true)
+        expect(result.failure_reason).to eq('Invalid API key')
+      end
+
+      it 'does not expose the raw key in the result' do
+        result = strategy.authenticate(env_with_header(presented), nil)
+        expect(result.user.inspect).not_to include(presented)
+        expect(result.metadata.inspect).not_to include(presented)
+        expect(result.metadata).not_to have_key(:api_key)
+        expect(result.to_h.inspect).not_to include(presented)
+        expect(result.inspect).not_to include(presented)
+      end
+
+      it 'ignores the query parameter by default' do
+        result = strategy.authenticate(env_with_param(presented), nil)
+        expect(result.authenticated?).to be(false)
+        expect(result.failure_reason).to eq('No API key provided')
+      end
+
+      it 'reads the query parameter when opted in' do
+        opted_in = described_class.new(param_name: 'api_key') { |key| key == presented ? account : nil }
+        result = opted_in.authenticate(env_with_param(presented), nil)
+        expect(result.authenticated?).to be(true)
+        expect(result.user).to eq(account)
+      end
+
+      it 'supports a custom header name' do
+        custom = described_class.new(header_name: 'X-Otto-Token') { |key| key == presented ? account : nil }
+        result = custom.authenticate(env_with_header(presented, header: 'HTTP_X_OTTO_TOKEN'), nil)
+        expect(result.authenticated?).to be(true)
+      end
+    end
+
+    describe 'callable resolver' do
+      let(:repo) do
+        Class.new do
+          def initialize(account)
+            @account = account
+          end
+
+          def find_by_key(key)
+            key == 'sk_live_resolver_key' ? @account : nil
+          end
+        end.new(account)
+      end
+
+      it 'accepts a Method object' do
+        strategy = described_class.new(resolver: repo.method(:find_by_key))
+        result = strategy.authenticate(env_with_header(presented), nil)
+        expect(result.authenticated?).to be(true)
+        expect(result.user).to eq(account)
+        expect(result.metadata[:api_key_fingerprint]).to eq(Digest::SHA256.hexdigest(presented)[0, 12])
+      end
+
+      it 'accepts a lambda' do
+        strategy = described_class.new(resolver: ->(key) { key == presented ? account : nil })
+        expect(strategy.authenticate(env_with_header(presented), nil).user).to eq(account)
+        expect(strategy.authenticate(env_with_header('nope'), nil).terminal?).to be(true)
+      end
+
+      it 'propagates exceptions raised by the callable' do
+        error_class = lookup_error
+        strategy = described_class.new(resolver: ->(_key) { raise error_class })
+        expect { strategy.authenticate(env_with_header(presented), nil) }.to raise_error(error_class)
+      end
+    end
+  end
 end

--- a/spec/otto/security/authentication/strategies/api_key_strategy_spec.rb
+++ b/spec/otto/security/authentication/strategies/api_key_strategy_spec.rb
@@ -37,6 +37,21 @@ RSpec.describe Otto::Security::Authentication::Strategies::APIKeyStrategy do
       expect { described_class.new(api_keys: ['', nil]) }
         .to raise_error(ArgumentError, /at least one non-empty API key/)
     end
+
+    it 'copies static keys so mutating the caller string afterwards does not change what is accepted' do
+      original = +'mutable-key'
+      strategy = described_class.new(api_keys: [original])
+      original << '-changed'
+
+      expect(strategy.authenticate({ 'HTTP_X_API_KEY' => 'mutable-key' }, nil).authenticated?).to be(true)
+      expect(strategy.authenticate({ 'HTTP_X_API_KEY' => 'mutable-key-changed' }, nil).authenticated?).to be(false)
+    end
+
+    it 'does not freeze the caller string it copies from' do
+      original = +'mutable-key'
+      described_class.new(api_keys: [original])
+      expect(original).not_to be_frozen
+    end
   end
 
   describe '#authenticate' do
@@ -234,6 +249,30 @@ RSpec.describe Otto::Security::Authentication::Strategies::APIKeyStrategy do
         raising = described_class.new { |_key| raise error_class, 'db down' }
         expect { raising.authenticate(env_with_header(presented), nil) }
           .to raise_error(error_class, 'db down')
+      end
+
+      it 'raises ArgumentError when the resolver returns the presented key itself as the user' do
+        keys = [presented]
+        naive = described_class.new { |key| key if keys.include?(key) }
+        expect { naive.authenticate(env_with_header(presented), nil) }
+          .to raise_error(ArgumentError,
+                          'APIKeyStrategy resolver returned the presented key as the user; ' \
+                          'return the account behind the key, not the key')
+      end
+
+      it 'accepts a String user that is not the presented key' do
+        by_id = described_class.new { |key| key == presented ? 'acct_42' : nil }
+        result = by_id.authenticate(env_with_header(presented), nil)
+        expect(result.authenticated?).to be(true)
+        expect(result.user).to eq('acct_42')
+      end
+
+      it 'accepts a String user of the same length as the presented key' do
+        same_length = presented.reverse
+        expect(same_length.bytesize).to eq(presented.bytesize)
+        by_id = described_class.new { |key| key == presented ? same_length : nil }
+        result = by_id.authenticate(env_with_header(presented), nil)
+        expect(result.user).to eq(same_length)
       end
 
       it 'does not call the block for a blank header and fails non-terminally' do

--- a/spec/otto/security/authentication/strategy_result_spec.rb
+++ b/spec/otto/security/authentication/strategy_result_spec.rb
@@ -1,0 +1,255 @@
+# spec/otto/security/authentication/strategy_result_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Otto::Security::Authentication::StrategyResult do
+  def build(user)
+    described_class.new(
+      session: {},
+      user: user,
+      auth_method: 'apikey',
+      metadata: {},
+      strategy_name: 'apikey'
+    )
+  end
+
+  describe '#roles' do
+    context 'with a Hash user' do
+      it 'reads :roles' do
+        expect(build({ roles: [:admin, 'editor'] }).roles).to eq(%w[admin editor])
+      end
+
+      it "reads 'roles'" do
+        expect(build({ 'roles' => ['admin'] }).roles).to eq(['admin'])
+      end
+
+      it 'falls back to :role' do
+        expect(build({ role: :admin }).roles).to eq(['admin'])
+      end
+
+      it 'returns [] when neither key is present' do
+        expect(build({ id: 1 }).roles).to eq([])
+      end
+    end
+
+    context 'with a PORO user exposing #roles' do
+      let(:user_class) do
+        Class.new do
+          def roles = [:admin, 'editor']
+        end
+      end
+
+      it 'normalizes the array to strings' do
+        expect(build(user_class.new).roles).to eq(%w[admin editor])
+      end
+    end
+
+    context 'with a PORO user exposing a single #roles value' do
+      let(:user_class) do
+        Class.new do
+          def roles = :admin
+        end
+      end
+
+      it 'wraps the scalar' do
+        expect(build(user_class.new).roles).to eq(['admin'])
+      end
+    end
+
+    context 'with a PORO user exposing #role only' do
+      let(:user_class) do
+        Class.new do
+          def role = :editor
+        end
+      end
+
+      it 'uses the single role' do
+        expect(build(user_class.new).roles).to eq(['editor'])
+      end
+    end
+
+    context 'with a PORO user whose #roles is nil but #role is set' do
+      let(:user_class) do
+        Class.new do
+          def roles = nil
+          def role = 'viewer'
+        end
+      end
+
+      it 'falls through to #role' do
+        expect(build(user_class.new).roles).to eq(['viewer'])
+      end
+    end
+
+    context 'with a PORO user exposing neither #roles nor #role' do
+      let(:user_class) do
+        Class.new do
+          def id = 42
+        end
+      end
+
+      it 'returns [] without raising' do
+        expect(build(user_class.new).roles).to eq([])
+      end
+
+      it 'does not raise from #to_h' do
+        expect { build(user_class.new).to_h }.not_to raise_error
+      end
+
+      it 'does not raise from #inspect' do
+        expect(build(user_class.new).inspect).to include('roles=[]')
+      end
+    end
+
+    context 'with a Data instance user' do
+      let(:user_data) { Data.define(:id, :roles) }
+
+      it 'reads #roles' do
+        expect(build(user_data.new(id: 1, roles: ['admin'])).roles).to eq(['admin'])
+      end
+    end
+
+    context 'with a Data instance user lacking a roles member' do
+      let(:user_data) { Data.define(:id) }
+
+      it 'returns [] without raising' do
+        expect(build(user_data.new(id: 1)).roles).to eq([])
+      end
+    end
+
+    context 'with a Struct instance user' do
+      let(:user_struct) { Struct.new(:id, :roles) }
+
+      it 'reads #roles' do
+        expect(build(user_struct.new(1, [:admin])).roles).to eq(['admin'])
+      end
+
+      it 'returns [] when roles is nil' do
+        expect(build(user_struct.new(1, nil)).roles).to eq([])
+      end
+    end
+
+    context 'with a Struct instance user lacking a roles member' do
+      let(:user_struct) { Struct.new(:id) }
+
+      it 'returns [] without calling #[]' do
+        expect(build(user_struct.new(1)).roles).to eq([])
+      end
+    end
+
+    context 'with an ORM-like user responding to #[], #roles and #role' do
+      let(:user_class) do
+        Class.new do
+          def initialize(roles:, role: nil)
+            @attrs = { 'role' => role }
+            @roles = roles
+          end
+
+          attr_reader :roles
+
+          def id = 7
+          def [](key) = @attrs[key.to_s]
+          def role = @attrs['role']
+        end
+      end
+
+      it 'prefers #roles over #[] and #role' do
+        expect(build(user_class.new(roles: %w[admin editor], role: 'viewer')).roles).to eq(%w[admin editor])
+      end
+
+      it 'falls back to #role when #roles is empty' do
+        expect(build(user_class.new(roles: [], role: 'viewer')).roles).to eq(['viewer'])
+      end
+
+      it 'expands a Set of roles' do
+        expect(build(user_class.new(roles: Set['admin', :editor])).roles).to eq(%w[admin editor])
+      end
+    end
+
+    it 'returns [] when anonymous' do
+      expect(described_class.anonymous.roles).to eq([])
+    end
+  end
+
+  describe '#permissions' do
+    context 'with a Hash user' do
+      it 'reads :permissions' do
+        expect(build({ permissions: [:read, 'write'] }).permissions).to eq(%w[read write])
+      end
+
+      it "reads 'permissions'" do
+        expect(build({ 'permissions' => 'read' }).permissions).to eq(['read'])
+      end
+
+      it 'returns [] when absent' do
+        expect(build({ id: 1 }).permissions).to eq([])
+      end
+    end
+
+    context 'with a PORO user exposing #permissions' do
+      let(:user_class) do
+        Class.new do
+          def permissions = [:read, 'write']
+        end
+      end
+
+      it 'normalizes to strings' do
+        expect(build(user_class.new).permissions).to eq(%w[read write])
+      end
+    end
+
+    context 'with a PORO user exposing a scalar #permissions' do
+      let(:user_class) do
+        Class.new do
+          def permissions = :read
+        end
+      end
+
+      it 'wraps the scalar' do
+        expect(build(user_class.new).permissions).to eq(['read'])
+      end
+    end
+
+    context 'with a PORO user without #permissions' do
+      let(:user_class) do
+        Class.new do
+          def id = 42
+        end
+      end
+
+      it 'returns [] without raising' do
+        expect(build(user_class.new).permissions).to eq([])
+      end
+
+      it 'does not raise from #to_h' do
+        expect(build(user_class.new).to_h).to include(roles: [], permissions: [])
+      end
+    end
+
+    context 'with a Data instance user' do
+      let(:user_data) { Data.define(:id, :permissions) }
+
+      it 'reads #permissions' do
+        expect(build(user_data.new(id: 1, permissions: ['read'])).permissions).to eq(['read'])
+      end
+
+      it 'returns [] when permissions is nil' do
+        expect(build(user_data.new(id: 1, permissions: nil)).permissions).to eq([])
+      end
+    end
+
+    context 'with a Struct instance user lacking a permissions member' do
+      let(:user_struct) { Struct.new(:id) }
+
+      it 'returns [] without calling #[]' do
+        expect(build(user_struct.new(1)).permissions).to eq([])
+      end
+    end
+
+    it 'returns [] when anonymous' do
+      expect(described_class.anonymous.permissions).to eq([])
+    end
+  end
+end

--- a/spec/otto/security/route_auth_wrapper_spec.rb
+++ b/spec/otto/security/route_auth_wrapper_spec.rb
@@ -1188,6 +1188,22 @@ RSpec.describe Otto::Security::Authentication::RouteAuthWrapper do
                   metadata: { user_roles: ['admin'] },
                   strategy_name: 'custom'
                 )
+              when :user_object_with_roles
+                Otto::Security::Authentication::StrategyResult.new(
+                  user: Data.define(:id, :roles).new(id: 123, roles: ['admin']),
+                  session: env['rack.session'],
+                  auth_method: 'custom',
+                  metadata: {},
+                  strategy_name: 'custom'
+                )
+              when :user_object_without_roles
+                Otto::Security::Authentication::StrategyResult.new(
+                  user: Data.define(:id).new(id: 123),
+                  session: env['rack.session'],
+                  auth_method: 'custom',
+                  metadata: {},
+                  strategy_name: 'custom'
+                )
               end
             end
           end.new
@@ -1242,6 +1258,29 @@ RSpec.describe Otto::Security::Authentication::RouteAuthWrapper do
 
         status, _headers, _body = wrapper.call(env)
         expect(status).to eq(200)
+      end
+
+      it 'extracts roles from an object-backed user via #roles' do
+        config = { auth_strategies: { 'custom' => custom_strategy.call(:user_object_with_roles) } }
+        wrapper = described_class.new(mock_handler, role_route, config)
+
+        env = mock_rack_env
+        env['rack.session'] = { 'user_id' => 123 }
+
+        status, _headers, _body = wrapper.call(env)
+        expect(status).to eq(200)
+      end
+
+      it 'denies (403) an object-backed user without #roles instead of raising' do
+        config = { auth_strategies: { 'custom' => custom_strategy.call(:user_object_without_roles) } }
+        wrapper = described_class.new(mock_handler, role_route, config)
+
+        env = mock_rack_env
+        env['rack.session'] = { 'user_id' => 123 }
+
+        status = nil
+        expect { status, _headers, _body = wrapper.call(env) }.not_to raise_error
+        expect(status).to eq(403)
       end
     end
   end


### PR DESCRIPTION
> **Stacked on #256's branch** (`feature/256-api-key-strategy-fail-closed`). Merge that first, then retarget this PR to `main`. The diff here is one commit.

## Why

A static `api_keys:` list is the right zero-dependency default, but a successful match yields only a key fingerprint, which is nearly useless for authorization. Real applications keep keys in a database and need the account behind the key.

## What

`APIKeyStrategy` accepts a resolver as an alternative to the static list:

```ruby
# static list (unchanged)
APIKeyStrategy.new(api_keys: keys)

# block resolver
APIKeyStrategy.new do |presented_key|
  ApiKey.find_by(digest: APIKeyStrategy.digest(presented_key))&.account
end

# any #call-able
APIKeyStrategy.new(resolver: repo.method(:find_by_key))
```

- Exactly one of `api_keys:`, `resolver:`, or a block. None or more than one raises `ArgumentError` at construction.
- A static list is wrapped in a resolver internally, so there is one authenticate path and no branching on mode.
- The #256 fail-closed guarantees hold in every form. Header extraction, the blank check, and the non-String rejection run before the resolver, which only ever receives a non-empty `String`.
- `nil` or `false` from the resolver is the same terminal `Invalid API key` failure as a static mismatch. Any other value is a match, including empty containers; docs and a spec pin this and tell readers to return one record or `nil`, not a `where` relation.
- Exceptions from the resolver propagate. A database outage must not become a silent 401 and can never become success.
- The resolver's return value becomes `user`. `api_key_fingerprint` is still set in metadata. The raw key never reaches the result.
- New `APIKeyStrategy.digest(key)` returns the full SHA-256 hex digest. The documented pattern stores digests and looks up by digest, which is constant-time by construction and keeps raw keys out of the database.

## Docs

The guide and reference gain a resolver section and a new "What `APIKeyStrategy` does not provide" section. In either form the strategy has no native support for runtime addition or revocation, expiration, per-client roles or scopes, ownership or descriptive metadata, usage quotas, a management API, persisted audit history, or hashed verifier storage. The framing:

> `APIKeyStrategy` is a conventional small static-allowlist authenticator included as a low-dependency convenience and reference implementation. Issue #256 makes that existing convenience safe by default; it does not establish that all Otto API-key authentication should use boot-loaded lists.

The #256 changelog fragment is reworded from "`api_keys:` is now a required keyword" to "without a key source raises `ArgumentError`", so the two fragments do not contradict each other when collected.

## Verification

- `bundle exec rspec`: 2284 examples, 0 failures
- `bundle exec rubocop` on touched files: no offenses
- New specs cover the construction matrix, block and callable forms, nil/false/exception handling, the resolver never seeing blank or non-String credentials, raw-key non-leakage, and `param_name:`/`header_name:` behaving identically under a resolver.
