### PR TITLE
Make static route precedence deterministic

### DIFF
--- a/changelog.d/20260904_133000_static_symlink_containment.rst
+++ b/changelog.d/20260904_133000_static_symlink_containment.rst
@@ -11,14 +11,8 @@ Security
   looping and non-directory components fail closed. A symlinked public root
   (the usual ``public -> releases/<n>/public`` deploy layout) still works.
 
-- Re-check containment on cached static routes (#257). ``routes_static``
-  caches the *directory* of an approved file, and a cache hit previously
-  skipped ``safe_file?`` entirely, authorizing every sibling of an
-  already-served asset. The cache is now only a dispatch-ordering hint, and it
-  is keyed on the canonical directory of a validated file instead of the raw
-  request path (which let ``.`` segments mint unbounded keys). Static
-  responses are served from the validated canonical path: ``Rack::Files`` is
-  rooted at the canonical public directory and ``PATH_INFO`` is rewritten to
-  the canonical relative path, so neither the root nor the path below it is
+- Serve static responses from the validated canonical path (#257).
+  ``Rack::Files`` is rooted at the canonical public directory and receives the
+  canonical relative path, so neither the root nor the path below it is
   traversed through a symlink at open time. NUL bytes in a request path are
   rejected rather than stripped.

--- a/changelog.d/20260904_160000_static_literal_precedence.rst
+++ b/changelog.d/20260904_160000_static_literal_precedence.rst
@@ -1,0 +1,13 @@
+Changed
+-------
+
+- Literal routes now consistently take precedence over static files at the same
+  path, regardless of which static files were requested earlier. Static files
+  continue to take precedence over dynamic routes. (#260)
+
+Removed
+-------
+
+- Removed ``add_static_path`` and the ``routes_static`` cache interface. Static
+  files are discovered directly from the configured ``public`` directory and
+  no longer need registration. (#260)

--- a/docs/guides/configuration_freezing.md
+++ b/docs/guides/configuration_freezing.md
@@ -20,7 +20,7 @@ This lazy approach allows multi-app architectures (like OneTime Secret's registr
 
 - **Security Config**: All security settings including CSRF, validation, rate limiting, and headers
 - **Middleware Stack**: Prevents adding, removing, or modifying middleware after initialization
-- **Routes**: All route structures (`@routes`, `@routes_literal`, `@routes_static`, `@route_definitions`)
+- **Routes**: All route structures (`@routes`, `@routes_literal`, `@route_definitions`)
 - **Configuration Hashes**: `@auth_config`, `@locale_config`, `@option` and all nested structures
 
 ## Security Guarantees

--- a/examples/basic/config.ru
+++ b/examples/basic/config.ru
@@ -20,7 +20,6 @@ if Otto.env?(:dev)
     use Rack::CommonLogger
     use Rack::Reloader, 0
     app.option[:public] = public_path
-    app.add_static_path '/favicon.ico'
     run app
   end
 

--- a/lib/otto.rb
+++ b/lib/otto.rb
@@ -76,7 +76,7 @@ class Otto
            end
   @logger = Logger.new($stdout, Logger::INFO)
 
-  attr_reader :routes, :routes_literal, :routes_static, :route_definitions,
+  attr_reader :routes, :routes_literal, :route_definitions,
               :routes_by_definition, :option,
               :static_route, :security_config, :locale_config, :auth_config,
               :route_handler_factory, :mcp_server, :caddy_tls_server, :security, :middleware,
@@ -180,16 +180,6 @@ class Otto
   private
 
   def initialize_core_state
-    # The GET cache is a Concurrent::Map, not a plain Hash: lazy static-file
-    # discovery (Core::Router#handle_request, Core::FileSafety#add_static_path)
-    # writes into it at request time, after freeze_configuration! has already
-    # deep-frozen the rest of the routing state. Deep-freezing this cache too
-    # would turn every as-yet-uncached static file request into a 500
-    # (FrozenError) in production (issue #185), so it is intentionally excluded
-    # from deep_freeze_value in Configuration#freeze_configuration! and kept as
-    # a structure that is both mutable post-freeze and safe under concurrent
-    # request threads.
-    @routes_static     = { GET: Concurrent::Map.new }
     @routes            = { GET: [] }
     @routes_literal    = { GET: {} }
     @route_definitions = {}

--- a/lib/otto/core/configuration.rb
+++ b/lib/otto/core/configuration.rb
@@ -291,16 +291,6 @@ class Otto
         # Deep freeze route structures (prevent modification of nested hashes/arrays)
         deep_freeze_value(@routes) if @routes
         deep_freeze_value(@routes_literal) if @routes_literal
-        # @routes_static is intentionally NOT deep-frozen: its :GET entry is a
-        # Concurrent::Map that lazy static-file discovery writes into at
-        # request time (Core::Router#handle_request, Core::FileSafety#add_static_path),
-        # after this method has already run. Deep-freezing it would turn the
-        # first request for any as-yet-uncached static file into a
-        # FrozenError / 500 in production (issue #185). The outer hash is
-        # still shallow-frozen so its verb-key structure (currently just
-        # :GET) can't be altered post-freeze, while the Concurrent::Map value
-        # stays writable.
-        @routes_static.freeze if @routes_static && !@routes_static.frozen?
         deep_freeze_value(@route_definitions) if @route_definitions
         deep_freeze_value(@routes_by_definition) if @routes_by_definition
 

--- a/lib/otto/core/file_safety.rb
+++ b/lib/otto/core/file_safety.rb
@@ -91,24 +91,6 @@ class Otto
           (File.owned?(real_path) || File.grpowned?(real_path))
       end
 
-      def add_static_path(path)
-        static_file = resolve_static_file(path)
-        return if static_file.nil?
-
-        base_path = static_cache_key(static_file)
-        Otto.logger.debug "new static route: #{base_path} (#{path})" if Otto.debug
-        routes_static[:GET][base_path] = base_path
-      end
-
-      # Bounded cache key for routes_static[:GET]: the canonical directory of
-      # a validated file, rooted at '/' ('/assets', or '/' for files directly
-      # in the public root). Keying on the request path instead let '.'
-      # segments mint unbounded distinct keys (issue #257).
-      def static_cache_key(static_file)
-        dir = File.dirname(static_file.relative)
-        dir == '.' ? '/' : "/#{dir}"
-      end
-
       private
 
       # Canonical public root, or nil when it is missing/not a directory.

--- a/lib/otto/core/router.rb
+++ b/lib/otto/core/router.rb
@@ -140,31 +140,12 @@ class Otto
         # for them. Literal lookup keeps '' — it already keys root that way.
         dispatch_path = path_info_clean.empty? ? '/' : path_info_clean
 
-        # Static dispatch is gated on the SAME containment check every time,
-        # including cache hits (issue #257). routes_static caches the base
-        # path (the *directory* of an approved file), so a cache hit alone
-        # authorized every sibling of an already-served file -- a symlink
-        # dropped next to it escaped the public root. The cache now only
-        # decides ordering versus literal routes, never safety.
         static_candidate = !static_route.nil? && http_verb == :GET
-        # The cache is keyed on the CANONICAL directory of an approved file
-        # (see #static_cache_key), not on File.split of the request path: the
-        # latter preserved '.' segments, so '/a/./././x.txt' variants minted
-        # unbounded distinct keys in the Concurrent::Map. Lookups use the
-        # lexical dirname; odd paths simply miss and take the cold branch.
-        lookup_key       = File.dirname(dispatch_path)
-        static_file      = if static_candidate && routes_static[:GET].key?(lookup_key)
-                             resolve_static_file(dispatch_path)
-                           end
 
-        if static_file
-          Otto.structured_log(:debug, 'Route matched',
-            Otto::LoggingHelpers.request_context(env).merge(
-              type: 'static_cached',
-              base_path: lookup_key
-            ))
-          serve_static_file(env, static_file)
-        elsif literal_routes.has_key?(path_info_clean)
+        # Dispatch precedence is fixed: literal routes, then static files, then
+        # dynamic routes. Static-file requests always pass through containment
+        # validation before they are served (issues #257 and #260).
+        if literal_routes.has_key?(path_info_clean)
           route = literal_routes[path_info_clean]
           Otto.structured_log(:debug, 'Route matched',
             Otto::LoggingHelpers.request_context(env).merge(
@@ -178,13 +159,8 @@ class Otto
           end
           route.call(env)
         elsif static_candidate && (static_file = resolve_static_file(dispatch_path))
-          cache_key = static_cache_key(static_file)
           Otto.structured_log(:debug, 'Route matched',
-            Otto::LoggingHelpers.request_context(env).merge(
-              type: 'static_new',
-              base_path: cache_key
-            ))
-          routes_static[:GET][cache_key] = cache_key
+            Otto::LoggingHelpers.request_context(env).merge(type: 'static'))
           serve_static_file(env, static_file)
         else
           match_dynamic_route(env, dispatch_path, http_verb, literal_routes)

--- a/spec/otto/file_safety_spec.rb
+++ b/spec/otto/file_safety_spec.rb
@@ -173,9 +173,9 @@ RSpec.describe Otto, 'file safety checks' do
     end
   end
 
-  # The static route cache keys on the *directory* of an approved file, so a
-  # cache hit used to skip safe_file? entirely and serve any sibling -- an
-  # escaping symlink dropped next to an already-served asset returned 200.
+  # Static dispatch must validate every candidate before serving it. An
+  # escaping symlink dropped next to an already-served asset must not inherit
+  # approval from the prior request.
   describe 'static dispatch containment (issue #257)' do
     let(:public_dir) { Dir.mktmpdir('otto_public') }
     let(:outside_dir) { Dir.mktmpdir('otto_outside') }
@@ -199,9 +199,8 @@ RSpec.describe Otto, 'file safety checks' do
       expect(body.to_enum(:each).to_a.join).to eq('ok')
     end
 
-    it 'does not serve an escaping symlink through a warm base-path cache' do
+    it 'does not serve an escaping symlink after serving a sibling file' do
       expect(app.call(Rack::MockRequest.env_for('/assets/ok.txt'))[0]).to eq(200)
-      expect(app.routes_static[:GET].key?('/assets')).to be true
 
       File.symlink(outside_dir, File.join(public_dir, 'assets', 'esc'))
       status, _headers, body = app.call(Rack::MockRequest.env_for('/assets/esc/secret.txt'))
@@ -210,27 +209,13 @@ RSpec.describe Otto, 'file safety checks' do
       expect(body.to_enum(:each).to_a.join).not_to include('SECRET')
     end
 
-    it 'does not serve an escaping symlink on a cold cache' do
+    it 'does not serve an escaping symlink on the first request' do
       File.symlink(File.join(outside_dir, 'secret.txt'), File.join(public_dir, 'link.txt'))
 
       status, _headers, body = app.call(Rack::MockRequest.env_for('/link.txt'))
 
       expect(status).to eq(404)
       expect(body.to_enum(:each).to_a.join).not_to include('SECRET')
-    end
-
-    # The cache used to key on File.split(path_info).first, which preserves
-    # '.' segments: '/assets/./././ok.txt' variants minted a distinct key per
-    # request, an attacker-driven leak in the Concurrent::Map.
-    it 'keeps the static cache key space bounded under dot-segment variants' do
-      expect(app.call(Rack::MockRequest.env_for('/assets/ok.txt'))[0]).to eq(200)
-
-      25.times do |i|
-        path = "/assets/#{'./' * (i + 1)}ok.txt"
-        expect(app.call(Rack::MockRequest.env_for(path))[0]).to eq(200)
-      end
-
-      expect(app.routes_static[:GET].keys).to contain_exactly('/assets')
     end
 
     it 'serves through a canonical Rack::Files root when the public root is a symlink' do

--- a/spec/otto/initialization_spec.rb
+++ b/spec/otto/initialization_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe Otto, 'initialization' do
       expect(otto).to be_an_instance_of(described_class)
       expect(otto.routes).to have_key(:GET)
       expect(otto.routes_literal).to have_key(:GET)
-      expect(otto.routes_static).to have_key(:GET)
     end
 
     it 'initializes security config with safe defaults' do

--- a/spec/otto/static_file_freezing_spec.rb
+++ b/spec/otto/static_file_freezing_spec.rb
@@ -4,67 +4,37 @@
 
 require 'spec_helper'
 
-# Regression coverage for issue #185: lazy static-file discovery
-# (Core::Router#handle_request / Core::FileSafety#add_static_path) writes into
-# routes_static[:GET] at request time, but freeze_configuration! runs before
-# any request is served. Under RSpec that freeze is skipped for #call, so
-# these specs freeze explicitly to exercise the path the way production does
-# (lazy freeze on the first real request).
 RSpec.describe Otto, 'static file serving after configuration freeze' do
-  subject(:otto) { described_class.new(nil, { public: '/tmp/test_static_freezing' }) }
-
-  before do
-    Dir.mkdir('/tmp/test_static_freezing') unless Dir.exist?('/tmp/test_static_freezing')
-    File.write('/tmp/test_static_freezing/asset.txt', 'asset content')
-  end
+  let(:public_dir) { Dir.mktmpdir('otto_static_freezing') }
 
   after do
-    FileUtils.rm_rf('/tmp/test_static_freezing') if Dir.exist?('/tmp/test_static_freezing')
+    FileUtils.remove_entry(public_dir) if File.exist?(public_dir)
   end
 
-  it 'serves an uncached static file without raising FrozenError' do
-    otto.freeze_configuration!
-    expect(otto.frozen_configuration?).to be true
-    expect(otto.routes_static[:GET].key?('/')).to be false
+  it 'serves a static file after configuration is frozen' do
+    File.write(File.join(public_dir, 'asset.txt'), 'asset content')
+    app = described_class.new(nil, { public: public_dir })
+    app.freeze_configuration!
 
-    status, = otto.call(Rack::MockRequest.env_for('/asset.txt'))
+    status, _headers, body = app.call(Rack::MockRequest.env_for('/asset.txt'))
 
+    expect(app.frozen_configuration?).to be true
     expect(status).to eq(200)
+    expect(body.to_enum(:each).to_a.join).to eq('asset content')
   end
 
-  # The cache key is the canonical *directory* of the served file (issue
-  # #257), so a file in the public root is cached under '/'.
-  it 'caches the base path in routes_static[:GET] for subsequent requests' do
-    otto.freeze_configuration!
-
-    otto.call(Rack::MockRequest.env_for('/asset.txt'))
-
-    expect(otto.routes_static[:GET].key?('/')).to be true
-  end
-
-  it 'does not deep-freeze routes_static, so the request-time cache write succeeds' do
-    otto.freeze_configuration!
-
-    expect { otto.routes_static[:GET]['/manual.txt'] = '/manual.txt' }.not_to raise_error
-  end
-
-  it 'shallow-freezes the outer routes_static hash so its verb-key structure cannot change' do
-    otto.freeze_configuration!
-
-    expect(otto.routes_static).to be_frozen
-    expect { otto.routes_static[:DELETE] = {} }.to raise_error(FrozenError)
-  end
-
-  it 'survives concurrent requests for distinct uncached files without error or lost writes' do
+  it 'serves concurrent static requests after configuration is frozen' do
     file_count = 50
-    file_count.times { |i| File.write("/tmp/test_static_freezing/concurrent_#{i}.txt", "content #{i}") }
-    otto.freeze_configuration!
+    file_count.times { |i| File.write(File.join(public_dir, "concurrent_#{i}.txt"), "content #{i}") }
+    app = described_class.new(nil, { public: public_dir })
+    app.freeze_configuration!
 
     errors = Queue.new
     threads = Array.new(file_count) do |i|
       Thread.new do
-        status, = otto.call(Rack::MockRequest.env_for("/concurrent_#{i}.txt"))
-        errors << "unexpected status #{status} for concurrent_#{i}.txt" unless status == 200
+        status, _headers, body = app.call(Rack::MockRequest.env_for("/concurrent_#{i}.txt"))
+        content = body.to_enum(:each).to_a.join
+        errors << "unexpected response #{status}: #{content}" unless status == 200 && content == "content #{i}"
       rescue StandardError => e
         errors << "#{e.class}: #{e.message}"
       end
@@ -72,6 +42,29 @@ RSpec.describe Otto, 'static file serving after configuration freeze' do
     threads.each(&:join)
 
     expect(errors).to be_empty
-    expect(otto.routes_static[:GET].key?('/')).to be true
+  end
+
+  it 'keeps literal routes ahead of static files regardless of request history' do
+    assets_dir = File.join(public_dir, 'assets')
+    FileUtils.mkdir_p(assets_dir)
+    File.write(File.join(assets_dir, 'collision.txt'), 'static collision')
+    File.write(File.join(assets_dir, 'sibling.txt'), 'static sibling')
+    routes_file = create_test_routes_file(
+      'static_literal_precedence.txt',
+      ['GET /assets/collision.txt TestApp.index']
+    )
+    app = described_class.new(routes_file, { public: public_dir })
+    app.freeze_configuration!
+
+    first = app.call(Rack::MockRequest.env_for('/assets/collision.txt'))
+    sibling = app.call(Rack::MockRequest.env_for('/assets/sibling.txt'))
+    second = app.call(Rack::MockRequest.env_for('/assets/collision.txt'))
+
+    expect(first[0]).to eq(200)
+    expect(first[2].to_enum(:each).to_a.join).to eq('Hello World')
+    expect(sibling[0]).to eq(200)
+    expect(sibling[2].to_enum(:each).to_a.join).to eq('static sibling')
+    expect(second[0]).to eq(200)
+    expect(second[2].to_enum(:each).to_a.join).to eq('Hello World')
   end
 end


### PR DESCRIPTION
## Summary
- Make static route precedence deterministic: literal routes now win over same-path static files, while static files continue to win over dynamic routes.
- Remove the routes_static request-history cache and add_static_path API; every static candidate is resolved and containment-validated directly from the configured public directory.
- Update regression coverage and documentation for frozen configuration, concurrent static requests, symlink containment, and route collisions.

## Review guide
- Start in lib/otto/core/router.rb and verify the fixed literal → static → dynamic dispatch order and per-request static-file validation.
- Review removal of routes_static across initialization, configuration freezing, file safety, examples, and specs; this intentionally removes the public cache interface documented in the changelog.

## Validation
- Pre-commit, pre-push, and CI checks will validate this change.

Resolves #260
