### PR TITLE
Make APIKeyStrategy fail closed and add a resolver form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ vendor
 .mcp.json
 .claude
 .serena
+.yardoc

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -296,12 +296,11 @@ Lint/DuplicateMethods:
   Exclude:
     - 'lib/otto/privacy/geo_resolver.rb'
 
-# Offense count: 2
+# Offense count: 1
 # Configuration parameters: AllowedParentClasses.
 Lint/MissingSuper:
   Exclude:
     - 'lib/otto/mcp/rate_limiting.rb'
-    - 'lib/otto/security/authentication/strategies/api_key_strategy.rb'
 
 # Offense count: 12
 # This cop supports unsafe autocorrection (--autocorrect-all).

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -296,15 +296,12 @@ Lint/DuplicateMethods:
   Exclude:
     - 'lib/otto/privacy/geo_resolver.rb'
 
-# Offense count: 5
+# Offense count: 2
 # Configuration parameters: AllowedParentClasses.
 Lint/MissingSuper:
   Exclude:
     - 'lib/otto/mcp/rate_limiting.rb'
     - 'lib/otto/security/authentication/strategies/api_key_strategy.rb'
-    - 'lib/otto/security/authentication/strategies/permission_strategy.rb'
-    - 'lib/otto/security/authentication/strategies/role_strategy.rb'
-    - 'lib/otto/security/authentication/strategies/session_strategy.rb'
 
 # Offense count: 12
 # This cop supports unsafe autocorrection (--autocorrect-all).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ Authentication is handled by `RouteAuthWrapper` at the handler level, NOT by mid
 
 ```ruby
 otto.add_auth_strategy('session', SessionStrategy.new)
-otto.add_auth_strategy('apikey', APIKeyStrategy.new)
+otto.add_auth_strategy('apikey', APIKeyStrategy.new(api_keys: ENV.fetch('API_KEYS').split(',')))
 ```
 
 - Strategy names must be unique

--- a/changelog.d/20260904_132323_delano_256_api_key_strategy_fail_closed.rst
+++ b/changelog.d/20260904_132323_delano_256_api_key_strategy_fail_closed.rst
@@ -1,0 +1,24 @@
+Changed
+-------
+
+- ``api_keys:`` is now a required keyword on
+  ``Otto::Security::Authentication::Strategies::APIKeyStrategy``, and
+  ``APIKeyStrategy.new`` without keys raises ``ArgumentError``. To migrate, pass
+  the configured keys explicitly, e.g.
+  ``APIKeyStrategy.new(api_keys: ENV.fetch('API_KEYS').split(','))``. (#256)
+
+Security
+--------
+
+- ``APIKeyStrategy`` now fails closed. Previously, when no keys were
+  configured, the strategy authenticated any request carrying a non-empty
+  ``X-API-Key`` header or ``api_key`` parameter, so a misconfigured or
+  partially configured deployment granted access to any caller that invented a
+  key. The constructor now raises ``ArgumentError`` when the normalized key
+  list is empty (``nil``, ``[]``, or only blank strings), a credential is
+  accepted only when it matches a configured key under constant-time
+  comparison, empty-string credentials are rejected, and a presented key that
+  is rejected produces a terminal failure so it can no longer fall through to a
+  later strategy in a multi-strategy OR chain. Non-string credentials, such as
+  an ``?api_key[]=`` array query parameter, are now rejected as invalid instead
+  of raising inside the constant-time comparison. (#256)

--- a/changelog.d/20260904_132323_delano_256_api_key_strategy_fail_closed.rst
+++ b/changelog.d/20260904_132323_delano_256_api_key_strategy_fail_closed.rst
@@ -1,10 +1,9 @@
 Changed
 -------
 
-- ``api_keys:`` is now a required keyword on
-  ``Otto::Security::Authentication::Strategies::APIKeyStrategy``, and
-  ``APIKeyStrategy.new`` without keys raises ``ArgumentError``. To migrate, pass
-  the configured keys explicitly, e.g.
+- ``Otto::Security::Authentication::Strategies::APIKeyStrategy.new`` without a
+  key source raises ``ArgumentError``. To migrate, pass the configured keys
+  explicitly, e.g.
   ``APIKeyStrategy.new(api_keys: ENV.fetch('API_KEYS').split(','))``. (#256)
 
 - ``APIKeyStrategy`` no longer places the presented key in the authentication

--- a/changelog.d/20260904_132323_delano_256_api_key_strategy_fail_closed.rst
+++ b/changelog.d/20260904_132323_delano_256_api_key_strategy_fail_closed.rst
@@ -7,6 +7,11 @@ Changed
   the configured keys explicitly, e.g.
   ``APIKeyStrategy.new(api_keys: ENV.fetch('API_KEYS').split(','))``. (#256)
 
+- ``APIKeyStrategy`` no longer places the presented key in the authentication
+  result. Callers that read ``user[:api_key]`` should read
+  ``user[:api_key_fingerprint]`` instead, which is a truncated SHA-256 digest of
+  the key rather than the key itself. (#256)
+
 - ``APIKeyStrategy`` no longer reads the ``api_key`` query or form parameter by
   default; only the configured header is consulted. To keep accepting
   query-string keys, pass the parameter name explicitly, e.g.
@@ -27,6 +32,13 @@ Security
   later strategy in a multi-strategy OR chain. Non-string credentials, such as
   an ``?api_key[]=`` array query parameter, are now rejected as invalid instead
   of raising inside the constant-time comparison. (#256)
+
+- ``APIKeyStrategy`` no longer leaks the credential into the authentication
+  result. Previously the raw key was returned in both the user hash and the
+  result metadata, from where it flowed into the Rack environment, the session,
+  and any log line that recorded the authenticated user. The result now carries
+  only a truncated SHA-256 fingerprint of the key, which is enough to correlate
+  requests in an audit trail but cannot be replayed. (#256)
 
 - ``APIKeyStrategy`` no longer accepts a key from the query or form parameter
   unless ``param_name:`` is set. A credential placed in a URL is recorded by

--- a/changelog.d/20260904_132323_delano_256_api_key_strategy_fail_closed.rst
+++ b/changelog.d/20260904_132323_delano_256_api_key_strategy_fail_closed.rst
@@ -7,6 +7,11 @@ Changed
   the configured keys explicitly, e.g.
   ``APIKeyStrategy.new(api_keys: ENV.fetch('API_KEYS').split(','))``. (#256)
 
+- ``APIKeyStrategy`` no longer reads the ``api_key`` query or form parameter by
+  default; only the configured header is consulted. To keep accepting
+  query-string keys, pass the parameter name explicitly, e.g.
+  ``APIKeyStrategy.new(api_keys: keys, param_name: 'api_key')``. (#256)
+
 Security
 --------
 
@@ -22,3 +27,8 @@ Security
   later strategy in a multi-strategy OR chain. Non-string credentials, such as
   an ``?api_key[]=`` array query parameter, are now rejected as invalid instead
   of raising inside the constant-time comparison. (#256)
+
+- ``APIKeyStrategy`` no longer accepts a key from the query or form parameter
+  unless ``param_name:`` is set. A credential placed in a URL is recorded by
+  access logs, proxies, and browser history, so the header is now the only
+  default transport. (#256)

--- a/changelog.d/20260904_132323_delano_256_api_key_strategy_fail_closed.rst
+++ b/changelog.d/20260904_132323_delano_256_api_key_strategy_fail_closed.rst
@@ -1,45 +1,15 @@
-Changed
--------
-
-- ``Otto::Security::Authentication::Strategies::APIKeyStrategy.new`` without a
-  key source raises ``ArgumentError``. To migrate, pass the configured keys
-  explicitly, e.g.
-  ``APIKeyStrategy.new(api_keys: ENV.fetch('API_KEYS').split(','))``. (#256)
-
-- ``APIKeyStrategy`` no longer places the presented key in the authentication
-  result. Callers that read ``user[:api_key]`` should read
-  ``user[:api_key_fingerprint]`` instead, which is a truncated SHA-256 digest of
-  the key rather than the key itself. (#256)
-
-- ``APIKeyStrategy`` no longer reads the ``api_key`` query or form parameter by
-  default; only the configured header is consulted. To keep accepting
-  query-string keys, pass the parameter name explicitly, e.g.
-  ``APIKeyStrategy.new(api_keys: keys, param_name: 'api_key')``. (#256)
-
 Security
 --------
 
-- ``APIKeyStrategy`` now fails closed. Previously, when no keys were
-  configured, the strategy authenticated any request carrying a non-empty
-  ``X-API-Key`` header or ``api_key`` parameter, so a misconfigured or
-  partially configured deployment granted access to any caller that invented a
-  key. The constructor now raises ``ArgumentError`` when the normalized key
-  list is empty (``nil``, ``[]``, or only blank strings), a credential is
-  accepted only when it matches a configured key under constant-time
-  comparison, empty-string credentials are rejected, and a presented key that
-  is rejected produces a terminal failure so it can no longer fall through to a
-  later strategy in a multi-strategy OR chain. Non-string credentials, such as
-  an ``?api_key[]=`` array query parameter, are now rejected as invalid instead
-  of raising inside the constant-time comparison. (#256)
+- ``APIKeyStrategy`` now requires exactly one key source and rejects empty
+  static key lists at construction. Invalid presented credentials terminate a
+  multi-strategy authentication chain, and static keys are compared in constant
+  time. (#256)
 
-- ``APIKeyStrategy`` no longer leaks the credential into the authentication
-  result. Previously the raw key was returned in both the user hash and the
-  result metadata, from where it flowed into the Rack environment, the session,
-  and any log line that recorded the authenticated user. The result now carries
-  only a truncated SHA-256 fingerprint of the key, which is enough to correlate
-  requests in an audit trail but cannot be replayed. (#256)
+- Successful authentication results no longer expose the raw API key in
+  strategy-generated fields. Static-list callers should replace
+  ``user[:api_key]`` with ``user[:api_key_fingerprint]``. (#256)
 
-- ``APIKeyStrategy`` no longer accepts a key from the query or form parameter
-  unless ``param_name:`` is set. A credential placed in a URL is recorded by
-  access logs, proxies, and browser history, so the header is now the only
-  default transport. (#256)
+- ``APIKeyStrategy`` now reads only the configured header by default. Applications
+  that still accept query or form parameters must opt in with ``param_name:``;
+  see ``docs/guides/authentication.md`` for configuration guidance. (#256)

--- a/changelog.d/20260904_132323_delano_256_api_key_strategy_fail_closed.rst
+++ b/changelog.d/20260904_132323_delano_256_api_key_strategy_fail_closed.rst
@@ -5,7 +5,8 @@ Security
   static key lists at construction. Invalid presented credentials terminate a
   multi-strategy authentication chain. Static keys are compared in constant
   time as fixed-width SHA-256 digests, so configured key lengths are not
-  observable through timing. (#256)
+  observable through timing. Blank credentials, empty or whitespace-only, are
+  rejected before any key source is consulted. (#256)
 
 - Successful authentication results no longer expose the raw API key in
   strategy-generated fields. Static-list callers should replace

--- a/changelog.d/20260904_132323_delano_256_api_key_strategy_fail_closed.rst
+++ b/changelog.d/20260904_132323_delano_256_api_key_strategy_fail_closed.rst
@@ -3,8 +3,9 @@ Security
 
 - ``APIKeyStrategy`` now requires exactly one key source and rejects empty
   static key lists at construction. Invalid presented credentials terminate a
-  multi-strategy authentication chain, and static keys are compared in constant
-  time. (#256)
+  multi-strategy authentication chain. Static keys are compared in constant
+  time as fixed-width SHA-256 digests, so configured key lengths are not
+  observable through timing. (#256)
 
 - Successful authentication results no longer expose the raw API key in
   strategy-generated fields. Static-list callers should replace

--- a/changelog.d/20260904_150900_delano_api_key_strategy_resolver.rst
+++ b/changelog.d/20260904_150900_delano_api_key_strategy_resolver.rst
@@ -9,3 +9,12 @@ Added
   that look up generated API keys by digest. See
   ``docs/guides/authentication.md`` for the resolver contract and credential
   storage guidance.
+
+Fixed
+-----
+
+- ``StrategyResult#has_role?`` and ``#has_permission?`` now derive their answer
+  from ``#roles`` and ``#permissions``, so the predicates agree with the
+  accessors for object-backed users exposing ``#roles`` and for ``Set`` or
+  other non-Array collections. A user model defining its own ``#has_role?`` or
+  ``#has_permission?`` is still consulted first.

--- a/changelog.d/20260904_150900_delano_api_key_strategy_resolver.rst
+++ b/changelog.d/20260904_150900_delano_api_key_strategy_resolver.rst
@@ -12,8 +12,14 @@ Added
   key as a non-empty ``String``; a ``nil`` or ``false`` return is the same
   terminal ``Invalid API key`` failure as a static mismatch, exceptions from
   the resolver propagate rather than becoming a 401 or a success, and the
-  result still carries ``api_key_fingerprint`` in its metadata while the raw
-  key never reaches the result, environment, session, or logs.
+  result still carries ``api_key_fingerprint`` in its metadata. The strategy
+  itself never places the raw key in the result; ``user`` is the resolver's
+  return value verbatim and is exposed to handlers through
+  ``env['otto.strategy_result']``, so the resolver must return the account
+  behind the key rather than an object that stores the key. A resolver that returns the presented key string itself
+  as the user raises ``ArgumentError``. Static ``api_keys:`` are copied and
+  frozen at construction, so mutating the caller's strings afterwards no
+  longer changes which credentials are accepted.
 
 - ``APIKeyStrategy.digest(key)`` returns the full SHA-256 hex digest of a key.
   The documented resolver pattern stores digests instead of raw keys and looks

--- a/changelog.d/20260904_150900_delano_api_key_strategy_resolver.rst
+++ b/changelog.d/20260904_150900_delano_api_key_strategy_resolver.rst
@@ -1,0 +1,21 @@
+Added
+-----
+
+- ``Otto::Security::Authentication::Strategies::APIKeyStrategy`` accepts a
+  resolver as an alternative to a static key list, so an application can look
+  a presented key up in a database, repository, or cache and return the
+  account behind it. Pass a block, ``APIKeyStrategy.new { |key| ... }``, or
+  any object that responds to ``#call`` as ``resolver:``, e.g.
+  ``APIKeyStrategy.new(resolver: repo.method(:find_by_key))``. Exactly one of
+  ``api_keys:``, ``resolver:``, or a block must be given; passing none or more
+  than one raises ``ArgumentError``. The resolver receives only the presented
+  key as a non-empty ``String``; a ``nil`` or ``false`` return is the same
+  terminal ``Invalid API key`` failure as a static mismatch, exceptions from
+  the resolver propagate rather than becoming a 401 or a success, and the
+  result still carries ``api_key_fingerprint`` in its metadata while the raw
+  key never reaches the result, environment, session, or logs.
+
+- ``APIKeyStrategy.digest(key)`` returns the full SHA-256 hex digest of a key.
+  The documented resolver pattern stores digests instead of raw keys and looks
+  up by ``APIKeyStrategy.digest(presented_key)``, which is constant-time by
+  construction and keeps raw credentials out of the database.

--- a/changelog.d/20260904_150900_delano_api_key_strategy_resolver.rst
+++ b/changelog.d/20260904_150900_delano_api_key_strategy_resolver.rst
@@ -1,27 +1,11 @@
 Added
 -----
 
-- ``Otto::Security::Authentication::Strategies::APIKeyStrategy`` accepts a
-  resolver as an alternative to a static key list, so an application can look
-  a presented key up in a database, repository, or cache and return the
-  account behind it. Pass a block, ``APIKeyStrategy.new { |key| ... }``, or
-  any object that responds to ``#call`` as ``resolver:``, e.g.
-  ``APIKeyStrategy.new(resolver: repo.method(:find_by_key))``. Exactly one of
-  ``api_keys:``, ``resolver:``, or a block must be given; passing none or more
-  than one raises ``ArgumentError``. The resolver receives only the presented
-  key as a non-empty ``String``; a ``nil`` or ``false`` return is the same
-  terminal ``Invalid API key`` failure as a static mismatch, exceptions from
-  the resolver propagate rather than becoming a 401 or a success, and the
-  result still carries ``api_key_fingerprint`` in its metadata. The strategy
-  itself never places the raw key in the result; ``user`` is the resolver's
-  return value verbatim and is exposed to handlers through
-  ``env['otto.strategy_result']``, so the resolver must return the account
-  behind the key rather than an object that stores the key. A resolver that returns the presented key string itself
-  as the user raises ``ArgumentError``. Static ``api_keys:`` are copied and
-  frozen at construction, so mutating the caller's strings afterwards no
-  longer changes which credentials are accepted.
+- ``APIKeyStrategy`` now accepts a block or ``resolver:`` callable instead of a
+  static ``api_keys:`` list, enabling database-, repository-, or cache-backed
+  key lookup. The resolved account becomes the authenticated user.
 
-- ``APIKeyStrategy.digest(key)`` returns the full SHA-256 hex digest of a key.
-  The documented resolver pattern stores digests instead of raw keys and looks
-  up by ``APIKeyStrategy.digest(presented_key)``, which is constant-time by
-  construction and keeps raw credentials out of the database.
+- ``APIKeyStrategy.digest(key)`` returns a full SHA-256 hex digest for stores
+  that look up generated API keys by digest. See
+  ``docs/guides/authentication.md`` for the resolver contract and credential
+  storage guidance.

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -50,10 +50,12 @@ Otto::Security::Authentication::Strategies::APIKeyStrategy.new(
 )
 ```
 
-The authenticated result never carries the raw key. `metadata[:api_key_fingerprint]`
+The strategy never places the raw key in the result. `metadata[:api_key_fingerprint]`
 (and, for the static list, `user[:api_key_fingerprint]`) holds a truncated
 SHA-256 digest of the presented key, so audit logs can correlate requests
-without recording the credential.
+without recording the credential. With a resolver, `user` is whatever the
+resolver returns, so that guarantee covers only the strategy's own fields; see
+the rules below.
 
 ### Resolve keys from a database
 
@@ -98,9 +100,15 @@ The rules are the same in every form:
 - Exceptions from the resolver propagate. The strategy does not rescue them,
   so a database outage surfaces as an error rather than a silent 401, and can
   never become a success.
-- Whatever the resolver returns becomes `user` in the result, and
-  `api_key_fingerprint` is still set in the result metadata. The raw key never
-  reaches the result, the Rack environment, the session, or the logs.
+- Whatever the resolver returns becomes `user` in the result, verbatim, and
+  `api_key_fingerprint` is still set in the result metadata. The strategy
+  itself never places the raw key in the result, but the result is stored in
+  `env['otto.strategy_result']` and exposed to handlers, so anything the
+  application serializes or logs from it carries `user`. It is the resolver's
+  responsibility not to return an object that carries the raw key. Return the
+  account, not the `ApiKey` row that stores the key, and store digests. A
+  resolver that returns the presented key string itself as the user raises
+  `ArgumentError`.
 
 The strategy cannot make a black-box lookup constant-time. Store SHA-256
 digests rather than raw keys and look up by `APIKeyStrategy.digest(key)`, as

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -49,6 +49,10 @@ Otto::Security::Authentication::Strategies::APIKeyStrategy.new(
 )
 ```
 
+The authenticated result never carries the raw key. `user[:api_key_fingerprint]`
+holds a truncated SHA-256 digest of the presented key, so audit logs can
+correlate requests without recording the credential.
+
 A strategy implements `authenticate(env, requirement)` and returns a
 `StrategyResult`, `AuthFailure`, or `AuthorizationFailure`. Subclass
 `Otto::Security::Authentication::AuthStrategy` to use its `success`, `failure`,
@@ -201,7 +205,7 @@ Otto includes these strategy classes as implementation starting points:
 - `SessionStrategy` — reads a configured key from `env['rack.session']`.
 - `APIKeyStrategy` — checks the configured header; the query parameter is opt-in
   via `param_name:`. `api_keys:` is required and must be non-empty; a rejected
-  key is a terminal failure.
+  key is a terminal failure, and the result exposes only a key fingerprint.
 - `RoleStrategy` — checks session roles against allowed roles or a
   colon-qualified requirement.
 - `PermissionStrategy` — checks application-provided permission data.

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -127,6 +127,19 @@ fail-closed changes in #256 make that existing convenience safe by default;
 they do not establish that all Otto API-key authentication should use
 boot-loaded lists.
 
+The shape is deliberate and has precedent. A key list loaded once at start,
+checked with a constant-time comparison, is what the Rails guides show for
+`authenticate_or_request_with_http_token` (a token from the environment,
+compared with `ActiveSupport::SecurityUtils.secure_compare`), what the
+Kubernetes API server does with its `--token-auth-file` CSV, and what Traefik
+and nginx do with their basic-auth user lists. Warden and Devise token
+examples, and the common Sinatra `before` filter that compares a header
+against `ENV['API_KEY']`, are the same pattern. All of them share the
+properties here: no source configured means no access, the set of keys is
+fixed for the life of the process, and a mismatch is final. The resolver form
+is the escape hatch for the dynamic case those tools also leave to an external
+store.
+
 In either form, the strategy has no native support for:
 
 - Runtime addition or immediate revocation.

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -34,7 +34,10 @@ otto.add_auth_strategy(
 when none is given, or when an `api_keys:` list normalizes to empty (`[]` or
 only blank strings), so the strategy enforces the check the example above makes
 explicit. A request that presents a key is accepted only when that key matches a
-configured key under constant-time comparison; an empty credential is rejected.
+configured key under constant-time comparison. Both sides are reduced to
+fixed-width SHA-256 digests before comparing, so the check never short-circuits
+on a length mismatch and configured key lengths are not observable. An empty
+credential is rejected.
 A presented-but-invalid key is a terminal failure, so it aborts the strategy
 chain instead of falling through to a later strategy in a multi-strategy `OR`
 route.

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -29,9 +29,10 @@ otto.add_auth_strategy(
 )
 ```
 
-`APIKeyStrategy` fails closed. Its constructor requires `api_keys:` and raises
-`ArgumentError` when the normalized key list is empty (`nil`, `[]`, or only
-blank strings), so the strategy enforces the check the example above makes
+`APIKeyStrategy` fails closed. Its constructor requires exactly one key source
+(`api_keys:`, `resolver:`, or a block; see below) and raises `ArgumentError`
+when none is given, or when an `api_keys:` list normalizes to empty (`[]` or
+only blank strings), so the strategy enforces the check the example above makes
 explicit. A request that presents a key is accepted only when that key matches a
 configured key under constant-time comparison; an empty credential is rejected.
 A presented-but-invalid key is a terminal failure, so it aborts the strategy
@@ -49,9 +50,95 @@ Otto::Security::Authentication::Strategies::APIKeyStrategy.new(
 )
 ```
 
-The authenticated result never carries the raw key. `user[:api_key_fingerprint]`
-holds a truncated SHA-256 digest of the presented key, so audit logs can
-correlate requests without recording the credential.
+The authenticated result never carries the raw key. `metadata[:api_key_fingerprint]`
+(and, for the static list, `user[:api_key_fingerprint]`) holds a truncated
+SHA-256 digest of the presented key, so audit logs can correlate requests
+without recording the credential.
+
+### Resolve keys from a database
+
+A static list is the simple default. When keys live in a database, a
+repository, or a cache, give the strategy a resolver instead. The resolver
+receives the presented key and returns the account behind it, or `nil` when
+there is none:
+
+```ruby
+APIKeyStrategy = Otto::Security::Authentication::Strategies::APIKeyStrategy
+
+otto.add_auth_strategy(
+  'api_key',
+  APIKeyStrategy.new do |presented_key|
+    ApiKey.find_by(digest: APIKeyStrategy.digest(presented_key))&.account
+  end
+)
+```
+
+Anything that responds to `#call` works as well, passed as `resolver:`:
+
+```ruby
+APIKeyStrategy.new(resolver: repo.method(:find_by_key))
+APIKeyStrategy.new(resolver: ->(key) { KeyCache.fetch(APIKeyStrategy.digest(key)) })
+```
+
+The rules are the same in every form:
+
+- Exactly one source: `api_keys:`, `resolver:`, or a block. Passing none, or
+  more than one, raises `ArgumentError`, as does a `resolver:` that does not
+  respond to `#call`.
+- The resolver receives only the presented key, as a non-empty `String`, and
+  nothing else. The blank check and the non-String rejection run before it, so
+  a missing header is still the non-terminal `No API key provided` failure and
+  the resolver is never asked about it.
+- A `nil` or `false` return is a terminal `Invalid API key` failure, identical
+  to a static mismatch. It aborts the strategy chain with a 401. Every other
+  return value is a match, including empty containers: a `where(...)` relation,
+  an empty Array from `select`, or `{}` from a cache miss is truthy and
+  authenticates every presented key. Return one record (`find_by`, `first`) or
+  `nil`.
+- Exceptions from the resolver propagate. The strategy does not rescue them,
+  so a database outage surfaces as an error rather than a silent 401, and can
+  never become a success.
+- Whatever the resolver returns becomes `user` in the result, and
+  `api_key_fingerprint` is still set in the result metadata. The raw key never
+  reaches the result, the Rack environment, the session, or the logs.
+
+The strategy cannot make a black-box lookup constant-time. Store SHA-256
+digests rather than raw keys and look up by `APIKeyStrategy.digest(key)`, as
+in the example above. The digest step is constant-time by construction, the
+lookup that follows is an exact match on a fixed-width value, and a database
+dump of high-entropy keys (generate them with `SecureRandom`, 32 bytes or
+more) does not expose usable credentials. Unsalted SHA-256 is not a password
+hash, so do not accept user-chosen keys. `APIKeyStrategy.digest(key)` returns
+the full hex digest; the fingerprint in the result is its first 12 characters.
+
+### What `APIKeyStrategy` does not provide
+
+`APIKeyStrategy` is a conventional small static-allowlist authenticator
+included as a low-dependency convenience and reference implementation. The
+fail-closed changes in #256 make that existing convenience safe by default;
+they do not establish that all Otto API-key authentication should use
+boot-loaded lists.
+
+In either form, the strategy has no native support for:
+
+- Runtime addition or immediate revocation.
+- Expiration.
+- Per-client roles or scopes.
+- Ownership and descriptive metadata.
+- Usage quotas.
+- A management API.
+- Persisted audit history.
+- Hashed verifier storage.
+
+With a static list, none of these exist: changing the set of valid keys means
+restarting the process, and every key is equal. With a resolver, the first
+four and the last become the application's key store's responsibility. The
+resolver decides whether a key is still valid, and whatever it returns is the
+`user` the handler sees, so roles, scopes, ownership, and expiry live on that
+record. Quotas, a management API, and audit history remain outside the
+strategy entirely. An application that needs them should build a custom
+`AuthStrategy` around its own key model, using `APIKeyStrategy` as the
+reference for header handling, terminal failures, and fingerprinting.
 
 A strategy implements `authenticate(env, requirement)` and returns a
 `StrategyResult`, `AuthFailure`, or `AuthorizationFailure`. Subclass
@@ -204,8 +291,9 @@ Otto includes these strategy classes as implementation starting points:
 
 - `SessionStrategy` — reads a configured key from `env['rack.session']`.
 - `APIKeyStrategy` — checks the configured header; the query parameter is opt-in
-  via `param_name:`. `api_keys:` is required and must be non-empty; a rejected
-  key is a terminal failure, and the result exposes only a key fingerprint.
+  via `param_name:`. Keys come from a non-empty `api_keys:` list, a `resolver:`
+  callable, or a block that looks the presented key up; a rejected key is a
+  terminal failure, and the result exposes only a key fingerprint.
 - `RoleStrategy` — checks session roles against allowed roles or a
   colon-qualified requirement.
 - `PermissionStrategy` — checks application-provided permission data.

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -38,6 +38,17 @@ A presented-but-invalid key is a terminal failure, so it aborts the strategy
 chain instead of falling through to a later strategy in a multi-strategy `OR`
 route.
 
+The strategy reads the `X-API-Key` header only. The query/form parameter path is
+opt-in via `param_name:`, because a key placed in a URL is captured by access
+logs, proxies, and browser history:
+
+```ruby
+Otto::Security::Authentication::Strategies::APIKeyStrategy.new(
+  api_keys: api_keys,
+  param_name: 'api_key' # caution: keys in URLs are logged; prefer the header
+)
+```
+
 A strategy implements `authenticate(env, requirement)` and returns a
 `StrategyResult`, `AuthFailure`, or `AuthorizationFailure`. Subclass
 `Otto::Security::Authentication::AuthStrategy` to use its `success`, `failure`,
@@ -188,9 +199,9 @@ its own `StrategyResult`. The result is immutable.
 Otto includes these strategy classes as implementation starting points:
 
 - `SessionStrategy` — reads a configured key from `env['rack.session']`.
-- `APIKeyStrategy` — checks the configured header first and then a query
-  parameter. `api_keys:` is required and must be non-empty; a rejected key is a
-  terminal failure.
+- `APIKeyStrategy` — checks the configured header; the query parameter is opt-in
+  via `param_name:`. `api_keys:` is required and must be non-empty; a rejected
+  key is a terminal failure.
 - `RoleStrategy` — checks session roles against allowed roles or a
   colon-qualified requirement.
 - `PermissionStrategy` — checks application-provided permission data.

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -36,8 +36,8 @@ only blank strings), so the strategy enforces the check the example above makes
 explicit. A request that presents a key is accepted only when that key matches a
 configured key under constant-time comparison. Both sides are reduced to
 fixed-width SHA-256 digests before comparing, so the check never short-circuits
-on a length mismatch and configured key lengths are not observable. An empty
-credential is rejected.
+on a length mismatch and configured key lengths are not observable. A blank
+credential (empty or whitespace-only) is rejected as missing.
 A presented-but-invalid key is a terminal failure, so it aborts the strategy
 chain instead of falling through to a later strategy in a multi-strategy `OR`
 route.
@@ -90,10 +90,11 @@ The rules are the same in every form:
 - Exactly one source: `api_keys:`, `resolver:`, or a block. Passing none, or
   more than one, raises `ArgumentError`, as does a `resolver:` that does not
   respond to `#call`.
-- The resolver receives only the presented key, as a non-empty `String`, and
-  nothing else. The blank check and the non-String rejection run before it, so
-  a missing header is still the non-terminal `No API key provided` failure and
-  the resolver is never asked about it.
+- The resolver receives only the presented key, as a non-blank `String`, and
+  nothing else. The blank check (empty or whitespace-only) and the non-String
+  rejection run before it, so a missing or blank header is still the
+  non-terminal `No API key provided` failure and the resolver is never asked
+  about it.
 - A `nil` or `false` return is a terminal `Invalid API key` failure, identical
   to a static mismatch. It aborts the strategy chain with a 401. Every other
   return value is a match, including empty containers: a `where(...)` relation,

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -29,8 +29,14 @@ otto.add_auth_strategy(
 )
 ```
 
-`APIKeyStrategy` accepts any nonblank key when its configured key list is empty,
-so never register it with an empty set. Fail startup instead, as above.
+`APIKeyStrategy` fails closed. Its constructor requires `api_keys:` and raises
+`ArgumentError` when the normalized key list is empty (`nil`, `[]`, or only
+blank strings), so the strategy enforces the check the example above makes
+explicit. A request that presents a key is accepted only when that key matches a
+configured key under constant-time comparison; an empty credential is rejected.
+A presented-but-invalid key is a terminal failure, so it aborts the strategy
+chain instead of falling through to a later strategy in a multi-strategy `OR`
+route.
 
 A strategy implements `authenticate(env, requirement)` and returns a
 `StrategyResult`, `AuthFailure`, or `AuthorizationFailure`. Subclass
@@ -183,7 +189,8 @@ Otto includes these strategy classes as implementation starting points:
 
 - `SessionStrategy` — reads a configured key from `env['rack.session']`.
 - `APIKeyStrategy` — checks the configured header first and then a query
-  parameter; configure a non-empty key set for actual validation.
+  parameter. `api_keys:` is required and must be non-empty; a rejected key is a
+  terminal failure.
 - `RoleStrategy` — checks session roles against allowed roles or a
   colon-qualified requirement.
 - `PermissionStrategy` — checks application-provided permission data.

--- a/docs/guides/configuration_freezing.md
+++ b/docs/guides/configuration_freezing.md
@@ -52,7 +52,7 @@ otto = Otto.new('routes.txt')
 
 # Step 2: Configure after initialization (BEFORE first request)
 otto.add_auth_strategy('session', SessionStrategy.new(session_key: 'user_id'))
-otto.add_auth_strategy('api_key', APIKeyStrategy.new(api_keys: ENV['API_KEYS']))
+otto.add_auth_strategy('api_key', APIKeyStrategy.new(api_keys: ENV.fetch('API_KEYS').split(',')))
 otto.enable_csrf_protection!
 otto.use CustomMiddleware
 

--- a/docs/guides/testing-guide.md
+++ b/docs/guides/testing-guide.md
@@ -479,7 +479,7 @@ RSpec.describe Otto::Security::Authentication::Strategies::APIKeyStrategy do
 
         expect(result).to be_a(Otto::Security::Authentication::StrategyResult)
         expect(result.authenticated?).to be true
-        expect(result.user[:api_key_fingerprint]).to eq(Digest::SHA256.hexdigest('key_123')[0, 12])
+        expect(result.user[:api_key_fingerprint]).to eq(described_class.digest('key_123')[0, 12])
       end
     end
 

--- a/docs/guides/testing-guide.md
+++ b/docs/guides/testing-guide.md
@@ -479,7 +479,7 @@ RSpec.describe Otto::Security::Authentication::Strategies::APIKeyStrategy do
 
         expect(result).to be_a(Otto::Security::Authentication::StrategyResult)
         expect(result.authenticated?).to be true
-        expect(result.user[:api_key]).to eq('key_123')
+        expect(result.user[:api_key_fingerprint]).to eq(Digest::SHA256.hexdigest('key_123')[0, 12])
       end
     end
 

--- a/docs/guides/testing-guide.md
+++ b/docs/guides/testing-guide.md
@@ -467,7 +467,8 @@ require 'spec_helper'
 
 RSpec.describe Otto::Security::Authentication::Strategies::APIKeyStrategy do
   let(:valid_keys) { ['key_123', 'key_456'] }
-  let(:strategy) { described_class.new(api_keys: valid_keys) }
+  # param_name: is opt-in; the default reads the X-API-Key header only.
+  let(:strategy) { described_class.new(api_keys: valid_keys, param_name: 'api_key') }
 
   describe '#authenticate' do
     context 'with valid API key in header' do

--- a/docs/migrating/v2.0.0.md
+++ b/docs/migrating/v2.0.0.md
@@ -78,7 +78,7 @@ Authentication has moved from middleware to handler level via RouteAuthWrapper.
 ```ruby
 # Add strategies (before first request)
 otto.add_auth_strategy('session', SessionStrategy.new)
-otto.add_auth_strategy('apikey', APIKeyStrategy.new)
+otto.add_auth_strategy('apikey', APIKeyStrategy.new(api_keys: ENV.fetch('API_KEYS').split(',')))
 
 # Configure login redirect path (optional)
 otto.auth_config[:login_path] = '/auth/login'  # Default: '/signin'

--- a/docs/reference/authentication.md
+++ b/docs/reference/authentication.md
@@ -114,16 +114,18 @@ end
 ### Session Strategy with Roles
 
 ```ruby
-class SessionStrategy
+class RoleAwareSessionStrategy < Otto::Security::Authentication::AuthStrategy
   def authenticate(env, _requirement)
     session = env['rack.session']
     return failure('No session') unless session
 
     user_id = session['user_id']
+    # A session cookie is an ambient credential: leave this non-terminal so a
+    # later strategy in an OR chain can still run.
     return failure('Not authenticated') unless user_id
 
     # Include roles in the user data
-    StrategyResult.success(
+    success(
       user: {
         id: user_id,
         roles: session['user_roles'] || []  # Accessible as user[:roles]
@@ -131,39 +133,44 @@ class SessionStrategy
       session: session
     )
   end
-
-  private
-
-  def failure(message)
-    StrategyResult.failure(message: message, redirect_to: '/login')
-  end
 end
 ```
+
+Strategies do not choose a redirect. `RouteAuthWrapper` turns a `failure` into
+a 401 for API clients and, for HTML requests, a 302 to
+`otto.auth_config[:login_path]` (default `/signin`).
 
 ### API Key Strategy
 
+Otto ships `Otto::Security::Authentication::Strategies::APIKeyStrategy`; see
+that class for the real implementation. A custom key-backed strategy follows the
+same shape:
+
 ```ruby
-class APIKeyStrategy
+class DatabaseAPIKeyStrategy < Otto::Security::Authentication::AuthStrategy
   def authenticate(env, _requirement)
     api_key = env['HTTP_X_API_KEY'] || extract_from_params(env)
-    return failure('Missing API key') unless api_key
+    # No credential presented: non-terminal, so a later strategy may still run.
+    return failure('Missing API key') if api_key.nil? || api_key.empty?
 
     user = User.find_by_api_key(api_key)
-    return failure('Invalid API key') unless user
+    # A credential WAS presented and rejected: terminal, fail closed with 401.
+    return failure('Invalid API key', terminal: true) unless user
 
-    StrategyResult.success(
-      user: { id: user.id, roles: user.roles },
-      metadata: { auth_method: 'api_key' }
-    )
+    success(user: { id: user.id, roles: user.roles }, auth_method: 'api_key')
   end
 
   private
 
-  def failure(message)
-    StrategyResult.failure(message: message, status: 401)
+  def extract_from_params(env)
+    Otto::Request.new(env).params['api_key']
   end
 end
 ```
+
+`success`, `failure`, and `authorization_failure` are protected helpers on
+`AuthStrategy`; `failure` maps to 401 (or the login redirect above, for HTML
+requests) and `authorization_failure` to 403.
 
 ## Complex Authorization Example
 

--- a/docs/reference/authentication.md
+++ b/docs/reference/authentication.md
@@ -146,7 +146,8 @@ Otto ships `Otto::Security::Authentication::Strategies::APIKeyStrategy`; see
 that class for the real implementation. It reads the `X-API-Key` header only
 unless you pass `param_name: 'api_key'` to also accept the credential as a query
 or form parameter — keys in URLs are recorded by access logs, proxies, and
-browser history. A custom key-backed strategy follows the
+browser history. Its result carries `user[:api_key_fingerprint]` (a truncated
+SHA-256 digest), never the key itself. A custom key-backed strategy follows the
 same shape:
 
 ```ruby

--- a/docs/reference/authentication.md
+++ b/docs/reference/authentication.md
@@ -145,10 +145,58 @@ a 401 for API clients and, for HTML requests, a 302 to
 Otto ships `Otto::Security::Authentication::Strategies::APIKeyStrategy`; see
 that class for the real implementation. It reads the `X-API-Key` header only
 unless you pass `param_name: 'api_key'` to also accept the credential as a query
-or form parameter — keys in URLs are recorded by access logs, proxies, and
-browser history. Its result carries `user[:api_key_fingerprint]` (a truncated
-SHA-256 digest), never the key itself. A custom key-backed strategy follows the
-same shape:
+or form parameter; keys in URLs are recorded by access logs, proxies, and
+browser history. Its result carries `metadata[:api_key_fingerprint]` (a
+truncated SHA-256 digest), never the key itself; with a static `api_keys:` list
+`user` is a Hash carrying the same fingerprint, and with a resolver `user` is
+whatever the resolver returned.
+
+Keys come from exactly one of three sources. `api_keys:` takes a static list
+and matches under constant-time comparison. A block, or a `resolver:` that
+responds to `#call`, looks the presented key up and returns the account behind
+it:
+
+```ruby
+APIKeyStrategy = Otto::Security::Authentication::Strategies::APIKeyStrategy
+
+# Static list
+APIKeyStrategy.new(api_keys: ENV.fetch('API_KEYS').split(','))
+
+# Block resolver, looking up by digest so raw keys never touch the database
+APIKeyStrategy.new do |presented_key|
+  ApiKey.find_by(digest: APIKeyStrategy.digest(presented_key))&.account
+end
+
+# Callable resolver
+APIKeyStrategy.new(resolver: repo.method(:find_by_key))
+```
+
+Passing none of the three, or more than one, raises `ArgumentError`. The
+resolver receives only the presented key as a non-empty `String`; a missing
+credential is still the non-terminal `No API key provided` failure and never
+reaches the resolver. A `nil` or `false` return is the terminal
+`Invalid API key` failure (401), the same as a static mismatch; any other
+value, including an empty relation, Array, or Hash, is a match, so return one
+record or `nil`, not a `where(...)` relation. Exceptions from
+the resolver propagate rather than turning into a 401 or a success. The
+returned value becomes `user`, and `api_key_fingerprint` is set in the metadata
+regardless. `APIKeyStrategy.digest(key)` is the full SHA-256 hex digest; the
+fingerprint is its first 12 characters.
+
+The strategy cannot make a black-box lookup constant-time. Store SHA-256
+digests and look up by `APIKeyStrategy.digest(presented_key)`, as above.
+
+`APIKeyStrategy` is a small static-allowlist authenticator shipped as a
+low-dependency convenience and reference implementation. It has no native
+support for runtime addition or revocation, expiration, per-client roles or
+scopes, ownership or descriptive metadata, usage quotas, a management API,
+persisted audit history, or hashed verifier storage. The resolver form hands
+validity, roles, and metadata to the application's key store; the rest stay
+outside the strategy. See the
+[authentication guide](../guides/authentication.md#what-apikeystrategy-does-not-provide).
+
+A custom key-backed strategy that needs more than the resolver offers (for
+example, consulting `env`) follows the same shape:
 
 ```ruby
 class DatabaseAPIKeyStrategy < Otto::Security::Authentication::AuthStrategy
@@ -157,7 +205,8 @@ class DatabaseAPIKeyStrategy < Otto::Security::Authentication::AuthStrategy
     # No credential presented: non-terminal, so a later strategy may still run.
     return failure('Missing API key') if api_key.nil? || api_key.empty?
 
-    user = User.find_by_api_key(api_key)
+    digest = Otto::Security::Authentication::Strategies::APIKeyStrategy.digest(api_key)
+    user = User.find_by(api_key_digest: digest)
     # A credential WAS presented and rejected: terminal, fail closed with 401.
     return failure('Invalid API key', terminal: true) unless user
 

--- a/docs/reference/authentication.md
+++ b/docs/reference/authentication.md
@@ -143,7 +143,10 @@ a 401 for API clients and, for HTML requests, a 302 to
 ### API Key Strategy
 
 Otto ships `Otto::Security::Authentication::Strategies::APIKeyStrategy`; see
-that class for the real implementation. A custom key-backed strategy follows the
+that class for the real implementation. It reads the `X-API-Key` header only
+unless you pass `param_name: 'api_key'` to also accept the credential as a query
+or form parameter — keys in URLs are recorded by access logs, proxies, and
+browser history. A custom key-backed strategy follows the
 same shape:
 
 ```ruby

--- a/docs/reference/authentication.md
+++ b/docs/reference/authentication.md
@@ -146,10 +146,10 @@ Otto ships `Otto::Security::Authentication::Strategies::APIKeyStrategy`; see
 that class for the real implementation. It reads the `X-API-Key` header only
 unless you pass `param_name: 'api_key'` to also accept the credential as a query
 or form parameter; keys in URLs are recorded by access logs, proxies, and
-browser history. Its result carries `metadata[:api_key_fingerprint]` (a
-truncated SHA-256 digest), never the key itself; with a static `api_keys:` list
-`user` is a Hash carrying the same fingerprint, and with a resolver `user` is
-whatever the resolver returned.
+browser history. The strategy never places the raw key in the result; its own
+field is `metadata[:api_key_fingerprint]` (a truncated SHA-256 digest). With a
+static `api_keys:` list `user` is a Hash carrying the same fingerprint, and
+with a resolver `user` is whatever the resolver returned, verbatim.
 
 Keys come from exactly one of three sources. `api_keys:` takes a static list
 and matches under constant-time comparison. A block, or a `resolver:` that
@@ -180,8 +180,13 @@ value, including an empty relation, Array, or Hash, is a match, so return one
 record or `nil`, not a `where(...)` relation. Exceptions from
 the resolver propagate rather than turning into a 401 or a success. The
 returned value becomes `user`, and `api_key_fingerprint` is set in the metadata
-regardless. `APIKeyStrategy.digest(key)` is the full SHA-256 hex digest; the
-fingerprint is its first 12 characters.
+regardless. The result is stored in `env['otto.strategy_result']` and exposed
+to handlers, so anything the application serializes or logs from it carries
+`user`; the resolver must not return an object that carries the raw key:
+return the account, not the `ApiKey` row that stores the key, and store
+digests. Returning the presented key string itself as the user raises
+`ArgumentError`. `APIKeyStrategy.digest(key)` is the full SHA-256 hex digest;
+the fingerprint is its first 12 characters.
 
 The strategy cannot make a black-box lookup constant-time. Store SHA-256
 digests and look up by `APIKeyStrategy.digest(presented_key)`, as above.

--- a/docs/reference/authentication.md
+++ b/docs/reference/authentication.md
@@ -9,7 +9,7 @@ Authentication strategies are configured during Otto initialization:
 ```ruby
 otto = Otto.new('routes.txt')
 otto.add_auth_strategy('session', SessionStrategy.new)
-otto.add_auth_strategy('apikey', APIKeyStrategy.new)
+otto.add_auth_strategy('apikey', APIKeyStrategy.new(api_keys: ENV.fetch('API_KEYS').split(',')))
 otto.add_auth_strategy('oauth', OAuthStrategy.new)
 ```
 

--- a/lib/otto/security/authentication/route_auth_wrapper/role_authorization.rb
+++ b/lib/otto/security/authentication/route_auth_wrapper/role_authorization.rb
@@ -73,9 +73,14 @@ class Otto
           #
           # Supports multiple role sources in order of precedence:
           # 1. result.user_roles (Array)
-          # 2. result.user[:roles] (Array)
-          # 3. result.user['roles'] (Array)
+          # 2. result.user[:roles] / result.user['roles'] (Hash user)
+          # 3. result.user.roles, then result.user.role (object-backed user:
+          #    ORM model, PORO, Data/Struct); #roles must return role names
           # 4. result.metadata[:user_roles] (Array)
+          #
+          # A user object that is neither a Hash nor responds to `#roles`/`#role`
+          # contributes no roles rather than raising, so authorization yields a
+          # deny result instead of a NoMethodError.
           #
           # @param result [StrategyResult] Authentication result
           # @return [Array<String>] Array of role strings
@@ -83,10 +88,17 @@ class Otto
             # Try direct user_roles accessor (e.g., from RoleStrategy)
             return Array(result.user_roles) if result.respond_to?(:user_roles) && result.user_roles
 
-            # Try user hash/object with roles
-            if result.user
-              roles = result.user[:roles] || result.user['roles']
+            # Hash access first (unchanged behaviour), then object-backed users
+            user = result.user
+            if user.is_a?(Hash)
+              roles = user[:roles] || user['roles']
               return Array(roles) if roles
+            elsif user.respond_to?(:roles)
+              roles = user.roles
+              return Array(roles).map(&:to_s) if roles
+            elsif user.respond_to?(:role)
+              role = user.role
+              return [role.to_s] if role
             end
 
             # Try metadata

--- a/lib/otto/security/authentication/route_auth_wrapper/role_authorization.rb
+++ b/lib/otto/security/authentication/route_auth_wrapper/role_authorization.rb
@@ -93,12 +93,17 @@ class Otto
             if user.is_a?(Hash)
               roles = user[:roles] || user['roles']
               return Array(roles) if roles
-            elsif user.respond_to?(:roles)
-              roles = user.roles
-              return Array(roles).map(&:to_s) if roles
-            elsif user.respond_to?(:role)
-              role = user.role
-              return [role.to_s] if role
+            else
+              # Same fallback as StrategyResult#roles: an empty or nil #roles
+              # falls through to a singular #role.
+              if user.respond_to?(:roles)
+                roles = Array(user.roles).map(&:to_s)
+                return roles unless roles.empty?
+              end
+              if user.respond_to?(:role)
+                role = user.role
+                return [role.to_s] if role
+              end
             end
 
             # Try metadata

--- a/lib/otto/security/authentication/strategies/api_key_strategy.rb
+++ b/lib/otto/security/authentication/strategies/api_key_strategy.rb
@@ -173,7 +173,10 @@ class Otto
             # strategy only ever receives a shallow freeze from config
             # finalization, so a caller mutating its key after boot would
             # otherwise change which credential is accepted.
-            keys = Array(api_keys).map { |key| key.to_s.dup.freeze }.reject(&:empty?).freeze
+            # Keys are kept verbatim, but a whitespace-only value is a blank
+            # configuration (`API_KEYS=" "`), not a credential: reject it so the
+            # fail-closed startup guarantee covers it.
+            keys = Array(api_keys).map { |key| key.to_s.dup.freeze }.reject { |key| key.strip.empty? }.freeze
             if keys.empty?
               raise ArgumentError,
                     'APIKeyStrategy requires at least one non-empty API key ' \

--- a/lib/otto/security/authentication/strategies/api_key_strategy.rb
+++ b/lib/otto/security/authentication/strategies/api_key_strategy.rb
@@ -43,8 +43,16 @@ class Otto
         # up by {APIKeyStrategy.digest}, which is constant-time by construction
         # and keeps raw keys out of the database.
         #
-        # The result never carries the raw key: it exposes only a short SHA-256
-        # fingerprint, so the secret does not reach env, session, or logs.
+        # The strategy never places the raw key in the result itself: the only
+        # strategy-generated field derived from the key is a short SHA-256
+        # fingerprint. With a resolver, `user` is whatever the resolver returns,
+        # verbatim; the result is stored in env['otto.strategy_result'] and
+        # exposed to handlers, so anything the application serializes or logs
+        # from it carries `user`. It is the resolver's responsibility not to
+        # return an object that holds the raw key: return the account, not the
+        # ApiKey row that stores the key, and store digests. A resolver that
+        # returns the presented key String itself as the user raises
+        # ArgumentError.
         #
         # The query/form parameter path is opt-in (`param_name:`), because keys in
         # URLs are recorded by access logs, proxies, and browser history.
@@ -118,8 +126,17 @@ class Otto
             user = @resolver.call(api_key)
             return failure('Invalid API key', terminal: true) unless user
 
-            # Identify the credential by a non-reversible fingerprint. The raw key
-            # must not reach the result, since it flows into env, session, and logs.
+            # The most likely naive misuse: `->(k) { k if keys.include?(k) }`.
+            # Fail loud before the key can reach the result and env.
+            if user.is_a?(String) && Rack::Utils.secure_compare(user, api_key)
+              raise ArgumentError,
+                    'APIKeyStrategy resolver returned the presented key as the user; ' \
+                    'return the account behind the key, not the key'
+            end
+
+            # Identify the credential by a non-reversible fingerprint. The strategy
+            # itself never places the raw key in the result; `user` is the
+            # resolver's return value, verbatim (see class docs).
             success(user: user,
                     auth_method: 'api_key',
                     api_key_fingerprint: key_fingerprint(api_key))
@@ -152,7 +169,11 @@ class Otto
           # Wrap a static key list in a resolver performing a constant-time,
           # non-short-circuiting membership check.
           def static_resolver(api_keys)
-            keys = Array(api_keys).map(&:to_s).reject(&:empty?).freeze
+            # Own frozen copies: `to_s` returns the caller's String, and the
+            # strategy only ever receives a shallow freeze from config
+            # finalization, so a caller mutating its key after boot would
+            # otherwise change which credential is accepted.
+            keys = Array(api_keys).map { |key| key.to_s.dup.freeze }.reject(&:empty?).freeze
             if keys.empty?
               raise ArgumentError,
                     'APIKeyStrategy requires at least one non-empty API key ' \

--- a/lib/otto/security/authentication/strategies/api_key_strategy.rb
+++ b/lib/otto/security/authentication/strategies/api_key_strategy.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require_relative '../auth_strategy'
+require 'digest'
 require 'rack/utils'
 
 class Otto
@@ -20,6 +21,9 @@ class Otto
         # credential such as an array query parameter — fails TERMINALLY, so a bad
         # key halts the strategy chain instead of falling through to a later
         # anonymous-capable strategy. A missing credential fails non-terminally.
+        #
+        # The result never carries the raw key: it exposes only a short SHA-256
+        # fingerprint, so the secret does not reach env, session, or logs.
         #
         # The query/form parameter path is opt-in (`param_name:`), because keys in
         # URLs are recorded by access logs, proxies, and browser history.
@@ -68,12 +72,21 @@ class Otto
               return failure('Invalid API key', terminal: true)
             end
 
-            # Create a simple user hash for API key authentication
-            user_data = { api_key: api_key }
-            success(user: user_data, api_key: api_key)
+            # Identify the credential by a non-reversible fingerprint. The raw key
+            # must not reach the result, since it flows into env, session, and logs.
+            fingerprint = key_fingerprint(api_key)
+            success(user: { api_key_fingerprint: fingerprint },
+                    auth_method: 'api_key',
+                    api_key_fingerprint: fingerprint)
           end
 
           private
+
+          # Short, non-reversible identifier for a key: enough to correlate
+          # requests and audit logs without exposing the credential.
+          def key_fingerprint(api_key)
+            Digest::SHA256.hexdigest(api_key)[0, 12]
+          end
 
           # Constant-time membership check over the configured API keys. Compares
           # against every key without short-circuiting so match position/membership is

--- a/lib/otto/security/authentication/strategies/api_key_strategy.rb
+++ b/lib/otto/security/authentication/strategies/api_key_strategy.rb
@@ -9,10 +9,34 @@ class Otto
   module Security
     module Authentication
       module Strategies
-        # API key authentication strategy
+        # API key authentication strategy.
+        #
+        # Fails closed: at least one non-empty API key MUST be configured. A
+        # strategy with no usable keys is a misconfiguration and raises
+        # ArgumentError at construction rather than authenticating every caller.
+        # Only a constant-time match against a configured key grants success.
+        #
+        # A credential that was presented and rejected — including a non-String
+        # credential such as an array query parameter — fails TERMINALLY, so a bad
+        # key halts the strategy chain instead of falling through to a later
+        # anonymous-capable strategy. A missing credential fails non-terminally.
+        #
+        # @example
+        #   APIKeyStrategy.new(api_keys: ['secret123'])
         class APIKeyStrategy < AuthStrategy
-          def initialize(api_keys: [], header_name: 'X-API-Key', param_name: 'api_key')
-            @api_keys = Array(api_keys)
+          # @param api_keys [String, Array<String>] one or more valid API keys (required)
+          # @param header_name [String] request header carrying the key
+          # @param param_name [String] query/form parameter carrying the key
+          # @raise [ArgumentError] if no non-empty API key is configured
+          def initialize(api_keys:, header_name: 'X-API-Key', param_name: 'api_key')
+            super()
+            @api_keys = Array(api_keys).map(&:to_s).reject(&:empty?).freeze
+            if @api_keys.empty?
+              raise ArgumentError,
+                    'APIKeyStrategy requires at least one non-empty API key ' \
+                    '(api_keys: was empty, nil, or contained only blank values)'
+            end
+
             @header_name = header_name
             @param_name = param_name
           end
@@ -26,15 +50,20 @@ class Otto
               api_key = request.params[@param_name]
             end
 
-            return failure('No API key provided') unless api_key
+            # '' is truthy in Ruby; treat it as a missing credential.
+            return failure('No API key provided') if api_key.nil? || (api_key.is_a?(String) && api_key.empty?)
 
-            if @api_keys.empty? || valid_api_key?(api_key)
-              # Create a simple user hash for API key authentication
-              user_data = { api_key: api_key }
-              success(user: user_data, api_key: api_key)
-            else
-              failure('Invalid API key')
+            # A non-String credential (e.g. `?api_key[]=k` yields an Array) was
+            # still presented, so reject it terminally rather than coercing it
+            # into a comparison Rack::Utils.secure_compare cannot perform.
+            unless api_key.is_a?(String) && valid_api_key?(api_key)
+              # Credentials were explicitly presented and rejected: fail closed.
+              return failure('Invalid API key', terminal: true)
             end
+
+            # Create a simple user hash for API key authentication
+            user_data = { api_key: api_key }
+            success(user: user_data, api_key: api_key)
           end
 
           private

--- a/lib/otto/security/authentication/strategies/api_key_strategy.rb
+++ b/lib/otto/security/authentication/strategies/api_key_strategy.rb
@@ -116,8 +116,10 @@ class Otto
               api_key = request.params[@param_name]
             end
 
-            # '' is truthy in Ruby; treat it as a missing credential.
-            return failure('No API key provided') if api_key.nil? || (api_key.is_a?(String) && api_key.empty?)
+            # '' is truthy in Ruby; treat it, and a whitespace-only value, as a
+            # missing credential. The static list already refuses blank keys, so
+            # the resolver must never be asked about one either.
+            return failure('No API key provided') if api_key.nil? || (api_key.is_a?(String) && api_key.strip.empty?)
 
             # A non-String credential (e.g. `?api_key[]=k` yields an Array) was
             # still presented, so reject it terminally rather than handing it to

--- a/lib/otto/security/authentication/strategies/api_key_strategy.rb
+++ b/lib/otto/security/authentication/strategies/api_key_strategy.rb
@@ -12,15 +12,36 @@ class Otto
       module Strategies
         # API key authentication strategy.
         #
-        # Fails closed: at least one non-empty API key MUST be configured. A
-        # strategy with no usable keys is a misconfiguration and raises
-        # ArgumentError at construction rather than authenticating every caller.
-        # Only a constant-time match against a configured key grants success.
+        # Accepts exactly one key source: a static list (`api_keys:`), a
+        # callable (`resolver:`), or a block. A resolver receives the presented
+        # key (a non-empty String, never env) and returns the account behind it,
+        # or nil/false when the key is unknown. Any other return value, including
+        # an empty container, counts as a match: an ORM relation from `where`,
+        # an empty Array from `select`, or `{}` from a cache miss is truthy and
+        # authenticates the caller. Return exactly one record (`find_by`,
+        # `first`) or nil. The strategy never branches on mode: a static list is
+        # wrapped in a resolver internally.
         #
-        # A credential that was presented and rejected — including a non-String
-        # credential such as an array query parameter — fails TERMINALLY, so a bad
+        # Fails closed: a strategy with no source, or a static list with no
+        # non-empty key, is a misconfiguration and raises ArgumentError at
+        # construction rather than authenticating every caller. Only a truthy
+        # resolver return (for a static list: a constant-time match) grants
+        # success.
+        #
+        # A credential that was presented and rejected, including a non-String
+        # credential such as an array query parameter, fails TERMINALLY, so a bad
         # key halts the strategy chain instead of falling through to a later
         # anonymous-capable strategy. A missing credential fails non-terminally.
+        # Blank and non-String credentials are rejected before the resolver runs.
+        #
+        # Exceptions raised by a resolver propagate. A database outage must
+        # surface as an error, not as a silent 401 and never as success.
+        #
+        # Timing: the static list is compared in constant time against every
+        # configured key. A black-box lookup cannot be made constant-time by the
+        # strategy; the documented pattern is to store SHA-256 digests and look
+        # up by {APIKeyStrategy.digest}, which is constant-time by construction
+        # and keeps raw keys out of the database.
         #
         # The result never carries the raw key: it exposes only a short SHA-256
         # fingerprint, so the secret does not reach env, session, or logs.
@@ -28,26 +49,49 @@ class Otto
         # The query/form parameter path is opt-in (`param_name:`), because keys in
         # URLs are recorded by access logs, proxies, and browser history.
         #
-        # @example Header only (recommended)
+        # Scope: this is a small static-allowlist authenticator shipped as a
+        # low-dependency convenience and reference implementation. It has no
+        # native support for runtime addition or revocation, expiration, roles
+        # or scopes, key metadata, quotas, a management API, audit history, or
+        # hashed verifier storage. The resolver form delegates those concerns
+        # to the application's key store; see docs/guides/authentication.md.
+        #
+        # @example Static list, header only (recommended)
         #   APIKeyStrategy.new(api_keys: ['secret123'])
+        # @example Block resolver looking up a stored digest
+        #   APIKeyStrategy.new do |presented_key|
+        #     ApiKey.find_by(digest: APIKeyStrategy.digest(presented_key))&.account
+        #   end
+        # @example Callable resolver (anything responding to #call)
+        #   APIKeyStrategy.new(resolver: repo.method(:find_by_key))
         # @example Also accept ?api_key= (logged in URLs; prefer the header)
         #   APIKeyStrategy.new(api_keys: ['secret123'], param_name: 'api_key')
         class APIKeyStrategy < AuthStrategy
-          # @param api_keys [String, Array<String>] one or more valid API keys (required)
+          # Full SHA-256 hex digest of a key. Store this instead of the raw key
+          # and look up presented keys by their digest.
+          #
+          # @param key [String]
+          # @return [String] 64-char hex digest
+          def self.digest(key)
+            Digest::SHA256.hexdigest(key)
+          end
+
+          # @param api_keys [String, Array<String>, nil] static list of valid API keys
+          # @param resolver [#call, nil] callable receiving the presented key and
+          #   returning the account (truthy) or nil/false when unknown
           # @param header_name [String] request header carrying the key
           # @param param_name [String, nil] query/form parameter carrying the key.
           #   Defaults to nil (header only): keys placed in a URL are captured by
           #   access logs, proxies, and browser history. Pass 'api_key' to opt in.
-          # @raise [ArgumentError] if no non-empty API key is configured
-          def initialize(api_keys:, header_name: 'X-API-Key', param_name: nil)
+          # @yieldparam presented_key [String] the non-empty presented key
+          # @yieldreturn [Object, nil, false] the account behind the key, or
+          #   nil/false when the key is unknown
+          # @raise [ArgumentError] if no source, or more than one, is given
+          # @raise [ArgumentError] if resolver: does not respond to #call
+          # @raise [ArgumentError] if api_keys: contains no non-empty API key
+          def initialize(api_keys: nil, resolver: nil, header_name: 'X-API-Key', param_name: nil, &block)
             super()
-            @api_keys = Array(api_keys).map(&:to_s).reject(&:empty?).freeze
-            if @api_keys.empty?
-              raise ArgumentError,
-                    'APIKeyStrategy requires at least one non-empty API key ' \
-                    '(api_keys: was empty, nil, or contained only blank values)'
-            end
-
+            @resolver = build_resolver(api_keys, resolver, block)
             @header_name = header_name
             @param_name = param_name
           end
@@ -65,36 +109,68 @@ class Otto
             return failure('No API key provided') if api_key.nil? || (api_key.is_a?(String) && api_key.empty?)
 
             # A non-String credential (e.g. `?api_key[]=k` yields an Array) was
-            # still presented, so reject it terminally rather than coercing it
-            # into a comparison Rack::Utils.secure_compare cannot perform.
-            unless api_key.is_a?(String) && valid_api_key?(api_key)
-              # Credentials were explicitly presented and rejected: fail closed.
-              return failure('Invalid API key', terminal: true)
-            end
+            # still presented, so reject it terminally rather than handing it to
+            # the resolver. Credentials were explicitly presented and rejected:
+            # fail closed.
+            return failure('Invalid API key', terminal: true) unless api_key.is_a?(String)
+
+            # Resolver exceptions propagate deliberately (see class docs).
+            user = @resolver.call(api_key)
+            return failure('Invalid API key', terminal: true) unless user
 
             # Identify the credential by a non-reversible fingerprint. The raw key
             # must not reach the result, since it flows into env, session, and logs.
-            fingerprint = key_fingerprint(api_key)
-            success(user: { api_key_fingerprint: fingerprint },
+            success(user: user,
                     auth_method: 'api_key',
-                    api_key_fingerprint: fingerprint)
+                    api_key_fingerprint: key_fingerprint(api_key))
           end
 
           private
 
+          def build_resolver(api_keys, resolver, block)
+            sources = [api_keys, resolver, block].count { |source| !source.nil? }
+            if sources > 1
+              raise ArgumentError,
+                    'APIKeyStrategy: pass api_keys:, resolver:, or a block, not more than one'
+            end
+            # `api_keys: nil` and omitting every source are indistinguishable
+            # here, so one message covers both.
+            if sources.zero?
+              raise ArgumentError,
+                    'APIKeyStrategy requires a key source: at least one non-empty API key ' \
+                    '(api_keys:), a resolver:, or a block'
+            end
+
+            return static_resolver(api_keys) unless api_keys.nil?
+            return block if block
+
+            raise ArgumentError, 'APIKeyStrategy resolver: must respond to #call' unless resolver.respond_to?(:call)
+
+            resolver
+          end
+
+          # Wrap a static key list in a resolver performing a constant-time,
+          # non-short-circuiting membership check.
+          def static_resolver(api_keys)
+            keys = Array(api_keys).map(&:to_s).reject(&:empty?).freeze
+            if keys.empty?
+              raise ArgumentError,
+                    'APIKeyStrategy requires at least one non-empty API key ' \
+                    '(api_keys: was empty or contained only blank values)'
+            end
+
+            lambda do |presented|
+              matched = keys.reduce(false) do |acc, key|
+                Rack::Utils.secure_compare(key, presented) || acc
+              end
+              matched ? { api_key_fingerprint: key_fingerprint(presented) } : nil
+            end
+          end
+
           # Short, non-reversible identifier for a key: enough to correlate
           # requests and audit logs without exposing the credential.
           def key_fingerprint(api_key)
-            Digest::SHA256.hexdigest(api_key)[0, 12]
-          end
-
-          # Constant-time membership check over the configured API keys. Compares
-          # against every key without short-circuiting so match position/membership is
-          # not leaked via timing.
-          def valid_api_key?(api_key)
-            @api_keys.reduce(false) do |matched, key|
-              Rack::Utils.secure_compare(key, api_key) || matched
-            end
+            self.class.digest(api_key)[0, 12]
           end
         end
       end

--- a/lib/otto/security/authentication/strategies/api_key_strategy.rb
+++ b/lib/otto/security/authentication/strategies/api_key_strategy.rb
@@ -21,14 +21,21 @@ class Otto
         # key halts the strategy chain instead of falling through to a later
         # anonymous-capable strategy. A missing credential fails non-terminally.
         #
-        # @example
+        # The query/form parameter path is opt-in (`param_name:`), because keys in
+        # URLs are recorded by access logs, proxies, and browser history.
+        #
+        # @example Header only (recommended)
         #   APIKeyStrategy.new(api_keys: ['secret123'])
+        # @example Also accept ?api_key= (logged in URLs; prefer the header)
+        #   APIKeyStrategy.new(api_keys: ['secret123'], param_name: 'api_key')
         class APIKeyStrategy < AuthStrategy
           # @param api_keys [String, Array<String>] one or more valid API keys (required)
           # @param header_name [String] request header carrying the key
-          # @param param_name [String] query/form parameter carrying the key
+          # @param param_name [String, nil] query/form parameter carrying the key.
+          #   Defaults to nil (header only): keys placed in a URL are captured by
+          #   access logs, proxies, and browser history. Pass 'api_key' to opt in.
           # @raise [ArgumentError] if no non-empty API key is configured
-          def initialize(api_keys:, header_name: 'X-API-Key', param_name: 'api_key')
+          def initialize(api_keys:, header_name: 'X-API-Key', param_name: nil)
             super()
             @api_keys = Array(api_keys).map(&:to_s).reject(&:empty?).freeze
             if @api_keys.empty?
@@ -42,10 +49,10 @@ class Otto
           end
 
           def authenticate(env, _requirement)
-            # Try header first, then query parameter
+            # Header first; the parameter path is consulted only when opted in.
             api_key = env["HTTP_#{@header_name.upcase.tr('-', '_')}"]
 
-            if api_key.nil?
+            if api_key.nil? && @param_name
               request = Otto::Request.new(env)
               api_key = request.params[@param_name]
             end

--- a/lib/otto/security/authentication/strategies/api_key_strategy.rb
+++ b/lib/otto/security/authentication/strategies/api_key_strategy.rb
@@ -38,10 +38,13 @@ class Otto
         # surface as an error, not as a silent 401 and never as success.
         #
         # Timing: the static list is compared in constant time against every
-        # configured key. A black-box lookup cannot be made constant-time by the
-        # strategy; the documented pattern is to store SHA-256 digests and look
-        # up by {APIKeyStrategy.digest}, which is constant-time by construction
-        # and keeps raw keys out of the database.
+        # configured key. Both sides are reduced to fixed-width SHA-256 digests
+        # first, so the comparison never short-circuits on a length mismatch and
+        # the lengths of configured keys are not observable. A black-box lookup
+        # cannot be made constant-time by the strategy; the documented pattern
+        # is to store SHA-256 digests and look up by {APIKeyStrategy.digest},
+        # which is constant-time by construction and keeps raw keys out of the
+        # database.
         #
         # The strategy never places the raw key in the result itself: the only
         # strategy-generated field derived from the key is a short SHA-256
@@ -128,7 +131,7 @@ class Otto
 
             # The most likely naive misuse: `->(k) { k if keys.include?(k) }`.
             # Fail loud before the key can reach the result and env.
-            if user.is_a?(String) && Rack::Utils.secure_compare(user, api_key)
+            if user.is_a?(String) && constant_time_equal?(user, api_key)
               raise ArgumentError,
                     'APIKeyStrategy resolver returned the presented key as the user; ' \
                     'return the account behind the key, not the key'
@@ -169,26 +172,35 @@ class Otto
           # Wrap a static key list in a resolver performing a constant-time,
           # non-short-circuiting membership check.
           def static_resolver(api_keys)
-            # Own frozen copies: `to_s` returns the caller's String, and the
-            # strategy only ever receives a shallow freeze from config
-            # finalization, so a caller mutating its key after boot would
-            # otherwise change which credential is accepted.
-            # Keys are kept verbatim, but a whitespace-only value is a blank
+            # `to_s` returns the caller's String and the strategy only ever
+            # receives a shallow freeze from config finalization, so the digest
+            # is taken now: a caller mutating its key after boot cannot change
+            # which credential is accepted, and the raw keys are not retained.
+            # Keys are matched verbatim, but a whitespace-only value is a blank
             # configuration (`API_KEYS=" "`), not a credential: reject it so the
             # fail-closed startup guarantee covers it.
-            keys = Array(api_keys).map { |key| key.to_s.dup.freeze }.reject { |key| key.strip.empty? }.freeze
-            if keys.empty?
+            digests = Array(api_keys).map(&:to_s).reject { |key| key.strip.empty? }
+                                     .map { |key| self.class.digest(key).freeze }.freeze
+            if digests.empty?
               raise ArgumentError,
                     'APIKeyStrategy requires at least one non-empty API key ' \
                     '(api_keys: was empty or contained only blank values)'
             end
 
             lambda do |presented|
-              matched = keys.reduce(false) do |acc, key|
-                Rack::Utils.secure_compare(key, presented) || acc
+              presented_digest = self.class.digest(presented)
+              matched = digests.reduce(false) do |acc, digest|
+                Rack::Utils.secure_compare(digest, presented_digest) || acc
               end
-              matched ? { api_key_fingerprint: key_fingerprint(presented) } : nil
+              matched ? { api_key_fingerprint: presented_digest[0, 12] } : nil
             end
+          end
+
+          # Constant-time equality that does not leak the length of either side:
+          # `Rack::Utils.secure_compare` returns immediately on a length mismatch,
+          # so compare fixed-width digests instead of the raw values.
+          def constant_time_equal?(left, right)
+            Rack::Utils.secure_compare(self.class.digest(left), self.class.digest(right))
           end
 
           # Short, non-reversible identifier for a key: enough to correlate

--- a/lib/otto/security/authentication/strategies/permission_strategy.rb
+++ b/lib/otto/security/authentication/strategies/permission_strategy.rb
@@ -11,6 +11,7 @@ class Otto
         # Permission-based authentication strategy
         class PermissionStrategy < AuthStrategy
           def initialize(required_permissions, session_key: 'user_permissions')
+            super()
             @required_permissions = Array(required_permissions)
             @session_key = session_key
           end

--- a/lib/otto/security/authentication/strategies/role_strategy.rb
+++ b/lib/otto/security/authentication/strategies/role_strategy.rb
@@ -11,6 +11,7 @@ class Otto
         # Role-based authentication strategy
         class RoleStrategy < AuthStrategy
           def initialize(allowed_roles, session_key: 'user_roles')
+            super()
             @allowed_roles = Array(allowed_roles)
             @session_key = session_key
           end

--- a/lib/otto/security/authentication/strategies/session_strategy.rb
+++ b/lib/otto/security/authentication/strategies/session_strategy.rb
@@ -11,6 +11,7 @@ class Otto
         # Session-based authentication strategy
         class SessionStrategy < AuthStrategy
           def initialize(session_key: 'user_id', session_store: nil)
+            super()
             @session_key = session_key
             @session_store = session_store
           end

--- a/lib/otto/security/authentication/strategy_result.rb
+++ b/lib/otto/security/authentication/strategy_result.rb
@@ -257,9 +257,30 @@ class Otto
 
         # Get all user roles as an array
         #
+        # Supports object-backed users (ORM models, POROs, Data/Struct) via
+        # `#roles` / `#role`, and Hash users via `:roles`/`'roles'` then
+        # `:role`/`'role'`. Never calls `#[]` on a non-Hash user, so a model
+        # without role support yields `[]` instead of raising. `#roles` on an
+        # object must return role names (Strings or Symbols, in any Enumerable);
+        # an association of role records is stringified as-is and matches
+        # nothing, which denies rather than grants.
+        #
         # @return [Array<String>] Array of roles (empty if none)
         def roles
           return [] unless authenticated?
+
+          # Try user model methods first, fall back to hash access for backward compatibility
+          if user.respond_to?(:roles)
+            normalized = normalize_list(user.roles)
+            return normalized unless normalized.empty?
+          end
+
+          if user.respond_to?(:role)
+            role = user.role
+            return [role.to_s] if role
+          end
+
+          return [] unless user.is_a?(Hash)
 
           roles_data = user[:roles] || user['roles']
           if roles_data.is_a?(Array)
@@ -274,13 +295,21 @@ class Otto
 
         # Get all user permissions as an array
         #
+        # Supports object-backed users via `#permissions` and Hash users via
+        # `:permissions`/`'permissions'`. Never calls `#[]` on a non-Hash user.
+        #
         # @return [Array<String>] Array of permissions (empty if none)
         def permissions
           return [] unless authenticated?
 
-          perms = user[:permissions] || user['permissions'] || []
-          perms = [perms] unless perms.is_a?(Array)
-          perms.map(&:to_s)
+          # Try user model methods first, fall back to hash access for backward compatibility
+          if user.respond_to?(:permissions)
+            normalize_list(user.permissions)
+          elsif user.is_a?(Hash)
+            normalize_list(user[:permissions] || user['permissions'])
+          else
+            []
+          end
         end
 
         # Create a string representation for debugging
@@ -331,6 +360,18 @@ class Otto
                              roles: roles,
                        permissions: permissions,
           }
+        end
+
+        private
+
+        # Coerce a roles/permissions value into an Array of Strings. Enumerables
+        # (Array, Set, an ORM relation) expand to their elements; a scalar
+        # becomes a one-element list; nil becomes [].
+        #
+        # @param value [Array, Enumerable, Object, nil]
+        # @return [Array<String>]
+        def normalize_list(value)
+          Array(value).map(&:to_s)
         end
       end
     end

--- a/lib/otto/security/authentication/strategy_result.rb
+++ b/lib/otto/security/authentication/strategy_result.rb
@@ -159,45 +159,34 @@ class Otto
 
         # Check if the user has a specific role
         #
+        # A user model that defines `#has_role?` is asked directly. Otherwise
+        # the answer is derived from {#roles}, so the predicate and the accessor
+        # always agree: `has_role?(r)` is `roles.include?(r.to_s)` for Hash,
+        # PORO, ORM, Set-backed, and single-`#role` users alike.
+        #
         # @param role [String, Symbol] Role to check
         # @return [Boolean] True if user has the role
         def has_role?(role)
           return false unless authenticated?
+          return user.has_role?(role) if user.respond_to?(:has_role?)
 
-          # Try user model methods first, fall back to hash access for backward compatibility
-          if user.respond_to?(:role)
-            user.role.to_s == role.to_s
-          elsif user.respond_to?(:has_role?)
-            user.has_role?(role)
-          elsif user.is_a?(Hash)
-            user_role = user[:role] || user['role']
-            user_role.to_s == role.to_s
-          else
-            false
-          end
+          roles.include?(role.to_s)
         end
 
         # Check if the user has a specific permission
+        #
+        # A user model that defines `#has_permission?` is asked directly.
+        # Otherwise the answer is derived from {#permissions}, so the predicate
+        # and the accessor always agree, including for Set-backed and other
+        # non-Array Enumerable collections.
         #
         # @param permission [String, Symbol] Permission to check
         # @return [Boolean] True if user has the permission
         def has_permission?(permission)
           return false unless authenticated?
+          return user.has_permission?(permission) if user.respond_to?(:has_permission?)
 
-          # Try user model methods first, fall back to hash access for backward compatibility
-          if user.respond_to?(:has_permission?)
-            user.has_permission?(permission)
-          elsif user.respond_to?(:permissions)
-            permissions = user.permissions || []
-            permissions = [permissions] unless permissions.is_a?(Array)
-            permissions.map(&:to_s).include?(permission.to_s)
-          elsif user.is_a?(Hash)
-            permissions = user[:permissions] || user['permissions'] || []
-            permissions = [permissions] unless permissions.is_a?(Array)
-            permissions.map(&:to_s).include?(permission.to_s)
-          else
-            false
-          end
+          permissions.include?(permission.to_s)
         end
 
         # Check if the user has any of the specified roles

--- a/lib/otto/security/core.rb
+++ b/lib/otto/security/core.rb
@@ -245,7 +245,7 @@ class Otto
       # @param strategy [AuthStrategy] Strategy instance
       # @example
       #   otto.add_auth_strategy('session', SessionStrategy.new(session_key: 'user_id'))
-      #   otto.add_auth_strategy('api_key', APIKeyStrategy.new)
+      #   otto.add_auth_strategy('api_key', APIKeyStrategy.new(api_keys: ENV.fetch('API_KEYS').split(',')))
       # @raise [ArgumentError] if strategy name already registered
       def add_auth_strategy(name, strategy)
         ensure_not_frozen!

--- a/spec/otto/security/authentication/api_key_fail_closed_integration_spec.rb
+++ b/spec/otto/security/authentication/api_key_fail_closed_integration_spec.rb
@@ -1,0 +1,79 @@
+# spec/otto/security/authentication/api_key_fail_closed_integration_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# End-to-end regression coverage for issue #256: APIKeyStrategy must fail
+# closed. These drive a real Otto app (routes file, RouteAuthWrapper, response
+# builder) rather than calling the strategy directly, so they also pin the
+# status codes a client actually sees.
+# rubocop:disable-next RSpec/DescribeClass -- end-to-end spec spans Otto, the
+# route auth wrapper, and the strategy; no single class is under test.
+RSpec.describe 'API key authentication end-to-end (issue #256)' do
+  include OttoTestHelpers
+
+  let(:api_key) { 'valid-key-256' }
+
+  let(:apikey_strategy) do
+    Otto::Security::Authentication::Strategies::APIKeyStrategy.new(api_keys: [api_key])
+  end
+
+  def get(otto, headers: {})
+    otto.call(mock_rack_env(path: '/api/data', headers: headers))
+  end
+
+  describe 'single-strategy route' do
+    let(:otto) do
+      app = create_minimal_otto(['GET /api/data TestApp.index auth=apikey response=json'])
+      app.add_auth_strategy('apikey', apikey_strategy)
+      app
+    end
+
+    it 'returns 401 when no API key is presented' do
+      status, = get(otto)
+      expect(status).to eq(401)
+    end
+
+    it 'returns 401 for an incorrect API key' do
+      status, = get(otto, headers: { 'X-API-Key' => 'wrong-key-256' })
+      expect(status).to eq(401)
+    end
+
+    it 'returns 401 for an empty API key header' do
+      status, = get(otto, headers: { 'X-API-Key' => '' })
+      expect(status).to eq(401)
+    end
+
+    it 'returns 401 for an array-valued api_key query parameter' do
+      status, = otto.call(mock_rack_env(path: '/api/data?api_key[]=valid-key-256'))
+      expect(status).to eq(401)
+    end
+
+    it 'returns 200 for the configured API key' do
+      status, _headers, body = get(otto, headers: { 'X-API-Key' => api_key })
+      expect(status).to eq(200)
+      expect(body.join).to include('Hello World')
+    end
+  end
+
+  describe 'multi-strategy OR chain with an anonymous-capable strategy' do
+    let(:otto) do
+      app = create_minimal_otto(['GET /api/data TestApp.index auth=apikey,noauth response=json'])
+      app.add_auth_strategy('apikey', apikey_strategy)
+      app.add_auth_strategy('noauth', Otto::Security::Authentication::Strategies::NoAuthStrategy.new)
+      app
+    end
+
+    it 'falls through to the anonymous strategy when no key is presented' do
+      status, = get(otto)
+      expect(status).to eq(200)
+    end
+
+    it 'does not fall through to the anonymous strategy for a rejected key' do
+      status, _headers, body = get(otto, headers: { 'X-API-Key' => 'wrong-key-256' })
+      expect(status).to eq(401)
+      expect(body.join).to include('Invalid API key')
+    end
+  end
+end

--- a/spec/otto/security/authentication/api_key_fail_closed_integration_spec.rb
+++ b/spec/otto/security/authentication/api_key_fail_closed_integration_spec.rb
@@ -45,8 +45,20 @@ RSpec.describe 'API key authentication end-to-end (issue #256)' do
       expect(status).to eq(401)
     end
 
+    it 'returns 401 for a valid key passed in the query string by default' do
+      status, = otto.call(mock_rack_env(path: "/api/data?api_key=#{api_key}"))
+      expect(status).to eq(401)
+    end
+
     it 'returns 401 for an array-valued api_key query parameter' do
-      status, = otto.call(mock_rack_env(path: '/api/data?api_key[]=valid-key-256'))
+      app = create_minimal_otto(['GET /api/data TestApp.index auth=apikey response=json'])
+      app.add_auth_strategy(
+        'apikey',
+        Otto::Security::Authentication::Strategies::APIKeyStrategy.new(
+          api_keys: [api_key], param_name: 'api_key'
+        )
+      )
+      status, = app.call(mock_rack_env(path: '/api/data?api_key[]=valid-key-256'))
       expect(status).to eq(401)
     end
 

--- a/spec/otto/security/authentication/route_auth_wrapper/role_authorization_spec.rb
+++ b/spec/otto/security/authentication/route_auth_wrapper/role_authorization_spec.rb
@@ -123,6 +123,19 @@ RSpec.describe Otto::Security::Authentication::RouteAuthWrapperComponents::RoleA
         expect(authorizer.check(result_for(user_class.new(roles: ['viewer'], role: 'admin')), env))
           .to eq(authorized: false, required: ['admin'], actual: ['viewer'])
       end
+
+      it 'falls back to #role when #roles is empty, matching StrategyResult#roles' do
+        expect(authorizer.check(result_for(user_class.new(roles: [], role: 'admin')), env)).to be(true)
+      end
+
+      it 'falls back to #role when #roles is nil' do
+        expect(authorizer.check(result_for(user_class.new(roles: nil, role: 'admin')), env)).to be(true)
+      end
+
+      it 'denies when #roles is empty and #role does not match' do
+        expect(authorizer.check(result_for(user_class.new(roles: [], role: 'viewer')), env))
+          .to eq(authorized: false, required: ['admin'], actual: ['viewer'])
+      end
     end
 
     context 'with an object-backed user exposing only a singular #role' do

--- a/spec/otto/security/authentication/route_auth_wrapper/role_authorization_spec.rb
+++ b/spec/otto/security/authentication/route_auth_wrapper/role_authorization_spec.rb
@@ -1,0 +1,166 @@
+# spec/otto/security/authentication/route_auth_wrapper/role_authorization_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Path mirrors lib/otto/security/authentication/route_auth_wrapper/, not the
+# RouteAuthWrapperComponents module name.
+RSpec.describe Otto::Security::Authentication::RouteAuthWrapperComponents::RoleAuthorization do # rubocop:disable RSpec/SpecFilePathFormat
+  subject(:authorizer) { described_class.new(route_definition) }
+
+  let(:route_definition) do
+    Otto::RouteDefinition.new('GET', '/admin', 'TestApp.admin auth=apikey role=admin')
+  end
+
+  let(:env) { { 'REQUEST_METHOD' => 'GET', 'PATH_INFO' => '/admin' } }
+
+  def result_for(user, metadata: {})
+    Otto::Security::Authentication::StrategyResult.new(
+      session: {},
+      user: user,
+      auth_method: 'apikey',
+      metadata: metadata,
+      strategy_name: 'apikey'
+    )
+  end
+
+  describe '#check' do
+    context 'with an object-backed user exposing #roles' do
+      let(:user_class) do
+        Class.new do
+          def id = 7
+          def roles = %w[admin]
+        end
+      end
+
+      it 'authorizes when a role matches' do
+        expect(authorizer.check(result_for(user_class.new), env)).to be(true)
+      end
+
+      it 'reports authorized? true' do
+        expect(authorizer.authorized?(result_for(user_class.new))).to be(true)
+      end
+    end
+
+    context 'with an object-backed user whose #roles do not match' do
+      let(:user_class) do
+        Class.new do
+          def id = 7
+          def roles = %w[viewer]
+        end
+      end
+
+      it 'returns the failure hash' do
+        expect(authorizer.check(result_for(user_class.new), env)).to eq(
+          authorized: false,
+          required: ['admin'],
+          actual: ['viewer']
+        )
+      end
+    end
+
+    context 'with an object-backed user exposing no #roles at all' do
+      let(:user_class) do
+        Class.new do
+          def id = 7
+        end
+      end
+
+      it 'denies without raising' do
+        outcome = nil
+        expect { outcome = authorizer.check(result_for(user_class.new), env) }.not_to raise_error
+        expect(outcome).to eq(authorized: false, required: ['admin'], actual: [])
+      end
+
+      it 'reports authorized? false' do
+        expect(authorizer.authorized?(result_for(user_class.new))).to be(false)
+      end
+
+      it 'still honours metadata[:user_roles]' do
+        result = result_for(user_class.new, metadata: { user_roles: ['admin'] })
+        expect(authorizer.check(result, env)).to be(true)
+      end
+    end
+
+    context 'with a Data instance user' do
+      let(:user_data) { Data.define(:id, :roles) }
+
+      it 'authorizes on matching #roles' do
+        expect(authorizer.check(result_for(user_data.new(id: 1, roles: ['admin'])), env)).to be(true)
+      end
+
+      it 'denies when #roles is nil' do
+        expect(authorizer.check(result_for(user_data.new(id: 1, roles: nil)), env))
+          .to eq(authorized: false, required: ['admin'], actual: [])
+      end
+    end
+
+    context 'with an ORM-like user responding to #[], #roles and #role' do
+      let(:user_class) do
+        Class.new do
+          def initialize(roles:, role: nil)
+            @roles = roles
+            @role = role
+          end
+
+          attr_reader :roles, :role
+
+          def id = 7
+          def [](_key) = nil
+        end
+      end
+
+      it 'authorizes on #roles, not #[]' do
+        expect(authorizer.check(result_for(user_class.new(roles: [:admin])), env)).to be(true)
+      end
+
+      it 'authorizes on a Set of roles' do
+        expect(authorizer.check(result_for(user_class.new(roles: Set['admin'])), env)).to be(true)
+      end
+
+      it 'denies on non-matching #roles even when #role would match' do
+        expect(authorizer.check(result_for(user_class.new(roles: ['viewer'], role: 'admin')), env))
+          .to eq(authorized: false, required: ['admin'], actual: ['viewer'])
+      end
+    end
+
+    context 'with an object-backed user exposing only a singular #role' do
+      let(:user_class) do
+        Class.new do
+          def id = 7
+          def role = 'admin'
+        end
+      end
+
+      it 'authorizes on #role' do
+        expect(authorizer.check(result_for(user_class.new), env)).to be(true)
+      end
+    end
+
+    context 'with a Hash user' do
+      it 'authorizes via :roles' do
+        expect(authorizer.check(result_for({ id: 1, roles: ['admin'] }), env)).to be(true)
+      end
+
+      it "authorizes via 'roles'" do
+        expect(authorizer.check(result_for({ id: 1, 'roles' => ['admin'] }), env)).to be(true)
+      end
+
+      it 'denies when roles absent' do
+        expect(authorizer.check(result_for({ id: 1 }), env))
+          .to eq(authorized: false, required: ['admin'], actual: [])
+      end
+    end
+
+    context 'without role requirements' do
+      let(:route_definition) do
+        Otto::RouteDefinition.new('GET', '/open', 'TestApp.open auth=apikey')
+      end
+
+      it 'authorizes any user, including one without #roles' do
+        expect(authorizer.check(result_for(Object.new), env)).to be(true)
+      end
+    end
+  end
+end

--- a/spec/otto/security/authentication/strategies/api_key_strategy_spec.rb
+++ b/spec/otto/security/authentication/strategies/api_key_strategy_spec.rb
@@ -134,4 +134,207 @@ RSpec.describe Otto::Security::Authentication::Strategies::APIKeyStrategy do
       expect(strategy.authenticate(env_with_header('key-one'), nil).authenticated?).to be(true)
     end
   end
+
+  describe '.digest' do
+    it 'returns the full SHA-256 hex digest of the key' do
+      expect(described_class.digest('key-one')).to eq(Digest::SHA256.hexdigest('key-one'))
+      expect(described_class.digest('key-one').length).to eq(64)
+    end
+
+    it 'prefixes the fingerprint placed in results' do
+      result = described_class.new(api_keys: ['key-one']).authenticate(env_with_header('key-one'), nil)
+      expect(described_class.digest('key-one')).to start_with(result.metadata[:api_key_fingerprint])
+    end
+  end
+
+  describe 'resolver form' do
+    let(:account) { { id: 42, name: 'acme' } }
+    let(:presented) { 'sk_live_resolver_key' }
+    let(:lookup_error) { Class.new(StandardError) }
+
+    describe 'construction' do
+      it 'rejects a resolver: that does not respond to #call' do
+        expect { described_class.new(resolver: 'not callable') }
+          .to raise_error(ArgumentError, /must respond to #call/)
+      end
+
+      it 'rejects api_keys: combined with a block' do
+        expect { described_class.new(api_keys: ['k']) { |_key| account } }
+          .to raise_error(ArgumentError, /not more than one/)
+      end
+
+      it 'rejects api_keys: combined with resolver:' do
+        expect { described_class.new(api_keys: ['k'], resolver: ->(_key) { account }) }
+          .to raise_error(ArgumentError, /not more than one/)
+      end
+
+      it 'rejects resolver: combined with a block' do
+        expect { described_class.new(resolver: ->(_key) { account }) { |_key| account } }
+          .to raise_error(ArgumentError, /not more than one/)
+      end
+
+      it 'rejects the absence of any key source' do
+        expect { described_class.new }
+          .to raise_error(ArgumentError, /requires a key source/)
+      end
+    end
+
+    describe 'block resolver' do
+      subject(:strategy) { described_class.new { |key| key == presented ? account : nil } }
+
+      it 'returns the block value as the user with a 12-char fingerprint in metadata' do
+        result = strategy.authenticate(env_with_header(presented), nil)
+        expect(result.authenticated?).to be(true)
+        expect(result.user).to eq(account)
+        expect(result.auth_method).to eq('api_key')
+        expect(result.metadata[:api_key_fingerprint]).to eq(Digest::SHA256.hexdigest(presented)[0, 12])
+        expect(result.metadata[:api_key_fingerprint].length).to eq(12)
+      end
+
+      it 'passes exactly the presented String key to the block' do
+        received = []
+        capturing = described_class.new do |*args|
+          received << args
+          account
+        end
+        capturing.authenticate(env_with_header(presented), nil)
+        expect(received).to eq([[presented]])
+        expect(received.first.first).to be_a(String)
+      end
+
+      it 'fails terminally when the block returns nil' do
+        result = strategy.authenticate(env_with_header('unknown-key'), nil)
+        expect(result).to be_a(Otto::Security::Authentication::AuthFailure)
+        expect(result.authenticated?).to be(false)
+        expect(result.terminal?).to be(true)
+        expect(result.failure_reason).to eq('Invalid API key')
+      end
+
+      it 'fails terminally when the block returns false' do
+        falsy = described_class.new { |_key| false }
+        result = falsy.authenticate(env_with_header(presented), nil)
+        expect(result).to be_a(Otto::Security::Authentication::AuthFailure)
+        expect(result.terminal?).to be(true)
+        expect(result.failure_reason).to eq('Invalid API key')
+      end
+
+      it 'treats any non-nil, non-false return as a match, including empty containers' do
+        # Pins the truthy contract: a resolver built on `where`/`select` or a
+        # cache returning {} on miss authenticates every key. Return nil on miss.
+        [[], {}, '', 0].each do |value|
+          permissive = described_class.new { |_key| value }
+          result = permissive.authenticate(env_with_header(presented), nil)
+          expect(result.authenticated?).to be(true), "expected #{value.inspect} to authenticate"
+          expect(result.user).to eq(value)
+        end
+      end
+
+      it 'propagates exceptions raised by the resolver' do
+        error_class = lookup_error
+        raising = described_class.new { |_key| raise error_class, 'db down' }
+        expect { raising.authenticate(env_with_header(presented), nil) }
+          .to raise_error(error_class, 'db down')
+      end
+
+      it 'does not call the block for a blank header and fails non-terminally' do
+        called = false
+        strict = described_class.new do |_key|
+          called = true
+          account
+        end
+        result = strict.authenticate(env_with_header(''), nil)
+        expect(called).to be(false)
+        expect(result.authenticated?).to be(false)
+        expect(result.terminal?).to be(false)
+        expect(result.failure_reason).to eq('No API key provided')
+      end
+
+      it 'does not call the block for a missing header' do
+        called = false
+        strict = described_class.new do |_key|
+          called = true
+          account
+        end
+        result = strict.authenticate({}, nil)
+        expect(called).to be(false)
+        expect(result.failure_reason).to eq('No API key provided')
+      end
+
+      it 'does not call the block for an array-valued query parameter and fails terminally' do
+        called = false
+        opted_in = described_class.new(param_name: 'api_key') do |_key|
+          called = true
+          account
+        end
+        env = Rack::MockRequest.env_for("/?api_key[]=#{presented}")
+        result = opted_in.authenticate(env, nil)
+        expect(called).to be(false)
+        expect(result.authenticated?).to be(false)
+        expect(result.terminal?).to be(true)
+        expect(result.failure_reason).to eq('Invalid API key')
+      end
+
+      it 'does not expose the raw key in the result' do
+        result = strategy.authenticate(env_with_header(presented), nil)
+        expect(result.user.inspect).not_to include(presented)
+        expect(result.metadata.inspect).not_to include(presented)
+        expect(result.metadata).not_to have_key(:api_key)
+        expect(result.to_h.inspect).not_to include(presented)
+        expect(result.inspect).not_to include(presented)
+      end
+
+      it 'ignores the query parameter by default' do
+        result = strategy.authenticate(env_with_param(presented), nil)
+        expect(result.authenticated?).to be(false)
+        expect(result.failure_reason).to eq('No API key provided')
+      end
+
+      it 'reads the query parameter when opted in' do
+        opted_in = described_class.new(param_name: 'api_key') { |key| key == presented ? account : nil }
+        result = opted_in.authenticate(env_with_param(presented), nil)
+        expect(result.authenticated?).to be(true)
+        expect(result.user).to eq(account)
+      end
+
+      it 'supports a custom header name' do
+        custom = described_class.new(header_name: 'X-Otto-Token') { |key| key == presented ? account : nil }
+        result = custom.authenticate(env_with_header(presented, header: 'HTTP_X_OTTO_TOKEN'), nil)
+        expect(result.authenticated?).to be(true)
+      end
+    end
+
+    describe 'callable resolver' do
+      let(:repo) do
+        Class.new do
+          def initialize(account)
+            @account = account
+          end
+
+          def find_by_key(key)
+            key == 'sk_live_resolver_key' ? @account : nil
+          end
+        end.new(account)
+      end
+
+      it 'accepts a Method object' do
+        strategy = described_class.new(resolver: repo.method(:find_by_key))
+        result = strategy.authenticate(env_with_header(presented), nil)
+        expect(result.authenticated?).to be(true)
+        expect(result.user).to eq(account)
+        expect(result.metadata[:api_key_fingerprint]).to eq(Digest::SHA256.hexdigest(presented)[0, 12])
+      end
+
+      it 'accepts a lambda' do
+        strategy = described_class.new(resolver: ->(key) { key == presented ? account : nil })
+        expect(strategy.authenticate(env_with_header(presented), nil).user).to eq(account)
+        expect(strategy.authenticate(env_with_header('nope'), nil).terminal?).to be(true)
+      end
+
+      it 'propagates exceptions raised by the callable' do
+        error_class = lookup_error
+        strategy = described_class.new(resolver: ->(_key) { raise error_class })
+        expect { strategy.authenticate(env_with_header(presented), nil) }.to raise_error(error_class)
+      end
+    end
+  end
 end

--- a/spec/otto/security/authentication/strategies/api_key_strategy_spec.rb
+++ b/spec/otto/security/authentication/strategies/api_key_strategy_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'digest'
+
 require_relative '../../../../spec_helper'
 
 RSpec.describe Otto::Security::Authentication::Strategies::APIKeyStrategy do
@@ -43,7 +45,15 @@ RSpec.describe Otto::Security::Authentication::Strategies::APIKeyStrategy do
     it 'authenticates a correct API key from the header' do
       result = strategy.authenticate(env_with_header('key-two'), nil)
       expect(result.authenticated?).to be(true)
-      expect(result.user[:api_key]).to eq('key-two')
+      expect(result.user[:api_key_fingerprint]).to eq(Digest::SHA256.hexdigest('key-two')[0, 12])
+      expect(result.auth_method).to eq('api_key')
+    end
+
+    it 'does not expose the raw key in the result' do
+      result = strategy.authenticate(env_with_header('key-two'), nil)
+      expect(result.user).not_to have_key(:api_key)
+      expect(result.metadata).not_to have_key(:api_key)
+      expect(result.to_h.inspect).not_to include('key-two')
     end
 
     it 'ignores the query parameter by default' do
@@ -56,7 +66,7 @@ RSpec.describe Otto::Security::Authentication::Strategies::APIKeyStrategy do
       opted_in = described_class.new(api_keys: %w[key-one], param_name: 'api_key')
       result = opted_in.authenticate(env_with_param('key-one'), nil)
       expect(result.authenticated?).to be(true)
-      expect(result.user[:api_key]).to eq('key-one')
+      expect(result.user[:api_key_fingerprint]).to eq(Digest::SHA256.hexdigest('key-one')[0, 12])
     end
 
     it 'authenticates the first configured key' do

--- a/spec/otto/security/authentication/strategies/api_key_strategy_spec.rb
+++ b/spec/otto/security/authentication/strategies/api_key_strategy_spec.rb
@@ -38,6 +38,20 @@ RSpec.describe Otto::Security::Authentication::Strategies::APIKeyStrategy do
         .to raise_error(ArgumentError, /at least one non-empty API key/)
     end
 
+    it 'rejects whitespace-only keys, as produced by a blank API_KEYS environment value' do
+      expect { described_class.new(api_keys: ' '.split(',')) }
+        .to raise_error(ArgumentError, /at least one non-empty API key/)
+      expect { described_class.new(api_keys: [' ', "\t\n"]) }
+        .to raise_error(ArgumentError, /at least one non-empty API key/)
+    end
+
+    it 'does not authenticate a whitespace-only presented key when the list also had a real key' do
+      strategy = described_class.new(api_keys: [' ', 'real-key'])
+
+      expect(strategy.authenticate({ 'HTTP_X_API_KEY' => ' ' }, nil).authenticated?).to be(false)
+      expect(strategy.authenticate({ 'HTTP_X_API_KEY' => 'real-key' }, nil).authenticated?).to be(true)
+    end
+
     it 'copies static keys so mutating the caller string afterwards does not change what is accepted' do
       original = +'mutable-key'
       strategy = described_class.new(api_keys: [original])

--- a/spec/otto/security/authentication/strategies/api_key_strategy_spec.rb
+++ b/spec/otto/security/authentication/strategies/api_key_strategy_spec.rb
@@ -131,6 +131,28 @@ RSpec.describe Otto::Security::Authentication::Strategies::APIKeyStrategy do
       expect(result.failure_reason).to eq('No API key provided')
     end
 
+    it 'compares fixed-width digests so configured key lengths are not observable' do
+      mixed = described_class.new(api_keys: %w[k a-much-longer-configured-key])
+      compared = []
+      allow(Rack::Utils).to receive(:secure_compare).and_wrap_original do |original, left, right|
+        compared << [left, right]
+        original.call(left, right)
+      end
+
+      expect(mixed.authenticate(env_with_header('nope'), nil).authenticated?).to be(false)
+
+      expect(compared.length).to eq(2)
+      expect(compared.flatten.map(&:bytesize).uniq).to eq([64])
+      expect(compared.flatten).not_to include('nope', 'k', 'a-much-longer-configured-key')
+    end
+
+    it 'authenticates keys whose length differs from the presented key length of a sibling' do
+      mixed = described_class.new(api_keys: %w[k a-much-longer-configured-key])
+      expect(mixed.authenticate(env_with_header('k'), nil).authenticated?).to be(true)
+      expect(mixed.authenticate(env_with_header('a-much-longer-configured-key'), nil).authenticated?).to be(true)
+      expect(mixed.authenticate(env_with_header('a-much-longer-configured-ke'), nil).authenticated?).to be(false)
+    end
+
     it 'rejects an array-valued credential terminally instead of raising' do
       opted_in = described_class.new(api_keys: %w[key-one], param_name: 'api_key')
       env = Rack::MockRequest.env_for('/?api_key[]=key-one')

--- a/spec/otto/security/authentication/strategies/api_key_strategy_spec.rb
+++ b/spec/otto/security/authentication/strategies/api_key_strategy_spec.rb
@@ -46,8 +46,15 @@ RSpec.describe Otto::Security::Authentication::Strategies::APIKeyStrategy do
       expect(result.user[:api_key]).to eq('key-two')
     end
 
-    it 'authenticates a correct API key from the query parameter' do
+    it 'ignores the query parameter by default' do
       result = strategy.authenticate(env_with_param('key-one'), nil)
+      expect(result.authenticated?).to be(false)
+      expect(result.failure_reason).to eq('No API key provided')
+    end
+
+    it 'authenticates a correct API key from the query parameter when opted in' do
+      opted_in = described_class.new(api_keys: %w[key-one], param_name: 'api_key')
+      result = opted_in.authenticate(env_with_param('key-one'), nil)
       expect(result.authenticated?).to be(true)
       expect(result.user[:api_key]).to eq('key-one')
     end
@@ -86,16 +93,18 @@ RSpec.describe Otto::Security::Authentication::Strategies::APIKeyStrategy do
     end
 
     it 'rejects an array-valued credential terminally instead of raising' do
+      opted_in = described_class.new(api_keys: %w[key-one], param_name: 'api_key')
       env = Rack::MockRequest.env_for('/?api_key[]=key-one')
-      result = strategy.authenticate(env, nil)
+      result = opted_in.authenticate(env, nil)
       expect(result.authenticated?).to be(false)
       expect(result.terminal?).to be(true)
       expect(result.failure_reason).to eq('Invalid API key')
     end
 
     it 'rejects a hash-valued credential terminally instead of raising' do
+      opted_in = described_class.new(api_keys: %w[key-one], param_name: 'api_key')
       env = Rack::MockRequest.env_for('/?api_key[k]=key-one')
-      result = strategy.authenticate(env, nil)
+      result = opted_in.authenticate(env, nil)
       expect(result.authenticated?).to be(false)
       expect(result.terminal?).to be(true)
     end

--- a/spec/otto/security/authentication/strategies/api_key_strategy_spec.rb
+++ b/spec/otto/security/authentication/strategies/api_key_strategy_spec.rb
@@ -37,6 +37,21 @@ RSpec.describe Otto::Security::Authentication::Strategies::APIKeyStrategy do
       expect { described_class.new(api_keys: ['', nil]) }
         .to raise_error(ArgumentError, /at least one non-empty API key/)
     end
+
+    it 'copies static keys so mutating the caller string afterwards does not change what is accepted' do
+      original = +'mutable-key'
+      strategy = described_class.new(api_keys: [original])
+      original << '-changed'
+
+      expect(strategy.authenticate({ 'HTTP_X_API_KEY' => 'mutable-key' }, nil).authenticated?).to be(true)
+      expect(strategy.authenticate({ 'HTTP_X_API_KEY' => 'mutable-key-changed' }, nil).authenticated?).to be(false)
+    end
+
+    it 'does not freeze the caller string it copies from' do
+      original = +'mutable-key'
+      described_class.new(api_keys: [original])
+      expect(original).not_to be_frozen
+    end
   end
 
   describe '#authenticate' do
@@ -234,6 +249,30 @@ RSpec.describe Otto::Security::Authentication::Strategies::APIKeyStrategy do
         raising = described_class.new { |_key| raise error_class, 'db down' }
         expect { raising.authenticate(env_with_header(presented), nil) }
           .to raise_error(error_class, 'db down')
+      end
+
+      it 'raises ArgumentError when the resolver returns the presented key itself as the user' do
+        keys = [presented]
+        naive = described_class.new { |key| key if keys.include?(key) }
+        expect { naive.authenticate(env_with_header(presented), nil) }
+          .to raise_error(ArgumentError,
+                          'APIKeyStrategy resolver returned the presented key as the user; ' \
+                          'return the account behind the key, not the key')
+      end
+
+      it 'accepts a String user that is not the presented key' do
+        by_id = described_class.new { |key| key == presented ? 'acct_42' : nil }
+        result = by_id.authenticate(env_with_header(presented), nil)
+        expect(result.authenticated?).to be(true)
+        expect(result.user).to eq('acct_42')
+      end
+
+      it 'accepts a String user of the same length as the presented key' do
+        same_length = presented.reverse
+        expect(same_length.bytesize).to eq(presented.bytesize)
+        by_id = described_class.new { |key| key == presented ? same_length : nil }
+        result = by_id.authenticate(env_with_header(presented), nil)
+        expect(result.user).to eq(same_length)
       end
 
       it 'does not call the block for a blank header and fails non-terminally' do

--- a/spec/otto/security/authentication/strategies/api_key_strategy_spec.rb
+++ b/spec/otto/security/authentication/strategies/api_key_strategy_spec.rb
@@ -131,6 +131,13 @@ RSpec.describe Otto::Security::Authentication::Strategies::APIKeyStrategy do
       expect(result.failure_reason).to eq('No API key provided')
     end
 
+    it 'rejects a whitespace-only header credential as missing, non-terminally' do
+      result = strategy.authenticate(env_with_header("  \t\n"), nil)
+      expect(result.authenticated?).to be(false)
+      expect(result.terminal?).to be(false)
+      expect(result.failure_reason).to eq('No API key provided')
+    end
+
     it 'compares fixed-width digests so configured key lengths are not observable' do
       mixed = described_class.new(api_keys: %w[k a-much-longer-configured-key])
       compared = []
@@ -318,6 +325,19 @@ RSpec.describe Otto::Security::Authentication::Strategies::APIKeyStrategy do
           account
         end
         result = strict.authenticate(env_with_header(''), nil)
+        expect(called).to be(false)
+        expect(result.authenticated?).to be(false)
+        expect(result.terminal?).to be(false)
+        expect(result.failure_reason).to eq('No API key provided')
+      end
+
+      it 'does not call the block for a whitespace-only header and fails non-terminally' do
+        called = false
+        strict = described_class.new do |_key|
+          called = true
+          account
+        end
+        result = strict.authenticate(env_with_header('   '), nil)
         expect(called).to be(false)
         expect(result.authenticated?).to be(false)
         expect(result.terminal?).to be(false)

--- a/spec/otto/security/authentication/strategies/api_key_strategy_spec.rb
+++ b/spec/otto/security/authentication/strategies/api_key_strategy_spec.rb
@@ -3,39 +3,116 @@
 require_relative '../../../../spec_helper'
 
 RSpec.describe Otto::Security::Authentication::Strategies::APIKeyStrategy do
-  def env_with_header(value)
-    { 'HTTP_X_API_KEY' => value }
+  def env_with_header(value, header: 'HTTP_X_API_KEY')
+    { header => value }
+  end
+
+  def env_with_param(query, param: 'api_key')
+    Rack::MockRequest.env_for("/?#{param}=#{query}")
+  end
+
+  describe '#initialize' do
+    it 'requires the api_keys keyword' do
+      expect { described_class.new }.to raise_error(ArgumentError)
+    end
+
+    it 'rejects an empty array' do
+      expect { described_class.new(api_keys: []) }
+        .to raise_error(ArgumentError, /at least one non-empty API key/)
+    end
+
+    it 'rejects nil' do
+      expect { described_class.new(api_keys: nil) }
+        .to raise_error(ArgumentError, /at least one non-empty API key/)
+    end
+
+    it 'rejects an array of only empty strings' do
+      expect { described_class.new(api_keys: ['']) }
+        .to raise_error(ArgumentError, /at least one non-empty API key/)
+    end
+
+    it 'rejects an array of only blank and nil values' do
+      expect { described_class.new(api_keys: ['', nil]) }
+        .to raise_error(ArgumentError, /at least one non-empty API key/)
+    end
   end
 
   describe '#authenticate' do
-    context 'with configured API keys' do
-      subject(:strategy) { described_class.new(api_keys: %w[key-one key-two]) }
+    subject(:strategy) { described_class.new(api_keys: %w[key-one key-two key-three]) }
 
-      it 'authenticates a correct API key' do
-        result = strategy.authenticate(env_with_header('key-two'), nil)
-        expect(result.authenticated?).to be(true)
-        expect(result.user[:api_key]).to eq('key-two')
-      end
-
-      it 'rejects an incorrect API key' do
-        result = strategy.authenticate(env_with_header('wrong-key'), nil)
-        expect(result.authenticated?).to be(false)
-      end
-
-      it 'rejects a request with no API key' do
-        result = strategy.authenticate({}, nil)
-        expect(result.authenticated?).to be(false)
-      end
+    it 'authenticates a correct API key from the header' do
+      result = strategy.authenticate(env_with_header('key-two'), nil)
+      expect(result.authenticated?).to be(true)
+      expect(result.user[:api_key]).to eq('key-two')
     end
 
-    context 'with no API keys configured' do
-      subject(:strategy) { described_class.new(api_keys: []) }
+    it 'authenticates a correct API key from the query parameter' do
+      result = strategy.authenticate(env_with_param('key-one'), nil)
+      expect(result.authenticated?).to be(true)
+      expect(result.user[:api_key]).to eq('key-one')
+    end
 
-      it 'accepts any provided API key' do
-        result = strategy.authenticate(env_with_header('anything-goes'), nil)
-        expect(result.authenticated?).to be(true)
-        expect(result.user[:api_key]).to eq('anything-goes')
-      end
+    it 'authenticates the first configured key' do
+      expect(strategy.authenticate(env_with_header('key-one'), nil).authenticated?).to be(true)
+    end
+
+    it 'authenticates the last configured key' do
+      expect(strategy.authenticate(env_with_header('key-three'), nil).authenticated?).to be(true)
+    end
+
+    it 'supports a custom header name' do
+      custom = described_class.new(api_keys: ['secret'], header_name: 'X-Otto-Token')
+      result = custom.authenticate(env_with_header('secret', header: 'HTTP_X_OTTO_TOKEN'), nil)
+      expect(result.authenticated?).to be(true)
+    end
+
+    it 'supports a custom param name' do
+      custom = described_class.new(api_keys: ['secret'], param_name: 'token')
+      result = custom.authenticate(env_with_param('secret', param: 'token'), nil)
+      expect(result.authenticated?).to be(true)
+    end
+
+    it 'rejects a request with no API key, non-terminally' do
+      result = strategy.authenticate({}, nil)
+      expect(result.authenticated?).to be(false)
+      expect(result.terminal?).to be(false)
+      expect(result.failure_reason).to eq('No API key provided')
+    end
+
+    it 'rejects an empty-string header credential' do
+      result = strategy.authenticate(env_with_header(''), nil)
+      expect(result.authenticated?).to be(false)
+      expect(result.failure_reason).to eq('No API key provided')
+    end
+
+    it 'rejects an array-valued credential terminally instead of raising' do
+      env = Rack::MockRequest.env_for('/?api_key[]=key-one')
+      result = strategy.authenticate(env, nil)
+      expect(result.authenticated?).to be(false)
+      expect(result.terminal?).to be(true)
+      expect(result.failure_reason).to eq('Invalid API key')
+    end
+
+    it 'rejects a hash-valued credential terminally instead of raising' do
+      env = Rack::MockRequest.env_for('/?api_key[k]=key-one')
+      result = strategy.authenticate(env, nil)
+      expect(result.authenticated?).to be(false)
+      expect(result.terminal?).to be(true)
+    end
+
+    it 'rejects an incorrect API key terminally' do
+      result = strategy.authenticate(env_with_header('wrong-key'), nil)
+      expect(result.authenticated?).to be(false)
+      expect(result.terminal?).to be(true)
+      expect(result.failure_reason).to eq('Invalid API key')
+    end
+
+    it 'compares against every configured key even when the first matches' do
+      # Message expectation (not have_received) is the point: assert the call
+      # count happens during authenticate, proving no short-circuit.
+      # rubocop:disable-next RSpec/MessageSpies
+      expect(Rack::Utils).to receive(:secure_compare).exactly(3).times.and_call_original
+      expect(strategy.authenticate(env_with_header('key-one'), nil).authenticated?).to be(true)
     end
   end
 end

--- a/spec/otto/security/authentication/strategy_result_spec.rb
+++ b/spec/otto/security/authentication/strategy_result_spec.rb
@@ -1,0 +1,255 @@
+# spec/otto/security/authentication/strategy_result_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Otto::Security::Authentication::StrategyResult do
+  def build(user)
+    described_class.new(
+      session: {},
+      user: user,
+      auth_method: 'apikey',
+      metadata: {},
+      strategy_name: 'apikey'
+    )
+  end
+
+  describe '#roles' do
+    context 'with a Hash user' do
+      it 'reads :roles' do
+        expect(build({ roles: [:admin, 'editor'] }).roles).to eq(%w[admin editor])
+      end
+
+      it "reads 'roles'" do
+        expect(build({ 'roles' => ['admin'] }).roles).to eq(['admin'])
+      end
+
+      it 'falls back to :role' do
+        expect(build({ role: :admin }).roles).to eq(['admin'])
+      end
+
+      it 'returns [] when neither key is present' do
+        expect(build({ id: 1 }).roles).to eq([])
+      end
+    end
+
+    context 'with a PORO user exposing #roles' do
+      let(:user_class) do
+        Class.new do
+          def roles = [:admin, 'editor']
+        end
+      end
+
+      it 'normalizes the array to strings' do
+        expect(build(user_class.new).roles).to eq(%w[admin editor])
+      end
+    end
+
+    context 'with a PORO user exposing a single #roles value' do
+      let(:user_class) do
+        Class.new do
+          def roles = :admin
+        end
+      end
+
+      it 'wraps the scalar' do
+        expect(build(user_class.new).roles).to eq(['admin'])
+      end
+    end
+
+    context 'with a PORO user exposing #role only' do
+      let(:user_class) do
+        Class.new do
+          def role = :editor
+        end
+      end
+
+      it 'uses the single role' do
+        expect(build(user_class.new).roles).to eq(['editor'])
+      end
+    end
+
+    context 'with a PORO user whose #roles is nil but #role is set' do
+      let(:user_class) do
+        Class.new do
+          def roles = nil
+          def role = 'viewer'
+        end
+      end
+
+      it 'falls through to #role' do
+        expect(build(user_class.new).roles).to eq(['viewer'])
+      end
+    end
+
+    context 'with a PORO user exposing neither #roles nor #role' do
+      let(:user_class) do
+        Class.new do
+          def id = 42
+        end
+      end
+
+      it 'returns [] without raising' do
+        expect(build(user_class.new).roles).to eq([])
+      end
+
+      it 'does not raise from #to_h' do
+        expect { build(user_class.new).to_h }.not_to raise_error
+      end
+
+      it 'does not raise from #inspect' do
+        expect(build(user_class.new).inspect).to include('roles=[]')
+      end
+    end
+
+    context 'with a Data instance user' do
+      let(:user_data) { Data.define(:id, :roles) }
+
+      it 'reads #roles' do
+        expect(build(user_data.new(id: 1, roles: ['admin'])).roles).to eq(['admin'])
+      end
+    end
+
+    context 'with a Data instance user lacking a roles member' do
+      let(:user_data) { Data.define(:id) }
+
+      it 'returns [] without raising' do
+        expect(build(user_data.new(id: 1)).roles).to eq([])
+      end
+    end
+
+    context 'with a Struct instance user' do
+      let(:user_struct) { Struct.new(:id, :roles) }
+
+      it 'reads #roles' do
+        expect(build(user_struct.new(1, [:admin])).roles).to eq(['admin'])
+      end
+
+      it 'returns [] when roles is nil' do
+        expect(build(user_struct.new(1, nil)).roles).to eq([])
+      end
+    end
+
+    context 'with a Struct instance user lacking a roles member' do
+      let(:user_struct) { Struct.new(:id) }
+
+      it 'returns [] without calling #[]' do
+        expect(build(user_struct.new(1)).roles).to eq([])
+      end
+    end
+
+    context 'with an ORM-like user responding to #[], #roles and #role' do
+      let(:user_class) do
+        Class.new do
+          def initialize(roles:, role: nil)
+            @attrs = { 'role' => role }
+            @roles = roles
+          end
+
+          attr_reader :roles
+
+          def id = 7
+          def [](key) = @attrs[key.to_s]
+          def role = @attrs['role']
+        end
+      end
+
+      it 'prefers #roles over #[] and #role' do
+        expect(build(user_class.new(roles: %w[admin editor], role: 'viewer')).roles).to eq(%w[admin editor])
+      end
+
+      it 'falls back to #role when #roles is empty' do
+        expect(build(user_class.new(roles: [], role: 'viewer')).roles).to eq(['viewer'])
+      end
+
+      it 'expands a Set of roles' do
+        expect(build(user_class.new(roles: Set['admin', :editor])).roles).to eq(%w[admin editor])
+      end
+    end
+
+    it 'returns [] when anonymous' do
+      expect(described_class.anonymous.roles).to eq([])
+    end
+  end
+
+  describe '#permissions' do
+    context 'with a Hash user' do
+      it 'reads :permissions' do
+        expect(build({ permissions: [:read, 'write'] }).permissions).to eq(%w[read write])
+      end
+
+      it "reads 'permissions'" do
+        expect(build({ 'permissions' => 'read' }).permissions).to eq(['read'])
+      end
+
+      it 'returns [] when absent' do
+        expect(build({ id: 1 }).permissions).to eq([])
+      end
+    end
+
+    context 'with a PORO user exposing #permissions' do
+      let(:user_class) do
+        Class.new do
+          def permissions = [:read, 'write']
+        end
+      end
+
+      it 'normalizes to strings' do
+        expect(build(user_class.new).permissions).to eq(%w[read write])
+      end
+    end
+
+    context 'with a PORO user exposing a scalar #permissions' do
+      let(:user_class) do
+        Class.new do
+          def permissions = :read
+        end
+      end
+
+      it 'wraps the scalar' do
+        expect(build(user_class.new).permissions).to eq(['read'])
+      end
+    end
+
+    context 'with a PORO user without #permissions' do
+      let(:user_class) do
+        Class.new do
+          def id = 42
+        end
+      end
+
+      it 'returns [] without raising' do
+        expect(build(user_class.new).permissions).to eq([])
+      end
+
+      it 'does not raise from #to_h' do
+        expect(build(user_class.new).to_h).to include(roles: [], permissions: [])
+      end
+    end
+
+    context 'with a Data instance user' do
+      let(:user_data) { Data.define(:id, :permissions) }
+
+      it 'reads #permissions' do
+        expect(build(user_data.new(id: 1, permissions: ['read'])).permissions).to eq(['read'])
+      end
+
+      it 'returns [] when permissions is nil' do
+        expect(build(user_data.new(id: 1, permissions: nil)).permissions).to eq([])
+      end
+    end
+
+    context 'with a Struct instance user lacking a permissions member' do
+      let(:user_struct) { Struct.new(:id) }
+
+      it 'returns [] without calling #[]' do
+        expect(build(user_struct.new(1)).permissions).to eq([])
+      end
+    end
+
+    it 'returns [] when anonymous' do
+      expect(described_class.anonymous.permissions).to eq([])
+    end
+  end
+end

--- a/spec/otto/security/authentication/strategy_result_spec.rb
+++ b/spec/otto/security/authentication/strategy_result_spec.rb
@@ -252,4 +252,104 @@ RSpec.describe Otto::Security::Authentication::StrategyResult do
       expect(described_class.anonymous.permissions).to eq([])
     end
   end
+
+  describe '#has_role?' do
+    let(:orm_like) do
+      Class.new do
+        def initialize(roles:, role: nil)
+          @roles = roles
+          @role = role
+        end
+
+        attr_reader :roles, :role
+
+        def id = 7
+        def [](_key) = nil
+      end
+    end
+
+    it 'agrees with #roles for a Set-backed ORM-like user' do
+      result = build(orm_like.new(roles: Set['admin']))
+      expect(result.roles).to eq(['admin'])
+      expect(result.has_role?(:admin)).to be(true)
+      expect(result.has_role?('admin')).to be(true)
+      expect(result.has_role?(:viewer)).to be(false)
+    end
+
+    it 'consults #roles before a single #role' do
+      result = build(orm_like.new(roles: %w[admin editor], role: 'viewer'))
+      expect(result.has_role?(:admin)).to be(true)
+      expect(result.has_role?(:editor)).to be(true)
+      expect(result.has_role?(:viewer)).to be(false)
+    end
+
+    it 'falls back to #role when #roles is empty' do
+      result = build(orm_like.new(roles: [], role: 'viewer'))
+      expect(result.has_role?(:viewer)).to be(true)
+    end
+
+    it 'reads a Hash :roles array' do
+      result = build({ roles: %w[admin] })
+      expect(result.has_role?(:admin)).to be(true)
+      expect(result.has_role?(:editor)).to be(false)
+    end
+
+    it 'reads a Hash :role scalar' do
+      expect(build({ 'role' => :admin }).has_role?('admin')).to be(true)
+    end
+
+    it 'delegates to a user model defining #has_role?' do
+      model = Struct.new(:granted) do
+        def has_role?(role) = granted.include?(role.to_s)
+      end
+      expect(build(model.new(%w[ops])).has_role?(:ops)).to be(true)
+      expect(build(model.new(%w[ops])).has_role?(:admin)).to be(false)
+    end
+
+    it 'is false for a user without role support' do
+      expect(build(Object.new).has_role?(:admin)).to be(false)
+    end
+
+    it 'is false when anonymous' do
+      expect(described_class.anonymous.has_role?(:admin)).to be(false)
+    end
+  end
+
+  describe '#has_permission?' do
+    it 'agrees with #permissions for a Set-backed PORO user' do
+      user = Struct.new(:permissions).new(Set['read', :write])
+      result = build(user)
+      expect(result.permissions).to eq(%w[read write])
+      expect(result.has_permission?(:read)).to be(true)
+      expect(result.has_permission?('write')).to be(true)
+      expect(result.has_permission?(:delete)).to be(false)
+    end
+
+    it 'agrees with #permissions for a Hash user holding a Set' do
+      result = build({ permissions: Set['read'] })
+      expect(result.permissions).to eq(['read'])
+      expect(result.has_permission?(:read)).to be(true)
+    end
+
+    it 'reads a Hash permissions array' do
+      expect(build({ 'permissions' => %w[read] }).has_permission?(:read)).to be(true)
+      expect(build({ 'permissions' => %w[read] }).has_permission?(:write)).to be(false)
+    end
+
+    it 'delegates to a user model defining #has_permission?' do
+      model = Struct.new(:granted) do
+        def has_permission?(permission) = granted.include?(permission.to_s)
+      end
+      expect(build(model.new(%w[read])).has_permission?(:read)).to be(true)
+      expect(build(model.new(%w[read])).has_permission?(:write)).to be(false)
+    end
+
+    it 'is false for a user without permission support' do
+      expect(build(Object.new).has_permission?(:read)).to be(false)
+    end
+
+    it 'is false when anonymous' do
+      expect(described_class.anonymous.has_permission?(:read)).to be(false)
+    end
+  end
 end

--- a/spec/otto/security/route_auth_wrapper_spec.rb
+++ b/spec/otto/security/route_auth_wrapper_spec.rb
@@ -1188,6 +1188,22 @@ RSpec.describe Otto::Security::Authentication::RouteAuthWrapper do
                   metadata: { user_roles: ['admin'] },
                   strategy_name: 'custom'
                 )
+              when :user_object_with_roles
+                Otto::Security::Authentication::StrategyResult.new(
+                  user: Data.define(:id, :roles).new(id: 123, roles: ['admin']),
+                  session: env['rack.session'],
+                  auth_method: 'custom',
+                  metadata: {},
+                  strategy_name: 'custom'
+                )
+              when :user_object_without_roles
+                Otto::Security::Authentication::StrategyResult.new(
+                  user: Data.define(:id).new(id: 123),
+                  session: env['rack.session'],
+                  auth_method: 'custom',
+                  metadata: {},
+                  strategy_name: 'custom'
+                )
               end
             end
           end.new
@@ -1242,6 +1258,29 @@ RSpec.describe Otto::Security::Authentication::RouteAuthWrapper do
 
         status, _headers, _body = wrapper.call(env)
         expect(status).to eq(200)
+      end
+
+      it 'extracts roles from an object-backed user via #roles' do
+        config = { auth_strategies: { 'custom' => custom_strategy.call(:user_object_with_roles) } }
+        wrapper = described_class.new(mock_handler, role_route, config)
+
+        env = mock_rack_env
+        env['rack.session'] = { 'user_id' => 123 }
+
+        status, _headers, _body = wrapper.call(env)
+        expect(status).to eq(200)
+      end
+
+      it 'denies (403) an object-backed user without #roles instead of raising' do
+        config = { auth_strategies: { 'custom' => custom_strategy.call(:user_object_without_roles) } }
+        wrapper = described_class.new(mock_handler, role_route, config)
+
+        env = mock_rack_env
+        env['rack.session'] = { 'user_id' => 123 }
+
+        status = nil
+        expect { status, _headers, _body = wrapper.call(env) }.not_to raise_error
+        expect(status).to eq(403)
       end
     end
   end


### PR DESCRIPTION
`APIKeyStrategy.new` now requires an `api_keys:` source and raises `ArgumentError` on an empty or blank list, removing the auth-time fallback that let an unconfigured strategy accept any key. A key mismatch is terminal rather than falling through to the next strategy, and the query parameter is only consulted when `param_name` is given.

Results carry a truncated SHA-256 `api_key_fingerprint` instead of the raw key, and `StrategyResult` guarantees strategy-generated fields never contain the presented key. Static key lists are copied and frozen at construction.

Adds a block/resolver form so keys can be looked up dynamically (databases, secret stores) alongside the static-list default, and object-backed users now work in role and permission extraction. Auth strategy constructors call `super`, and the auth guides and reference examples are rewritten against the required-keys API.

Includes changelog fragments, fail-closed integration specs, and expanded strategy and result specs.

Closes #256