### PR TITLE
[#259] Gate forwarded host authority on trust, add explicit trust-nobody assertion

### DIFF
--- a/changelog.d/20260904_160000_delano_252_forwarded_authority.rst
+++ b/changelog.d/20260904_160000_delano_252_forwarded_authority.rst
@@ -1,0 +1,16 @@
+Security
+--------
+
+- When proxy trust is configured, forwarded host, scheme, and port metadata
+  from untrusted peers is now stripped before it can affect Rack's request
+  authority. Requests from trusted peers retain this metadata; see
+  ``docs/guides/forwarded-authority.md`` for deployment guidance. (#252)
+
+Changed
+-------
+
+- Otto applications in one process that resolve proxied requests must now use
+  the same forwarded-header family; incompatible configurations fail during
+  configuration. CIDR-based proxy trust supports only ``X-Forwarded-*`` headers; use
+  depth-based trust for ``Forwarded`` or both families. See
+  ``docs/guides/forwarded-authority.md`` for configuration guidance. (#252)

--- a/changelog.d/20260904_160500_delano_259_trust_no_proxies.rst
+++ b/changelog.d/20260904_160500_delano_259_trust_no_proxies.rst
@@ -1,0 +1,9 @@
+Added
+-----
+
+- Applications exposed directly can now set ``trusted_proxies: :none`` or call
+  ``trust_no_proxies!`` to distrust every peer and strip forwarded authority
+  metadata. This differs from leaving proxy trust unconfigured, which preserves
+  forwarded metadata. Applications behind a reverse proxy, including one on
+  loopback, must explicitly trust that proxy instead. See
+  ``docs/guides/forwarded-authority.md`` for configuration guidance. (#259)

--- a/changelog.d/20260904_160500_delano_259_trust_no_proxies.rst
+++ b/changelog.d/20260904_160500_delano_259_trust_no_proxies.rst
@@ -7,3 +7,8 @@ Added
   forwarded metadata. Applications behind a reverse proxy, including one on
   loopback, must explicitly trust that proxy instead. See
   ``docs/guides/forwarded-authority.md`` for configuration guidance. (#259)
+
+- ``env['otto.peer_relayed']`` records whether a request carried any relay
+  marker header, evaluated before forwarded carriers may be deleted, so
+  ``Otto::CaddyTLS::LocalhostGuard`` still refuses a relayed loopback call once
+  the carriers are stripped. (#259)

--- a/changelog.d/20260904_160500_delano_259_trust_no_proxies.rst
+++ b/changelog.d/20260904_160500_delano_259_trust_no_proxies.rst
@@ -1,21 +1,21 @@
 Added
 -----
 
-- Applications exposed directly can now set ``trusted_proxies: :none`` or call
-  ``trust_no_proxies!`` to distrust every peer and strip forwarded authority
-  metadata. This differs from leaving proxy trust unconfigured, which preserves
-  forwarded metadata. Applications behind a reverse proxy, including one on
-  loopback, must explicitly trust that proxy instead. See
+- Directly exposed applications can now set ``trusted_proxies: :none`` or call
+  ``trust_no_proxies!`` to distrust every peer. Otto then ignores forwarded
+  client IPs and strips forwarded host, scheme, and port metadata. Leaving proxy
+  trust unconfigured continues to preserve forwarded metadata. Applications
+  behind a reverse proxy, including one on loopback, must explicitly trust it.
+  The sentinel is only valid as the whole option; a list containing it, such
+  as ``['none']``, is rejected at configuration time. See
   ``docs/guides/forwarded-authority.md`` for configuration guidance. (#259)
 
-- ``env['otto.peer_relayed']`` records whether a request carried any relay
-  marker header, evaluated before forwarded carriers may be deleted, so
-  ``Otto::CaddyTLS::LocalhostGuard`` still refuses a relayed loopback call once
-  the carriers are stripped. The relay markers cover every carrier the scrub
-  deletes, including ``X-Forwarded-Host`` and the other authority headers, not
-  only the client-IP carriers. (#259)
+Security
+--------
 
-- ``IPPrivacyMiddleware`` enforces its own proxy trust posture even when an
-  outer instance already resolved ``otto.client_ip``. ``trusted_proxies: :none``
-  always strips forwarded authority; a CIDR configuration that can no longer
-  match the connecting peer treats it as untrusted and logs a warning. (#259)
+- Proxy trust is now enforced when privacy middleware runs in both a shared Rack
+  stack and an Otto application. The application applies its own trust posture
+  before retaining forwarded authority metadata. (#259)
+
+- Caddy on-demand TLS authorization now rejects relayed loopback requests even
+  when untrusted forwarded authority metadata is stripped first. (#259)

--- a/changelog.d/20260904_160500_delano_259_trust_no_proxies.rst
+++ b/changelog.d/20260904_160500_delano_259_trust_no_proxies.rst
@@ -11,4 +11,11 @@ Added
 - ``env['otto.peer_relayed']`` records whether a request carried any relay
   marker header, evaluated before forwarded carriers may be deleted, so
   ``Otto::CaddyTLS::LocalhostGuard`` still refuses a relayed loopback call once
-  the carriers are stripped. (#259)
+  the carriers are stripped. The relay markers cover every carrier the scrub
+  deletes, including ``X-Forwarded-Host`` and the other authority headers, not
+  only the client-IP carriers. (#259)
+
+- ``IPPrivacyMiddleware`` enforces its own proxy trust posture even when an
+  outer instance already resolved ``otto.client_ip``. ``trusted_proxies: :none``
+  always strips forwarded authority; a CIDR configuration that can no longer
+  match the connecting peer treats it as untrusted and logs a warning. (#259)

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ the smallest complete configuration that uses it safely.
 | Application model | Plain-text routes; class, instance, Logic-class, and registered lambda handlers; response selection | [Routing](guides/routing.md) and [route syntax](reference/route-syntax.md) |
 | Request lifecycle | Rack integration, middleware ordering, helper registration, lifecycle hooks, and boot-time configuration | `guides/application-lifecycle.md` |
 | Authentication and authorization | Named authentication strategies, ordered multi-strategy fallback, terminal failures, route roles, and resource-level authorization | [Authentication](guides/authentication.md) |
-| Security | CSRF enforcement, request validation, rate limiting, security headers, CSP, error handling, and trusted proxies | `guides/security.md` |
+| Security | CSRF enforcement, request validation, rate limiting, security headers, CSP, error handling, and trusted proxies | `guides/security.md`; [forwarded host authority](guides/forwarded-authority.md) |
 | Runtime and dependencies | Ruby compatibility tiers, upstream security-maintenance limits, dependency-range guarantees, and consumer lockfile auditing | [Runtime and dependency security policy](reference/runtime-and-dependency-security.md) |
 | Privacy and network identity | IP privacy profiles, privacy-safe client signals, country resolution, ASN lookup, and anonymizer classification | [Privacy](guides/privacy.md), [geo-country](guides/geo-country.md), and [enrichment](guides/enrichment.md) |
 | Internationalization | Locale configuration and request locale resolution | `guides/locales.md` |
@@ -40,6 +40,9 @@ the smallest complete configuration that uses it safely.
   fallback, and the privacy model.
 - [ASN and anonymizer enrichment](guides/enrichment.md) — opt-in network signals
   and their database contracts.
+- [Forwarded host authority](guides/forwarded-authority.md) — trust-gated
+  handling of `X-Forwarded-Host` and `Forwarded`, and the process-global Rack
+  forwarding family.
 - [Caddy TLS integration](guides/caddy-tls.md) — deploy the loopback-only
   permission endpoint.
 - [Migration guides](migrating/) — version-specific behavior changes.

--- a/docs/guides/forwarded-authority.md
+++ b/docs/guides/forwarded-authority.md
@@ -93,7 +93,10 @@ behind a proxy without configuring Otto's trust controls.
 Use `trusted_proxies: :none` when clients connect directly to the application
 and no reverse proxy should influence request authority. This explicit assertion
 is different from omitting `trusted_proxies`. The String spelling `'none'` (any
-case) is accepted too, for YAML- or environment-driven configuration.
+case) is accepted too, for YAML- or environment-driven configuration. The
+sentinel is only valid as the whole option: a list that contains it, such as
+`trusted_proxies: ['none']`, is rejected at configuration time rather than
+installed as a proxy entry.
 
 You can also make the assertion after construction, but before the first
 request:

--- a/docs/guides/forwarded-authority.md
+++ b/docs/guides/forwarded-authority.md
@@ -151,6 +151,13 @@ which forwarding family Rack reads: `X-Forwarded-*`, RFC 7239 `Forwarded`, or
 both. Otto pins it to the family selected by `trusted_proxy_header` so Otto and
 Rack interpret the same request metadata.
 
+The pin governs host, port, and the `X-Forwarded-Proto` / `proto=` scheme
+lookup. It does not govern `X-Forwarded-SSL`: Rack (3.2.x) honors
+`X-Forwarded-SSL: on` before it consults `forwarded_priority`, in every family.
+Otto covers this by deleting `X-Forwarded-SSL` together with the other
+authority carriers for any untrusted peer, so the header only reaches Rack from
+a trusted proxy or an unconfigured deployment.
+
 ```ruby
 otto = Otto.new(
   'routes',
@@ -174,18 +181,22 @@ The two placeholders are the requested family and the already committed one.
 An application that configures no proxy trust, and one that asserts
 `trusted_proxies: :none`, read no forwarded chain and therefore stake no claim
 on the family. Neither can block a later explicit choice, unless it also names
-`trusted_proxy_header` explicitly: naming the header is always a claim, even
-under `trusted_proxies: :none`.
+`trusted_proxy_header` explicitly. Otto only reads the header in depth mode,
+but setting it is always a claim: it pins Rack's `forwarded_priority` and
+registers the family for the process, even under `trusted_proxies: :none`.
 
 `trusted_proxy_header` accepts `X-Forwarded-For` (the default), `Forwarded`, or
 `Both`. When configuring proxy trust, `Forwarded` and `Both` require depth mode.
-CIDR filter mode resolves client IPs from `X-Forwarded-For`, so a non-default
-family would make Rack read a header that Otto ignores:
+CIDR filter mode resolves client IPs from the `X-Forwarded-For` family only
+(`X-Forwarded-For`, then `X-Real-IP`, then `X-Client-IP`) and never from RFC
+7239 `Forwarded`, so a non-default family would make Rack read a header that
+Otto ignores:
 
 ```text
 Cannot configure trusted_proxy_header 'Forwarded' or 'Both' together with
-trusted_proxies (CIDR filter mode): CIDR-walk resolves client IPs from
-X-Forwarded-For only. Use trusted_proxy_depth (count mode) to read the RFC 7239
+trusted_proxies (CIDR filter mode): CIDR-walk resolves client IPs from the
+X-Forwarded-For family only (X-Forwarded-For, X-Real-IP, X-Client-IP), never
+RFC 7239 Forwarded. Use trusted_proxy_depth (count mode) to read the RFC 7239
 Forwarded header.
 ```
 
@@ -205,3 +216,17 @@ application's security configuration, as shown in
 [Privacy-preserving request data](privacy.md#middleware-placement). Without that
 configuration, the outer middleware instance applies defaults and makes no
 trust decision, so forwarded authority reaches earlier middleware unchanged.
+
+The inner instance still enforces the application's own posture when an outer
+pass has already resolved the client IP:
+
+- `trusted_proxies: :none` always applies. The inner instance records
+  `otto.via_trusted_proxy` as `false` and strips the authority carriers, whatever
+  the outer instance did.
+- `trusted_proxy_depth` records `true` unless a configured outer pass already
+  recorded a verdict.
+- `trusted_proxies: [...]` keeps the verdict of a configured outer pass. When no
+  outer pass recorded one, the connecting peer can no longer be matched, because
+  the outer pass rewrote `REMOTE_ADDR`. Otto then treats the peer as untrusted,
+  strips the carriers, and logs a warning naming the fix: pass the application's
+  security configuration to the outer instance.

--- a/docs/guides/forwarded-authority.md
+++ b/docs/guides/forwarded-authority.md
@@ -1,77 +1,131 @@
 # Forwarded host authority
 
-`Rack::Request#host` is derived from forwarded headers before it falls back to
-the `Host` header. Rack applies its process-global forwarding priority and does
-not consult Otto's proxy trust decision, so on a bare Rack stack any client can
-send `X-Forwarded-Host` or an RFC 7239 `Forwarded` header and choose the host
-the application believes it is serving.
+Reverse proxies use forwarding headers to report the original request's host,
+scheme, and port. Rack reads these values before it falls back to the request's
+`Host` header and direct connection details. Without a trust boundary, a client
+can send `X-Forwarded-Host` or an RFC 7239 `Forwarded` header and choose the host
+that the application believes it serves.
 
-Everything built on `request.host` inherits that choice: redirect targets,
-generated links, WebAuthn `rp_id`, OmniAuth `redirect_uri`, mailer base URLs,
-and any mounted gem that builds absolute URLs. The same applies to
-`request.scheme`, `request.ssl?`, and `request.port`, which come from the same
-carriers. `Rack::Session` gates its `Secure` cookie flag on `ssl?`.
+This affects any value derived from `request.host`, `request.scheme`,
+`request.ssl?`, or `request.port`, including redirect targets, generated links,
+WebAuthn `rp_id`, OmniAuth `redirect_uri`, mailer base URLs, secure-cookie
+decisions, and mounted Rack applications that build absolute URLs.
 
-Otto gates those carriers on the trusted-proxy trust signal it already computes
-for client IP resolution.
+Otto uses the proxy trust configured for client IP resolution to decide whether
+Rack may also use forwarded host, scheme, and port values.
 
-## What Otto does per trust state
+> [!WARNING]
+> Omitting proxy trust does not reject forwarded authority. Otto leaves the
+> headers intact for compatibility, and Rack applies its own process-global
+> policy. Choose an explicit trust posture before serving requests whenever
+> application behavior depends on these request values.
 
-The decision is made by `IPPrivacyMiddleware` from the connecting peer
-(`REMOTE_ADDR`) before any masking, and recorded in
-`env['otto.via_trusted_proxy']`.
+## Choose a trust posture
 
-| Trust state | `otto.via_trusted_proxy` | Forwarded host, proto, scheme, ssl, port carriers |
+| Deployment | Configuration | Result |
 | --- | --- | --- |
-| Peer matches a configured trusted-proxy CIDR, or any peer under depth mode | `true` | Kept. `Forwarded` keeps its `proto=`, `host=`, and `by=` fields; the `for=` value is redacted to the masked IP when privacy masking applies. |
-| Proxy trust is configured and this peer fails it | `false` | Deleted. |
-| Nothing about proxy trust is configured | absent | Left to Rack. Otto asserts nothing. |
-| Operator explicitly asserted that no proxy is trusted | `false` for every peer | Deleted. |
+| The application is directly exposed and should trust no proxy | `trusted_proxies: :none` | Otto strips forwarded host, scheme, and port carriers from every request. |
+| Proxy addresses can be enumerated | `trusted_proxies: [...]` | Otto keeps the carriers only when `REMOTE_ADDR` matches a configured proxy. |
+| Proxy addresses cannot be enumerated, but the hop count is fixed | `trusted_proxy_depth: N` | Otto trusts the carriers on every request. The application origin must accept traffic only from the proxy tier. |
+| Another layer owns the trust decision | Leave proxy trust unconfigured | Otto leaves the carriers unchanged and makes no trust assertion. |
 
-The deleted keys are `HTTP_FORWARDED`, `HTTP_X_FORWARDED_HOST`,
-`HTTP_X_FORWARDED_PROTO`, `HTTP_X_FORWARDED_SCHEME`, `HTTP_X_FORWARDED_SSL`,
-and `HTTP_X_FORWARDED_PORT`. `X-Forwarded-For` is not deleted on this path;
-Otto's own client IP resolution already ignores it from an untrusted peer, and
-the privacy pipeline masks it separately.
-
-An application that configures no proxy trust at all keeps the third row's
-behavior deliberately. The absent key is a contract: it means the operator
-asserted nothing, and downstream consumers may apply their own heuristics.
-Changing that default would break host resolution for operators who run behind
-a proxy without configuring trust.
-
-## Asserting that no proxy is trusted
-
-To get the stripping behavior on a directly exposed application, make the
-assertion explicit:
+For a directly exposed application:
 
 ```ruby
 otto = Otto.new('routes', trusted_proxies: :none)
 ```
 
-Post-construction, before the first request freezes configuration:
+For an application behind proxies whose addresses are known:
+
+```ruby
+otto = Otto.new(
+  'routes',
+  trusted_proxies: ['10.0.0.0/8', '192.0.2.0/24']
+)
+```
+
+Use depth mode only when the proxy addresses cannot be listed and the number of
+proxy hops is fixed:
+
+```ruby
+otto = Otto.new('routes', trusted_proxy_depth: 1)
+```
+
+Depth mode treats every connecting peer as trusted. Before enabling it, prevent
+direct access to the application origin with private networking, firewall or
+security-group rules, or an equivalent control. Otherwise, a client can submit
+forwarded host, scheme, port, and IP values directly.
+
+Configure these options before the first request, when Otto freezes its
+configuration.
+
+## How Otto handles each trust state
+
+The decision is made by `IPPrivacyMiddleware` from the connecting peer
+(`REMOTE_ADDR`) before any masking, and recorded in
+`env['otto.via_trusted_proxy']`.
+
+| Trust state | `otto.via_trusted_proxy` | Forwarded host, scheme, and port carriers |
+| --- | --- | --- |
+| `REMOTE_ADDR` matches a configured trusted-proxy CIDR | `true` | Kept. When privacy masking applies, `Forwarded` keeps its `proto=`, `host=`, and `by=` fields while its `for=` value is replaced with the masked IP. |
+| Depth mode is enabled | `true` for every peer | Kept, subject to the same privacy masking. |
+| Proxy trust is configured, but the peer does not match a configured CIDR | `false` | Deleted. |
+| `trusted_proxies: :none` is configured | `false` for every peer | Deleted. |
+| Proxy trust is not configured | absent | Left unchanged. Otto makes no trust assertion, so Rack may apply its own policy. |
+
+The deleted keys are `HTTP_FORWARDED`, `HTTP_X_FORWARDED_HOST`,
+`HTTP_X_FORWARDED_PROTO`, `HTTP_X_FORWARDED_SCHEME`, `HTTP_X_FORWARDED_SSL`,
+and `HTTP_X_FORWARDED_PORT`. `X-Forwarded-For` is not deleted on this path;
+Otto's own client IP resolution already ignores it from an untrusted peer, and a
+masking privacy profile rewrites it separately. With IP privacy disabled the
+header reaches the application intact, and `Rack::Request#ip` returns its value
+whenever `REMOTE_ADDR` is private or loopback. Read `env['otto.client_ip']`
+rather than `Rack::Request#ip`, and configure any mounted gem that reads
+`request.ip` (for example `Rack::Attack`) accordingly.
+
+The absent `otto.via_trusted_proxy` key is intentional. It means the operator
+made no proxy-trust assertion, so downstream consumers may apply their own
+heuristics. This preserves compatibility for applications that already run
+behind a proxy without configuring Otto's trust controls.
+
+## Direct exposure: trust no proxy
+
+Use `trusted_proxies: :none` when clients connect directly to the application
+and no reverse proxy should influence request authority. This explicit assertion
+is different from omitting `trusted_proxies`. The String spelling `'none'` (any
+case) is accepted too, for YAML- or environment-driven configuration.
+
+You can also make the assertion after construction, but before the first
+request:
 
 ```ruby
 otto.trust_no_proxies!
 ```
 
-The same call exists on the security config and the configurator:
+The same operation is available through the security configurator and the
+underlying security configuration:
 
 ```ruby
-config.trust_no_proxies!
+otto.security.trust_no_proxies!
+otto.security_config.trust_no_proxies!
 ```
 
-Under this assertion `env['otto.via_trusted_proxy']` is `false` for every peer,
-client IP resolution ignores forwarded chains and uses `REMOTE_ADDR`, the
-forwarded host, scheme, and port carriers are stripped, and `Rack::Request#host`
-resolves only from the `Host` header. Trusted geo headers stay off, since they
-require enumerated trusted-proxy CIDRs.
+Under this assertion:
+
+- `env['otto.via_trusted_proxy']` is `false` for every peer;
+- client IP resolution ignores forwarded chains and uses `REMOTE_ADDR`;
+- forwarded host, scheme, and port carriers are stripped;
+- `Rack::Request#host` resolves from the `Host` header; and
+- trusted geo headers remain disabled because they require enumerated
+  trusted-proxy CIDRs.
 
 Loopback is not special-cased. A reverse proxy running on `127.0.0.1` in front
 of the application is an untrusted peer under this assertion and its forwarded
 headers are stripped. Use `add_trusted_proxy('127.0.0.1')` for that deployment
 instead. The separate `env['otto.peer_loopback']` signal is derived from the raw
-peer and is unaffected.
+peer and is unaffected, as is `env['otto.peer_relayed']`, which records whether
+any relay marker header was present before the carriers were stripped so
+`Otto::CaddyTLS::LocalhostGuard` still refuses a relayed request.
 
 The assertion is mutually exclusive with an actual trust grant. Combining it
 with trusted-proxy CIDRs or a depth of 1 or more raises at configuration time:
@@ -90,12 +144,12 @@ A value such as `for=a"b;host=evil` is enough to produce that disagreement.
 Deletion has no such failure mode. On this path Otto reads nothing from the
 header itself, so nothing is lost.
 
-## The process-global forwarding family
+## Choose the forwarding family for depth mode
 
-`Rack::Request.forwarded_priority` is a single process-wide setting that decides
-which forwarded family Rack reads: `X-Forwarded-*`, RFC 7239 `Forwarded`, or
-both. Otto pins it to the family selected by `trusted_proxy_header` so Otto's
-view of the request and Rack's cannot disagree.
+`Rack::Request.forwarded_priority` is a process-wide setting that determines
+which forwarding family Rack reads: `X-Forwarded-*`, RFC 7239 `Forwarded`, or
+both. Otto pins it to the family selected by `trusted_proxy_header` so Otto and
+Rack interpret the same request metadata.
 
 ```ruby
 otto = Otto.new(
@@ -119,11 +173,14 @@ The two placeholders are the requested family and the already committed one.
 
 An application that configures no proxy trust, and one that asserts
 `trusted_proxies: :none`, read no forwarded chain and therefore stake no claim
-on the family. Neither can block a later explicit choice.
+on the family. Neither can block a later explicit choice, unless it also names
+`trusted_proxy_header` explicitly: naming the header is always a claim, even
+under `trusted_proxies: :none`.
 
-A non-default family cannot be combined with CIDR filter mode. Otto's CIDR walk
-resolves client IPs from `X-Forwarded-For` only, so pinning Rack to `Forwarded`
-or `Both` would make Rack read a header Otto ignores:
+`trusted_proxy_header` accepts `X-Forwarded-For` (the default), `Forwarded`, or
+`Both`. When configuring proxy trust, `Forwarded` and `Both` require depth mode.
+CIDR filter mode resolves client IPs from `X-Forwarded-For`, so a non-default
+family would make Rack read a header that Otto ignores:
 
 ```text
 Cannot configure trusted_proxy_header 'Forwarded' or 'Both' together with
@@ -132,18 +189,19 @@ X-Forwarded-For only. Use trusted_proxy_depth (count mode) to read the RFC 7239
 Forwarded header.
 ```
 
-Use `trusted_proxy_depth` (count mode) when the deployment needs the RFC 7239
-header.
+Use `trusted_proxy_depth` when the deployment requires RFC 7239 `Forwarded`.
+Remember that depth mode also requires origin lockdown because it trusts every
+connecting peer.
 
-## Middleware ordering
+## Place the middleware before other request consumers
 
-The scrub happens in `IPPrivacyMiddleware`, which Otto installs first in its own
-stack. Downstream middleware, mounted applications, and handler code all see the
-already scrubbed environment.
+Otto performs this filtering in `IPPrivacyMiddleware`, which it installs first
+in its own stack. Downstream middleware, mounted applications, and handlers see
+the filtered environment.
 
-If middleware outside the Otto application inspects the request first, mount the
-privacy middleware in the common stack ahead of it and pass the application's
-security config, as described in
-[Privacy-preserving request data](privacy.md#middleware-placement). Without the
-config, the outer instance applies defaults and makes no trust decision, so the
-carriers reach the outer middleware intact.
+If middleware outside the Otto application reads the request first, mount
+`IPPrivacyMiddleware` ahead of it in the common Rack stack. Pass the
+application's security configuration, as shown in
+[Privacy-preserving request data](privacy.md#middleware-placement). Without that
+configuration, the outer middleware instance applies defaults and makes no
+trust decision, so forwarded authority reaches earlier middleware unchanged.

--- a/docs/guides/forwarded-authority.md
+++ b/docs/guides/forwarded-authority.md
@@ -1,0 +1,149 @@
+# Forwarded host authority
+
+`Rack::Request#host` is derived from forwarded headers before it falls back to
+the `Host` header. Rack applies its process-global forwarding priority and does
+not consult Otto's proxy trust decision, so on a bare Rack stack any client can
+send `X-Forwarded-Host` or an RFC 7239 `Forwarded` header and choose the host
+the application believes it is serving.
+
+Everything built on `request.host` inherits that choice: redirect targets,
+generated links, WebAuthn `rp_id`, OmniAuth `redirect_uri`, mailer base URLs,
+and any mounted gem that builds absolute URLs. The same applies to
+`request.scheme`, `request.ssl?`, and `request.port`, which come from the same
+carriers. `Rack::Session` gates its `Secure` cookie flag on `ssl?`.
+
+Otto gates those carriers on the trusted-proxy trust signal it already computes
+for client IP resolution.
+
+## What Otto does per trust state
+
+The decision is made by `IPPrivacyMiddleware` from the connecting peer
+(`REMOTE_ADDR`) before any masking, and recorded in
+`env['otto.via_trusted_proxy']`.
+
+| Trust state | `otto.via_trusted_proxy` | Forwarded host, proto, scheme, ssl, port carriers |
+| --- | --- | --- |
+| Peer matches a configured trusted-proxy CIDR, or any peer under depth mode | `true` | Kept. `Forwarded` keeps its `proto=`, `host=`, and `by=` fields; the `for=` value is redacted to the masked IP when privacy masking applies. |
+| Proxy trust is configured and this peer fails it | `false` | Deleted. |
+| Nothing about proxy trust is configured | absent | Left to Rack. Otto asserts nothing. |
+| Operator explicitly asserted that no proxy is trusted | `false` for every peer | Deleted. |
+
+The deleted keys are `HTTP_FORWARDED`, `HTTP_X_FORWARDED_HOST`,
+`HTTP_X_FORWARDED_PROTO`, `HTTP_X_FORWARDED_SCHEME`, `HTTP_X_FORWARDED_SSL`,
+and `HTTP_X_FORWARDED_PORT`. `X-Forwarded-For` is not deleted on this path;
+Otto's own client IP resolution already ignores it from an untrusted peer, and
+the privacy pipeline masks it separately.
+
+An application that configures no proxy trust at all keeps the third row's
+behavior deliberately. The absent key is a contract: it means the operator
+asserted nothing, and downstream consumers may apply their own heuristics.
+Changing that default would break host resolution for operators who run behind
+a proxy without configuring trust.
+
+## Asserting that no proxy is trusted
+
+To get the stripping behavior on a directly exposed application, make the
+assertion explicit:
+
+```ruby
+otto = Otto.new('routes', trusted_proxies: :none)
+```
+
+Post-construction, before the first request freezes configuration:
+
+```ruby
+otto.trust_no_proxies!
+```
+
+The same call exists on the security config and the configurator:
+
+```ruby
+config.trust_no_proxies!
+```
+
+Under this assertion `env['otto.via_trusted_proxy']` is `false` for every peer,
+client IP resolution ignores forwarded chains and uses `REMOTE_ADDR`, the
+forwarded host, scheme, and port carriers are stripped, and `Rack::Request#host`
+resolves only from the `Host` header. Trusted geo headers stay off, since they
+require enumerated trusted-proxy CIDRs.
+
+Loopback is not special-cased. A reverse proxy running on `127.0.0.1` in front
+of the application is an untrusted peer under this assertion and its forwarded
+headers are stripped. Use `add_trusted_proxy('127.0.0.1')` for that deployment
+instead. The separate `env['otto.peer_loopback']` signal is derived from the raw
+peer and is unaffected.
+
+The assertion is mutually exclusive with an actual trust grant. Combining it
+with trusted-proxy CIDRs or a depth of 1 or more raises at configuration time:
+
+```text
+Cannot combine trusted_proxies: :none (trust no proxy) with trusted_proxies
+CIDRs or trusted_proxy_depth >= 1. Assert :none OR grant trust, not both.
+```
+
+## Why the whole Forwarded header is removed
+
+For an untrusted peer Otto deletes `Forwarded` entirely rather than editing out
+its `host=` field. Editing would require Otto to parse RFC 7239 itself, and a
+parser that disagrees with Rack's on quoting can let a `host=` survive the edit.
+A value such as `for=a"b;host=evil` is enough to produce that disagreement.
+Deletion has no such failure mode. On this path Otto reads nothing from the
+header itself, so nothing is lost.
+
+## The process-global forwarding family
+
+`Rack::Request.forwarded_priority` is a single process-wide setting that decides
+which forwarded family Rack reads: `X-Forwarded-*`, RFC 7239 `Forwarded`, or
+both. Otto pins it to the family selected by `trusted_proxy_header` so Otto's
+view of the request and Rack's cannot disagree.
+
+```ruby
+otto = Otto.new(
+  'routes',
+  trusted_proxy_depth: 1,
+  trusted_proxy_header: 'Forwarded'  # or 'X-Forwarded-For' (default), or 'Both'
+)
+```
+
+Because the setting is process-wide, two Otto applications mounted in one
+process that both resolve proxied requests must agree. The later one raises:
+
+```text
+Cannot use forwarding family %s (trusted_proxy_header) because another Otto
+application in this process already uses %s. Rack's forwarded host, port,
+scheme, and IP policy is process-global, so every Otto application in one
+process that resolves proxied requests must use the same forwarding family.
+```
+
+The two placeholders are the requested family and the already committed one.
+
+An application that configures no proxy trust, and one that asserts
+`trusted_proxies: :none`, read no forwarded chain and therefore stake no claim
+on the family. Neither can block a later explicit choice.
+
+A non-default family cannot be combined with CIDR filter mode. Otto's CIDR walk
+resolves client IPs from `X-Forwarded-For` only, so pinning Rack to `Forwarded`
+or `Both` would make Rack read a header Otto ignores:
+
+```text
+Cannot configure trusted_proxy_header 'Forwarded' or 'Both' together with
+trusted_proxies (CIDR filter mode): CIDR-walk resolves client IPs from
+X-Forwarded-For only. Use trusted_proxy_depth (count mode) to read the RFC 7239
+Forwarded header.
+```
+
+Use `trusted_proxy_depth` (count mode) when the deployment needs the RFC 7239
+header.
+
+## Middleware ordering
+
+The scrub happens in `IPPrivacyMiddleware`, which Otto installs first in its own
+stack. Downstream middleware, mounted applications, and handler code all see the
+already scrubbed environment.
+
+If middleware outside the Otto application inspects the request first, mount the
+privacy middleware in the common stack ahead of it and pass the application's
+security config, as described in
+[Privacy-preserving request data](privacy.md#middleware-placement). Without the
+config, the outer instance applies defaults and makes no trust decision, so the
+carriers reach the outer middleware intact.

--- a/docs/guides/privacy.md
+++ b/docs/guides/privacy.md
@@ -164,6 +164,10 @@ Pass `otto.security_config` as shown. The outer instance resolves `otto.client_i
 first and the inner one then short-circuits, so an outer instance constructed
 without the configuration would silently apply defaults instead of the
 application's profile, precision, correlation secret, and enrichment settings.
+Proxy trust is the exception: the inner instance re-applies its own trust
+posture even after an outer pass, and a CIDR configuration that can no longer
+see the connecting peer fails closed. See
+[Forwarded host authority](forwarded-authority.md#place-the-middleware-before-other-request-consumers).
 
 ## Operational rules
 

--- a/docs/guides/privacy.md
+++ b/docs/guides/privacy.md
@@ -133,6 +133,11 @@ CIDR-based trust lets Otto verify the proxy peer. Count-based
 trustworthy. A configured `geo_header` combined with depth mode is rejected at
 configuration time; use a local database in depth-mode deployments instead.
 
+The same trust decision also gates the forwarded host, scheme, and port headers
+that `Rack::Request#host` reads. See
+[Forwarded host authority](forwarded-authority.md), including the explicit
+`trusted_proxies: :none` assertion for directly exposed applications.
+
 For precise access control without exposing the address to application code,
 configure or call the verdict-only `env['otto.ip_match']` capability. It matches
 the resolved full client IP against application CIDRs and returns only

--- a/lib/otto/caddy_tls/localhost_guard.rb
+++ b/lib/otto/caddy_tls/localhost_guard.rb
@@ -99,10 +99,13 @@ class Otto
       # Unlike the peer check, a header scan reads STATE that IPPrivacyMiddleware
       # has already touched by the time the guard runs, and one of its paths
       # DELETES relay markers while REMOTE_ADDR stays loopback: the
-      # untrusted-peer scrub, which removes HTTP_FORWARDED for every peer under
-      # `trusted_proxies: :none` and for any unlisted peer in CIDR mode. A
-      # request relayed over loopback by a proxy emitting only RFC 7239
-      # `Forwarded` would then look direct, turning a deny into an allow.
+      # untrusted-peer scrub, which removes HTTP_FORWARDED and the
+      # X-Forwarded-Host/Proto/Scheme/SSL/Port authority carriers for every
+      # peer under `trusted_proxies: :none` and for any unlisted peer in CIDR
+      # mode. A request relayed over loopback by a proxy emitting only RFC 7239
+      # `Forwarded`, or only `X-Forwarded-Host`, would then look direct,
+      # turning a deny into an allow. Otto::Utils::RELAY_MARKER_HEADERS
+      # therefore covers every carrier the scrub can delete.
       #
       # So prefer +env['otto.peer_relayed']+ — IPPrivacyMiddleware's verdict on
       # the ORIGINAL headers, recorded before any scrub — and fall back to the

--- a/lib/otto/caddy_tls/localhost_guard.rb
+++ b/lib/otto/caddy_tls/localhost_guard.rb
@@ -64,13 +64,9 @@ class Otto
     class LocalhostGuard
       # Forwarding headers whose presence means the request was relayed by a
       # proxy rather than issued directly. Any one present => not a direct local
-      # call. Mirrors Otto::Utils::FORWARDED_FOR_HEADERS plus RFC 7239 Forwarded.
-      FORWARDED_HEADERS = %w[
-        HTTP_X_FORWARDED_FOR
-        HTTP_X_REAL_IP
-        HTTP_X_CLIENT_IP
-        HTTP_FORWARDED
-      ].freeze
+      # call. The forwarded-for family plus RFC 7239 Forwarded, shared with
+      # IPPrivacyMiddleware's pre-scrub record so the two cannot drift.
+      FORWARDED_HEADERS = Otto::Utils::RELAY_MARKER_HEADERS
 
       # @param app [#call] the downstream Rack app
       # @param endpoint [String] the path to protect (e.g. '/_caddy/tls-permission')
@@ -100,27 +96,25 @@ class Otto
 
       # Whether any forwarding header is present (request came via a proxy).
       #
-      # Unlike the peer check, this reads header STATE, which IPPrivacyMiddleware
-      # has already touched by the time the guard runs. That is safe in both of
-      # its paths, but only for a reason worth writing down:
+      # Unlike the peer check, a header scan reads STATE that IPPrivacyMiddleware
+      # has already touched by the time the guard runs, and one of its paths
+      # DELETES relay markers while REMOTE_ADDR stays loopback: the
+      # untrusted-peer scrub, which removes HTTP_FORWARDED for every peer under
+      # `trusted_proxies: :none` and for any unlisted peer in CIDR mode. A
+      # request relayed over loopback by a proxy emitting only RFC 7239
+      # `Forwarded` would then look direct, turning a deny into an allow.
       #
-      # - Masking REWRITES a forwarded header to the masked IP rather than
-      #   removing it, so a relayed request still looks relayed. Correct — it was.
-      # - The no-resolvable-client-IP path DELETES them, which would make a
-      #   relayed request look direct. That path is reached only when REMOTE_ADDR
-      #   is absent or blank, which forces otto.peer_loopback to false, so
-      #   #direct_local_call? denies on the peer check before this one matters.
-      #
-      # So header deletion upstream cannot turn a deny into an allow — but that
-      # rests on the peer check failing closed for a blank address. Anything that
-      # makes an unresolvable-IP request keep a loopback peer verdict would need
-      # to record the relay state pre-scrub too (an otto.peer_relayed sibling to
-      # otto.peer_loopback).
+      # So prefer +env['otto.peer_relayed']+ — IPPrivacyMiddleware's verdict on
+      # the ORIGINAL headers, recorded before any scrub — and fall back to the
+      # live scan only when the guard runs without that middleware.
       #
       # @param env [Hash] Rack environment
       # @return [Boolean]
       def relayed?(env)
-        FORWARDED_HEADERS.any? { |header| !env[header].to_s.strip.empty? }
+        recorded = env['otto.peer_relayed']
+        return recorded if [true, false].include?(recorded)
+
+        Otto::Utils.relayed_request?(env)
       end
 
       # Whether this request is for the protected endpoint. Normalizes

--- a/lib/otto/core/configuration.rb
+++ b/lib/otto/core/configuration.rb
@@ -61,7 +61,10 @@ class Otto
         if Otto::Security::Config.trust_no_proxies_option?(opts[:trusted_proxies])
           @security_config.trust_no_proxies!
         elsif opts[:trusted_proxies]
-          Array(opts[:trusted_proxies]).each { |proxy| add_trusted_proxy(proxy) }
+          # Pass the list whole so add_trusted_proxy validates every entry
+          # before registering any (a mixed list containing 'none' is rejected
+          # without installing the rest).
+          add_trusted_proxy(Array(opts[:trusted_proxies])) unless Array(opts[:trusted_proxies]).empty?
         end
 
         # Set count-based trusted-proxy depth if provided (mutually exclusive

--- a/lib/otto/core/configuration.rb
+++ b/lib/otto/core/configuration.rb
@@ -55,7 +55,14 @@ class Otto
         end
 
         # Add trusted proxies if provided
-        Array(opts[:trusted_proxies]).each { |proxy| add_trusted_proxy(proxy) } if opts[:trusted_proxies]
+        # `trusted_proxies: :none` is an explicit operator assertion that no
+        # proxy is trusted (as opposed to omitting the option, which asserts
+        # nothing); see Otto::Security::Config#trust_no_proxies!.
+        if Otto::Security::Config.trust_no_proxies_option?(opts[:trusted_proxies])
+          @security_config.trust_no_proxies!
+        elsif opts[:trusted_proxies]
+          Array(opts[:trusted_proxies]).each { |proxy| add_trusted_proxy(proxy) }
+        end
 
         # Set count-based trusted-proxy depth if provided (mutually exclusive
         # with trusted_proxies; conflict validated at configuration freeze).

--- a/lib/otto/env_keys.rb
+++ b/lib/otto/env_keys.rb
@@ -137,12 +137,14 @@ class Otto
     # Type: Boolean
     # Set by: IPPrivacyMiddleware (every request), evaluated on the ORIGINAL
     #   headers BEFORE the untrusted-peer scrub may DELETE those carriers
-    #   (Otto::Utils::RELAY_MARKER_HEADERS include HTTP_FORWARDED, which the
-    #   scrub removes). A boolean, so it carries no identifying data.
+    #   (Otto::Utils::RELAY_MARKER_HEADERS cover the forwarded-for family, RFC
+    #   7239 Forwarded, and the X-Forwarded-Host/Proto/Scheme/SSL/Port
+    #   authority carriers — everything the scrub removes). A boolean, so it
+    #   carries no identifying data.
     # Used by: Otto::CaddyTLS::LocalhostGuard#relayed? — without this record a
     #   request relayed over loopback by a proxy emitting only RFC 7239
-    #   `Forwarded` would look like a direct local call after the scrub, and a
-    #   deny would become an allow.
+    #   `Forwarded` or only `X-Forwarded-Host` would look like a direct local
+    #   call after the scrub, and a deny would become an allow.
     PEER_RELAYED = 'otto.peer_relayed'
 
     # =========================================================================

--- a/lib/otto/env_keys.rb
+++ b/lib/otto/env_keys.rb
@@ -100,13 +100,16 @@ class Otto
     # Type: Boolean when present; the key may be ABSENT.
     # Set by: IPPrivacyMiddleware, evaluated on the original peer BEFORE
     #   REMOTE_ADDR is masked — but ONLY when proxy trust is configured
-    #   (Security::Config#proxy_trust_configured?: CIDR matchers or a depth).
+    #   (Security::Config#proxy_trust_configured?: CIDR matchers, a depth, or
+    #   the explicit trust-nobody assertion `trusted_proxies: :none`).
     #   True when the peer matches a configured trusted_proxies CIDR (filter
     #   mode), or unconditionally when count-based depth mode is active
     #   (trusted_proxy_depth >= 1) — the modes are mutually exclusive, and
     #   configuring a depth is the operator's assertion that the connecting
     #   peer is their proxy tier (#226). False means trust IS configured and
-    #   this peer failed it — an authoritative deny. When no proxy trust is
+    #   this peer failed it — an authoritative deny; it is also false for
+    #   EVERY peer (loopback included) when the operator asserted
+    #   `trusted_proxies: :none` (#259). When no proxy trust is
     #   configured the key is NOT written, so consumers can distinguish
     #   "denied" from "unconfigured" and apply legacy heuristics only in the
     #   latter case.
@@ -128,6 +131,19 @@ class Otto
     #   peer, not the resolved client IP: forwarded headers must play no part
     #   in a localhost trust decision.
     PEER_LOOPBACK = 'otto.peer_loopback'
+
+    # Whether the request arrived relayed by a proxy (any relay marker header
+    # present).
+    # Type: Boolean
+    # Set by: IPPrivacyMiddleware (every request), evaluated on the ORIGINAL
+    #   headers BEFORE the untrusted-peer scrub may DELETE those carriers
+    #   (Otto::Utils::RELAY_MARKER_HEADERS include HTTP_FORWARDED, which the
+    #   scrub removes). A boolean, so it carries no identifying data.
+    # Used by: Otto::CaddyTLS::LocalhostGuard#relayed? — without this record a
+    #   request relayed over loopback by a proxy emitting only RFC 7239
+    #   `Forwarded` would look like a direct local call after the scrub, and a
+    #   deny would become an allow.
+    PEER_RELAYED = 'otto.peer_relayed'
 
     # =========================================================================
     # LOCALIZATION (I18N)

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -56,6 +56,33 @@ class Otto
         (geo_db_path or geo_db_reader).
       MSG
 
+      # Error raised when the explicit "trust no proxy" assertion
+      # (#trust_no_proxies!, `trusted_proxies: :none`) is combined with an
+      # actual trust grant (enumerated CIDRs or a depth >= 1). The two say
+      # opposite things about the same peer, so the combination is refused at
+      # configuration time rather than silently resolved in one direction.
+      TRUST_NO_PROXIES_CONFLICT_MESSAGE = <<~MSG.gsub(/\s+/, ' ').strip.freeze
+        Cannot combine trusted_proxies: :none (trust no proxy) with
+        trusted_proxies CIDRs or trusted_proxy_depth >= 1. Assert :none OR
+        grant trust, not both.
+      MSG
+
+      # Sentinel accepted wherever a trusted_proxies list is accepted, meaning
+      # "the operator asserts that NO proxy is trusted". See #trust_no_proxies!.
+      TRUST_NO_PROXIES = :none
+
+      # Whether a trusted_proxies option value is the trust-nobody sentinel.
+      # Accepts the symbol and the String spelling 'none' (case-insensitive),
+      # which is what YAML/ENV-driven configuration naturally produces; without
+      # this, 'none' would fall through to add_trusted_proxy and install a
+      # legacy string-prefix matcher, silently inverting the assertion.
+      #
+      # @param value [Object] raw trusted_proxies option
+      # @return [Boolean]
+      def self.trust_no_proxies_option?(value)
+        (value.is_a?(Symbol) || value.is_a?(String)) && value.to_s.casecmp?('none')
+      end
+
       # Forwarded-header sources depth mode (#trusted_proxy_depth) can count
       # hops from: X-Forwarded-For (default), the RFC 7239 Forwarded header, or
       # Both (Forwarded when present, else X-Forwarded-For). Mirrors
@@ -231,6 +258,7 @@ class Otto
         @max_param_keys         = 64
         @trusted_proxies        = []
         @trusted_proxy_matchers = []
+        @trust_no_proxies       = false
         @trusted_proxy_depth    = nil
         @trusted_proxy_header   = DEFAULT_TRUSTED_PROXY_HEADER
         @require_secure_cookies = false
@@ -312,6 +340,7 @@ class Otto
         # conflict eagerly here (and in #trusted_proxy_depth=) so it surfaces at
         # configuration time, not only at freeze (which the test harness skips).
         raise ArgumentError, PROXY_MODE_CONFLICT_MESSAGE if trusted_proxy_depth_mode?
+        raise ArgumentError, TRUST_NO_PROXIES_CONFLICT_MESSAGE if @trust_no_proxies
         # Same pattern for header-then-proxies; proxies-then-header is caught
         # in #trusted_proxy_header=.
         raise ArgumentError, FORWARDED_HEADER_CIDR_CONFLICT_MESSAGE unless default_trusted_proxy_header?
@@ -384,8 +413,56 @@ class Otto
       # (false) from "no proxy trust configured" (absent) and apply their own
       # legacy heuristics only in the latter case.
       #
-      # @return [Boolean] true when filter or depth mode is configured
+      # @return [Boolean] true when filter or depth mode is configured, or when
+      #   the operator explicitly asserted that no proxy is trusted
       def proxy_trust_configured?
+        trusted_proxies_configured? || trusted_proxy_depth_mode? || trust_no_proxies?
+      end
+
+      # Assert that NO proxy is trusted for this application.
+      #
+      # This is a positive operator assertion, not the absence of one: an app
+      # that never configures proxy trust leaves env['otto.via_trusted_proxy']
+      # ABSENT (the tri-state contract from #228) so downstream consumers may
+      # apply their own heuristics. After this call the key is written as
+      # `false` for EVERY peer — loopback included, since Otto has no
+      # loopback special case in either resolution mode — which means client
+      # IP resolution ignores X-Forwarded-For entirely (REMOTE_ADDR wins) and
+      # IPPrivacyMiddleware strips the forwarded host/scheme/port carriers, so
+      # Rack::Request#host resolves only from the Host header (#259).
+      #
+      # Mutually exclusive with any actual trust grant (trusted_proxies CIDRs
+      # or trusted_proxy_depth >= 1). It stakes no claim on the process-global
+      # Rack forwarding family: an app that trusts nobody reads no forwarded
+      # chain, so it cannot conflict with another app's explicit choice.
+      #
+      # @raise [FrozenError] if configuration is frozen
+      # @raise [ArgumentError] if trusted proxies or a depth >= 1 are configured
+      # @return [void]
+      #
+      # @example
+      #   config.trust_no_proxies!
+      def trust_no_proxies!
+        ensure_not_frozen!
+        raise ArgumentError, TRUST_NO_PROXIES_CONFLICT_MESSAGE if trusted_proxies_configured? || trusted_proxy_depth_mode?
+
+        @trust_no_proxies = true
+      end
+
+      # Whether the operator explicitly asserted that no proxy is trusted.
+      #
+      # @return [Boolean]
+      def trust_no_proxies?
+        @trust_no_proxies
+      end
+
+      # Whether this config's request handling DEPENDS on Rack's process-global
+      # forwarding family — i.e. it actually reads a forwarded chain. True for
+      # filter and depth mode; false for trust-nobody (reads nothing) and for
+      # unconfigured apps.
+      #
+      # @return [Boolean]
+      def forwarding_family_dependent?
         trusted_proxies_configured? || trusted_proxy_depth_mode?
       end
 
@@ -418,6 +495,7 @@ class Otto
 
         validate_trusted_proxy_depth!(depth)
         raise ArgumentError, PROXY_MODE_CONFLICT_MESSAGE if depth.to_i >= 1 && @trusted_proxies.any?
+        raise ArgumentError, TRUST_NO_PROXIES_CONFLICT_MESSAGE if depth.to_i >= 1 && @trust_no_proxies
         # Depth-then-geo assignment order is caught by configure_ip_privacy;
         # this catches geo-then-depth so both orders fail eagerly.
         raise ArgumentError, GEO_HEADER_DEPTH_CONFLICT_MESSAGE if depth.to_i >= 1 && @ip_privacy_config&.geo_header
@@ -475,7 +553,7 @@ class Otto
       def apply_default_rack_forwarding_family!
         ensure_not_frozen!
 
-        self.class.apply_rack_forwarding_family!(self, @trusted_proxy_header, claim: proxy_trust_configured?)
+        self.class.apply_rack_forwarding_family!(self, @trusted_proxy_header, claim: forwarding_family_dependent?)
       end
 
       # Commit this config's current family process-wide once it depends on
@@ -490,7 +568,7 @@ class Otto
       # @return [void]
       def commit_rack_forwarding_family!
         ensure_not_frozen!
-        return unless proxy_trust_configured?
+        return unless forwarding_family_dependent?
 
         self.class.apply_rack_forwarding_family!(self, @trusted_proxy_header)
       end
@@ -1022,6 +1100,8 @@ class Otto
         validate_trusted_proxy_header!(@trusted_proxy_header)
         validate_trusted_proxy_depth!(@trusted_proxy_depth)
         raise ArgumentError, FORWARDED_HEADER_CIDR_CONFLICT_MESSAGE if !default_trusted_proxy_header? && @trusted_proxies.any?
+
+        raise ArgumentError, TRUST_NO_PROXIES_CONFLICT_MESSAGE if @trust_no_proxies && (@trusted_proxies.any? || @trusted_proxy_depth.to_i >= 1)
 
         if @trusted_proxy_depth
           raise ArgumentError, PROXY_MODE_CONFLICT_MESSAGE if @trusted_proxy_depth >= 1 && @trusted_proxies.any?

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -109,16 +109,19 @@ class Otto
         same forwarding family.
       MSG
       # Error raised when a non-default trusted_proxy_header is combined with
-      # CIDR filter mode. Otto's CIDR-walk resolves the client IP from
-      # X-Forwarded-For only, while trusted_proxy_header also pins Rack's
+      # CIDR filter mode. Otto's CIDR-walk resolves the client IP from the
+      # X-Forwarded-For family only (X-Forwarded-For, then X-Real-IP, then
+      # X-Client-IP — Otto::Utils::FORWARDED_FOR_HEADERS), never RFC 7239
+      # Forwarded, while trusted_proxy_header also pins Rack's
       # forwarding family; honoring 'Forwarded' or 'Both' there would make Rack
       # read a header Otto ignores, recreating the disagreement the pin exists
       # to close.
       FORWARDED_HEADER_CIDR_CONFLICT_MESSAGE = <<~MSG.gsub(/\s+/, ' ').strip.freeze
         Cannot configure trusted_proxy_header 'Forwarded' or 'Both' together
         with trusted_proxies (CIDR filter mode): CIDR-walk resolves client IPs
-        from X-Forwarded-For only. Use trusted_proxy_depth (count mode) to
-        read the RFC 7239 Forwarded header.
+        from the X-Forwarded-For family only (X-Forwarded-For, X-Real-IP,
+        X-Client-IP), never RFC 7239 Forwarded. Use trusted_proxy_depth (count
+        mode) to read the RFC 7239 Forwarded header.
       MSG
 
       # Eager so the first two concurrent Otto.new calls cannot race on

--- a/lib/otto/security/config.rb
+++ b/lib/otto/security/config.rb
@@ -67,6 +67,19 @@ class Otto
         grant trust, not both.
       MSG
 
+      # Error raised when the trust-nobody sentinel arrives as a proxy ENTRY
+      # (`trusted_proxies: ['none']`, as a YAML/JSON list naturally yields, or
+      # `add_trusted_proxy('none')`) instead of as the whole option. Inside a
+      # list it would otherwise register a legacy string-prefix matcher that
+      # matches nothing: peers would be untrusted, but trust_no_proxies? would
+      # stay false and the config would stake a forwarding-family claim, so the
+      # explicit assertion would be silently replaced by a lookalike.
+      TRUST_NO_PROXIES_ENTRY_MESSAGE = <<~MSG.gsub(/\s+/, ' ').strip.freeze
+        trusted_proxies entry :none is the trust-nobody assertion, not a proxy
+        address. Pass trusted_proxies: :none as the whole option (not inside a
+        list) or call trust_no_proxies! instead.
+      MSG
+
       # Sentinel accepted wherever a trusted_proxies list is accepted, meaning
       # "the operator asserts that NO proxy is trusted". See #trust_no_proxies!.
       TRUST_NO_PROXIES = :none
@@ -347,6 +360,13 @@ class Otto
         # Same pattern for header-then-proxies; proxies-then-header is caught
         # in #trusted_proxy_header=.
         raise ArgumentError, FORWARDED_HEADER_CIDR_CONFLICT_MESSAGE unless default_trusted_proxy_header?
+
+        # The trust-nobody sentinel is an option value, never an entry; validate
+        # the whole list before registering anything so a bad list leaves the
+        # config untouched.
+        Array(proxy).each do |entry|
+          raise ArgumentError, TRUST_NO_PROXIES_ENTRY_MESSAGE if self.class.trust_no_proxies_option?(entry)
+        end
 
         case proxy
         when String, Regexp

--- a/lib/otto/security/configurator.rb
+++ b/lib/otto/security/configurator.rb
@@ -42,7 +42,10 @@ class Otto
       #   with trusted_proxies (validated at configuration freeze)
       # @param trusted_proxy_header [String, nil] Forwarded header depth mode
       #   counts hops from: 'X-Forwarded-For' (default), 'Forwarded' (RFC 7239),
-      #   or 'Both'. Only consulted in depth mode.
+      #   or 'Both'. Otto reads it only in depth mode, but setting it always
+      #   pins Rack::Request.forwarded_priority (process-global) to that family
+      #   and claims the family for this process; see
+      #   Otto::Security::Config.apply_rack_forwarding_family!.
       # @param security_headers [Hash] Custom security headers to merge with defaults
       # @param hsts [Boolean] Enable HTTP Strict Transport Security
       # @param csp [Boolean, String] Enable Content Security Policy
@@ -168,9 +171,13 @@ class Otto
       end
 
       # Select which forwarded header depth mode counts hops from:
-      # 'X-Forwarded-For' (default), 'Forwarded' (RFC 7239), or 'Both'. Only
-      # consulted when depth mode is active. Mirrors OneTimeSecret's
-      # site.network.trusted_proxy.header.
+      # 'X-Forwarded-For' (default), 'Forwarded' (RFC 7239), or 'Both'. Otto
+      # reads the value only when depth mode is active, but setting it always
+      # pins Rack::Request.forwarded_priority (process-global) to that family
+      # and claims the family for this process, even under
+      # `trusted_proxies: :none`; see
+      # Otto::Security::Config.apply_rack_forwarding_family!. Mirrors
+      # OneTimeSecret's site.network.trusted_proxy.header.
       #
       # @param header [String] one of Otto::Security::Config::TRUSTED_PROXY_HEADERS
       def trusted_proxy_header=(header)

--- a/lib/otto/security/configurator.rb
+++ b/lib/otto/security/configurator.rb
@@ -35,7 +35,8 @@ class Otto
       # @param rate_limiting [Boolean, Hash] Enable rate limiting
       #   - `true`: Enable with default settings
       #   - `Hash`: Provide custom rate limiting rules
-      # @param trusted_proxies [String, Array<String>] IP addresses or CIDR ranges to trust
+      # @param trusted_proxies [String, Array<String>, Symbol] IP addresses or
+      #   CIDR ranges to trust, or :none to assert that no proxy is trusted
       # @param trusted_proxy_depth [Integer, nil] Count-based proxy depth ("trust
       #   the last N hops") for non-enumerable proxy tiers; mutually exclusive
       #   with trusted_proxies (validated at configuration freeze)
@@ -76,7 +77,11 @@ class Otto
         enable_request_validation! if request_validation
         enable_rate_limiting!(rate_limiting.is_a?(Hash) ? rate_limiting : {}) if rate_limiting
 
-        Array(trusted_proxies).each { |proxy| add_trusted_proxy(proxy) }
+        if Otto::Security::Config.trust_no_proxies_option?(trusted_proxies)
+          trust_no_proxies!
+        else
+          Array(trusted_proxies).each { |proxy| add_trusted_proxy(proxy) }
+        end
         self.trusted_proxy_depth = trusted_proxy_depth unless trusted_proxy_depth.nil?
         self.trusted_proxy_header = trusted_proxy_header unless trusted_proxy_header.nil?
         # Proxy trust configured here (after Otto.new) commits the app to its
@@ -139,6 +144,17 @@ class Otto
       # @param proxy [String, Regexp] IP address, CIDR range, or regex pattern
       def add_trusted_proxy(proxy)
         @security_config.add_trusted_proxy(proxy)
+      end
+
+      # Assert that NO proxy is trusted (equivalent to `trusted_proxies:
+      # :none`). Makes env['otto.via_trusted_proxy'] false for every peer, so
+      # forwarded client-IP and host/scheme/port carriers are ignored and
+      # stripped. See Otto::Security::Config#trust_no_proxies!.
+      #
+      # @raise [ArgumentError] if trusted proxies or a depth >= 1 are configured
+      # @return [void]
+      def trust_no_proxies!
+        @security_config.trust_no_proxies!
       end
 
       # Set count-based trusted-proxy depth ("trust the last N hops") for

--- a/lib/otto/security/configurator.rb
+++ b/lib/otto/security/configurator.rb
@@ -83,7 +83,10 @@ class Otto
         if Otto::Security::Config.trust_no_proxies_option?(trusted_proxies)
           trust_no_proxies!
         else
-          Array(trusted_proxies).each { |proxy| add_trusted_proxy(proxy) }
+          # Pass the list whole so add_trusted_proxy validates every entry
+          # before registering any; a mixed list like ['10.0.0.0/8', 'none']
+          # must not leave the first half installed.
+          add_trusted_proxy(Array(trusted_proxies)) unless Array(trusted_proxies).empty?
         end
         self.trusted_proxy_depth = trusted_proxy_depth unless trusted_proxy_depth.nil?
         self.trusted_proxy_header = trusted_proxy_header unless trusted_proxy_header.nil?

--- a/lib/otto/security/core.rb
+++ b/lib/otto/security/core.rb
@@ -77,6 +77,23 @@ class Otto
         @security_config.add_trusted_proxy(proxy)
       end
 
+      # Assert that NO proxy is trusted: every peer gets
+      # env['otto.via_trusted_proxy'] = false, forwarded client-IP chains are
+      # ignored, and forwarded host/scheme/port carriers are stripped so
+      # Rack::Request#host resolves only from the Host header.
+      #
+      # Equivalent to passing `trusted_proxies: :none` to Otto.new. Distinct
+      # from configuring nothing, which asserts nothing (tri-state, #228).
+      #
+      # @raise [ArgumentError] if trusted proxies or a depth >= 1 are configured
+      # @return [void]
+      # @example
+      #   otto.trust_no_proxies!
+      def trust_no_proxies!
+        ensure_not_frozen!
+        @security_config.trust_no_proxies!
+      end
+
       # Set custom security headers that will be added to all responses.
       # These merge with the default security headers.
       #

--- a/lib/otto/security/middleware/ip_privacy_middleware.rb
+++ b/lib/otto/security/middleware/ip_privacy_middleware.rb
@@ -78,7 +78,9 @@ class Otto
           # REMOTE_ADDR is rewritten to the masked client IP. Leak-free boolean.
           #
           # TRI-STATE: the key is written ONLY when the operator configured
-          # proxy trust (CIDR matchers or a depth). Present, its value is
+          # proxy trust (CIDR matchers, a depth, or the explicit trust-nobody
+          # assertion `trusted_proxies: :none`, which makes the value false for
+          # every peer, #259). Present, its value is
           # authoritative in both directions — true means the peer matched a
           # CIDR (filter mode) or depth mode is active (configuring a depth
           # asserts the connecting peer IS the operator's proxy tier, #226);
@@ -94,6 +96,13 @@ class Otto
                                    @security_config.proxy_trust_configured?
           via_trusted_proxy = proxy_trust_configured && trusted_proxy?(env['REMOTE_ADDR'])
           env['otto.via_trusted_proxy'] = via_trusted_proxy if proxy_trust_configured
+
+          # Record whether the request was relayed BEFORE the scrub below can
+          # delete the relay markers. Downstream middleware that must
+          # authenticate a direct local call (Otto::CaddyTLS::LocalhostGuard)
+          # runs after this one and would otherwise read a request whose
+          # HTTP_FORWARDED was deleted here as "direct". Leak-free boolean.
+          env['otto.peer_relayed'] = Otto::Utils.relayed_request?(env)
 
           # A peer that failed configured proxy trust cannot supply forwarded
           # host, scheme, or port either. Unconfigured trust (absent tri-state
@@ -416,8 +425,9 @@ class Otto
         # family, so without this an untrusted client would control
         # request.host, request.ssl?, and request.port for every mounted Rack
         # app (Rack::Session's Secure-cookie gate reads ssl?). Delete the
-        # carriers rather than editing them: this path only runs in CIDR filter
-        # mode, where Otto never reads the Forwarded header itself, and a
+        # carriers rather than editing them: this path runs only in CIDR filter
+        # mode or under the trust-nobody assertion (`trusted_proxies: :none`,
+        # #259), neither of which reads the Forwarded header itself, and a
         # hand-rolled RFC 7239 parser that disagrees with Rack's on quoting
         # (e.g. `for=a"b;host=evil`) would let a host= survive the edit.
         # X-Forwarded-For stays, masked or not, because Otto's own resolution

--- a/lib/otto/security/middleware/ip_privacy_middleware.rb
+++ b/lib/otto/security/middleware/ip_privacy_middleware.rb
@@ -39,15 +39,10 @@ class Otto
         # Forwarding metadata Rack::Request reads without consulting Otto's
         # proxy trust verdict: host (#host/#authority), scheme (#scheme/#ssl?),
         # and port (#port), from both the X-Forwarded-* family and RFC 7239
-        # Forwarded (host=, proto=, and the port inside for=).
-        UNTRUSTED_FORWARDING_METADATA_HEADERS = %w[
-          HTTP_FORWARDED
-          HTTP_X_FORWARDED_HOST
-          HTTP_X_FORWARDED_PROTO
-          HTTP_X_FORWARDED_SCHEME
-          HTTP_X_FORWARDED_SSL
-          HTTP_X_FORWARDED_PORT
-        ].freeze
+        # Forwarded (host=, proto=, and the port inside for=). Defined in
+        # Otto::Utils so Otto::Utils::RELAY_MARKER_HEADERS is built from the
+        # same list and cannot fall out of step with what is scrubbed here.
+        UNTRUSTED_FORWARDING_METADATA_HEADERS = Otto::Utils::FORWARDED_AUTHORITY_HEADERS
 
         # Initialize IP Privacy middleware
         #
@@ -68,8 +63,13 @@ class Otto
           # canonical client IP for this request, do not re-resolve or re-mask.
           # This makes stacking two instances (e.g. an app-level mount plus
           # Otto's built-in router mount) order-safe instead of double-masking.
+          #
+          # Client-IP resolution is idempotent, but proxy TRUST is not: the
+          # prior pass may have run under a different (or no) configuration,
+          # so this instance still enforces its own trust posture below.
           if env.key?('otto.client_ip')
             ensure_ip_match_present(env)
+            enforce_proxy_trust_after_prior_pass(env)
             return @app.call(env)
           end
 
@@ -149,6 +149,58 @@ class Otto
         # @return [Boolean]
         def privacy_enabled?
           @config.enabled?
+        end
+
+        # Enforce THIS instance's proxy trust posture when a prior
+        # IPPrivacyMiddleware pass already resolved the client IP.
+        #
+        # The early return in #call keeps client-IP resolution idempotent, but
+        # trust enforcement must not ride on it: an outer instance mounted
+        # without the application's security config (the "unconfigured
+        # defaults" case in docs/guides/privacy.md) writes otto.client_ip and
+        # nothing else, and returning here would let an inner
+        # `trusted_proxies: :none` instance pass X-Forwarded-Host through
+        # untouched — the exact bypass the assertion exists to close.
+        #
+        # What can still be decided after the prior pass:
+        # - trust-nobody: the verdict is false for every peer, so it needs no
+        #   peer address. Always enforced, overriding a laxer prior verdict.
+        # - depth mode: the verdict is true by assertion. Recorded only when
+        #   no configured pass has spoken (key absent).
+        # - CIDR mode: needs the connecting peer, which the prior pass has
+        #   rewritten (REMOTE_ADDR is now the resolved, possibly masked, client
+        #   IP — matching a masked address against a narrow CIDR produces false
+        #   ALLOWs, see #ensure_ip_match_present). A verdict recorded by a prior
+        #   CONFIGURED pass is kept (the same-config stacking case). With none,
+        #   fail closed: deny, scrub, and warn so the misconfiguration is
+        #   diagnosable rather than a silent grant.
+        #
+        # Every deny also scrubs the authority carriers, which is idempotent:
+        # deleting an already-deleted key is a no-op.
+        #
+        # @param env [Hash] Rack environment
+        def enforce_proxy_trust_after_prior_pass(env)
+          return unless @security_config.respond_to?(:proxy_trust_configured?) &&
+                        @security_config.proxy_trust_configured?
+
+          if @security_config.trust_no_proxies?
+            env['otto.via_trusted_proxy'] = false
+            scrub_untrusted_forwarding_metadata(env)
+          elsif env.key?('otto.via_trusted_proxy')
+            nil # a configured pass already decided; honor it
+          elsif @security_config.trusted_proxy_depth_mode?
+            env['otto.via_trusted_proxy'] = true
+          else
+            Otto.logger.warn(
+              '[IPPrivacyMiddleware] otto.client_ip was resolved by a prior ' \
+              'pass with no proxy trust configured, so the connecting peer ' \
+              'can no longer be matched against trusted_proxies; treating ' \
+              'the peer as untrusted and stripping forwarded authority. ' \
+              'Pass the application security config to the outer instance.'
+            )
+            env['otto.via_trusted_proxy'] = false
+            scrub_untrusted_forwarding_metadata(env)
+          end
         end
 
         # Guarantee env['otto.ip_match'] exists on the idempotent-return path.

--- a/lib/otto/utils.rb
+++ b/lib/otto/utils.rb
@@ -19,13 +19,31 @@ class Otto
       HTTP_X_CLIENT_IP
     ].freeze
 
+    # Forwarding metadata Rack::Request reads without consulting Otto's proxy
+    # trust verdict: host (#host/#authority), scheme (#scheme/#ssl?), and port
+    # (#port), from both the X-Forwarded-* family and RFC 7239 Forwarded
+    # (host=, proto=, and the port inside for=). IPPrivacyMiddleware deletes
+    # every one of these for a peer that failed configured proxy trust.
+    FORWARDED_AUTHORITY_HEADERS = %w[
+      HTTP_FORWARDED
+      HTTP_X_FORWARDED_HOST
+      HTTP_X_FORWARDED_PROTO
+      HTTP_X_FORWARDED_SCHEME
+      HTTP_X_FORWARDED_SSL
+      HTTP_X_FORWARDED_PORT
+    ].freeze
+
     # Headers whose presence means the request was RELAYED by a proxy rather
-    # than issued directly by the peer: the forwarded-for family plus RFC 7239
-    # Forwarded. Shared by IPPrivacyMiddleware (which records the verdict as
-    # env['otto.peer_relayed'] BEFORE it may delete these carriers) and
+    # than issued directly by the peer: every forwarding carrier Otto knows —
+    # the forwarded-for family, RFC 7239 Forwarded, and the authority (host /
+    # scheme / port) carriers. The set must cover everything IPPrivacyMiddleware
+    # may DELETE on the untrusted-peer path: a carrier that is scrubbed but not
+    # counted here would let a relayed request look direct afterwards. Shared
+    # by IPPrivacyMiddleware (which records the verdict as
+    # env['otto.peer_relayed'] BEFORE the scrub) and
     # Otto::CaddyTLS::LocalhostGuard, so the record and the guard's own
     # fallback scan cannot drift.
-    RELAY_MARKER_HEADERS = (FORWARDED_FOR_HEADERS + %w[HTTP_FORWARDED]).freeze
+    RELAY_MARKER_HEADERS = (FORWARDED_FOR_HEADERS + FORWARDED_AUTHORITY_HEADERS).uniq.freeze
 
     # Special-use IPv4/IPv6 ranges that IPAddr's #private?/#loopback?/#link_local?
     # predicates do not cover but that should still be treated as non-public
@@ -43,14 +61,10 @@ class Otto
     # address in a real chain means a misconfigured hop, which is better surfaced
     # than skipped.
     SPECIAL_USE_RANGES = [
-      IPAddr.new('0.0.0.0/8'), # "this" network / unspecified (IPv4)
-      # RFC 6598 shared address space (CGNAT): not covered by IPAddr#private?, and
-      # cloud-internal load balancers and Tailscale allocate from it, so a proxy hop
-      # here would otherwise be mistaken for the public client.
-      IPAddr.new('100.64.0.0/10'), # RFC 6598 shared address space (CGNAT)
-      IPAddr.new('224.0.0.0/4'),   # IPv4 multicast
-      IPAddr.new('::/128'),        # IPv6 unspecified
-      IPAddr.new('ff00::/8'),      # IPv6 multicast
+      IPAddr.new('0.0.0.0/8'),   # "this" network / unspecified (IPv4)
+      IPAddr.new('224.0.0.0/4'), # IPv4 multicast
+      IPAddr.new('::/128'),      # IPv6 unspecified
+      IPAddr.new('ff00::/8'),    # IPv6 multicast
     ].freeze
 
     # @return [Time] Current time in UTC

--- a/lib/otto/utils.rb
+++ b/lib/otto/utils.rb
@@ -19,14 +19,38 @@ class Otto
       HTTP_X_CLIENT_IP
     ].freeze
 
+    # Headers whose presence means the request was RELAYED by a proxy rather
+    # than issued directly by the peer: the forwarded-for family plus RFC 7239
+    # Forwarded. Shared by IPPrivacyMiddleware (which records the verdict as
+    # env['otto.peer_relayed'] BEFORE it may delete these carriers) and
+    # Otto::CaddyTLS::LocalhostGuard, so the record and the guard's own
+    # fallback scan cannot drift.
+    RELAY_MARKER_HEADERS = (FORWARDED_FOR_HEADERS + %w[HTTP_FORWARDED]).freeze
+
     # Special-use IPv4/IPv6 ranges that IPAddr's #private?/#loopback?/#link_local?
     # predicates do not cover but that should still be treated as non-public
     # (e.g. when picking the real client out of a forwarded chain).
+    #
+    # The documentation ranges (192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24,
+    # 2001:db8::/32 and the newer 3fff::/20) are deliberately NOT listed here.
+    # The predicate answers "could this be the real client", and non-public
+    # entries are skipped as proxy hops. Those ranges are not globally routable,
+    # but they are the universal convention for an example public client in tests
+    # and docs, including this repo's own specs and guides, so treating them as
+    # non-public would make the resolver skip the example client and silently
+    # invalidate those examples. There is no security gain either: an attacker who
+    # can inject into a chain injects a routable address, and a documentation
+    # address in a real chain means a misconfigured hop, which is better surfaced
+    # than skipped.
     SPECIAL_USE_RANGES = [
-      IPAddr.new('0.0.0.0/8'),   # "this" network / unspecified (IPv4)
-      IPAddr.new('224.0.0.0/4'), # IPv4 multicast
-      IPAddr.new('::/128'),      # IPv6 unspecified
-      IPAddr.new('ff00::/8'),    # IPv6 multicast
+      IPAddr.new('0.0.0.0/8'), # "this" network / unspecified (IPv4)
+      # RFC 6598 shared address space (CGNAT): not covered by IPAddr#private?, and
+      # cloud-internal load balancers and Tailscale allocate from it, so a proxy hop
+      # here would otherwise be mistaken for the public client.
+      IPAddr.new('100.64.0.0/10'), # RFC 6598 shared address space (CGNAT)
+      IPAddr.new('224.0.0.0/4'),   # IPv4 multicast
+      IPAddr.new('::/128'),        # IPv6 unspecified
+      IPAddr.new('ff00::/8'),      # IPv6 multicast
     ].freeze
 
     # @return [Time] Current time in UTC
@@ -387,6 +411,18 @@ class Otto
         range = range.native
         range.family == client.family && range.include?(client)
       end
+    end
+
+    # Whether any relay marker header is present on the request.
+    #
+    # Call this only from code that runs BEFORE forwarding carriers may be
+    # deleted (IPPrivacyMiddleware's untrusted-peer scrub); downstream code
+    # should prefer the recorded env['otto.peer_relayed'] boolean.
+    #
+    # @param env [Hash] Rack environment
+    # @return [Boolean]
+    def relayed_request?(env)
+      RELAY_MARKER_HEADERS.any? { |header| !env[header].to_s.strip.empty? }
     end
 
     # Whether an address is on the loopback interface.

--- a/spec/otto/caddy_tls/localhost_guard_spec.rb
+++ b/spec/otto/caddy_tls/localhost_guard_spec.rb
@@ -121,6 +121,25 @@ RSpec.describe Otto::CaddyTLS::LocalhostGuard do
     end
   end
 
+  describe "env['otto.peer_relayed'] (pre-scrub relay record, otto#259)" do
+    it 'denies when the record says relayed even though the carriers were deleted' do
+      status, = call(remote_addr: '127.0.0.1', headers: { 'otto.peer_relayed' => true })
+      expect(status).to eq(401)
+      expect(downstream.calls).to be_empty
+    end
+
+    it 'allows when the record says not relayed' do
+      expect(call(remote_addr: '127.0.0.1', headers: { 'otto.peer_relayed' => false })[0]).to eq(200)
+    end
+
+    it 'falls back to a header scan when the record is absent or not a Boolean' do
+      expect(call(remote_addr: '127.0.0.1', headers: { 'HTTP_FORWARDED' => 'for=203.0.113.9' })[0]).to eq(401)
+      expect(call(remote_addr: '127.0.0.1',
+                  headers: { 'otto.peer_relayed' => 'true', 'HTTP_FORWARDED' => 'for=1.2.3.4' })[0]).to eq(401)
+      expect(call(remote_addr: '127.0.0.1', headers: { 'otto.peer_relayed' => nil })[0]).to eq(200)
+    end
+  end
+
   describe 'behind IPPrivacyMiddleware (the real Otto stack order)' do
     let(:security_config) { Otto::Security::Config.new }
 
@@ -172,6 +191,33 @@ RSpec.describe Otto::CaddyTLS::LocalhostGuard do
       expect(env['otto.peer_loopback']).to be false       # but the peer check holds
       expect(status).to eq(401)
       expect(downstream.calls).to be_empty
+    end
+
+    it 'denies a Forwarded-relayed loopback call under trusted_proxies: :none (otto#259)' do
+      # Trust-nobody scrubs HTTP_FORWARDED for EVERY peer, including a loopback
+      # one, so a header scan after the scrub would see a direct call. The
+      # pre-scrub env['otto.peer_relayed'] record is what keeps this a deny.
+      security_config.trust_no_proxies!
+
+      env = env_for(remote_addr: '127.0.0.1',
+                    headers: { 'HTTP_FORWARDED' => 'for=203.0.113.9;host=evil.example' })
+      status, = stack_call(env)
+
+      expect(env).not_to have_key('HTTP_FORWARDED') # scrubbed: looks direct
+      expect(env['otto.peer_loopback']).to be true  # and the peer check passes
+      expect(env['otto.peer_relayed']).to be true   # only this record denies
+      expect(status).to eq(401)
+      expect(downstream.calls).to be_empty
+    end
+
+    it 'still allows a genuinely direct loopback call under trusted_proxies: :none' do
+      security_config.trust_no_proxies!
+
+      env = env_for(remote_addr: '127.0.0.1')
+      status, = stack_call(env)
+
+      expect(env['otto.peer_relayed']).to be false
+      expect(status).to eq(200)
     end
 
     it 'allows a direct IPv6 loopback call even when masking rewrites ::1' do

--- a/spec/otto/caddy_tls/localhost_guard_spec.rb
+++ b/spec/otto/caddy_tls/localhost_guard_spec.rb
@@ -210,6 +210,25 @@ RSpec.describe Otto::CaddyTLS::LocalhostGuard do
       expect(downstream.calls).to be_empty
     end
 
+    Otto::Utils::FORWARDED_AUTHORITY_HEADERS.each do |header|
+      it "denies a loopback call relayed with only #{header} under trusted_proxies: :none (otto#259)" do
+        # The authority carriers are scrubbed for every peer under trust-nobody.
+        # A relay that emits only one of them (no X-Forwarded-For) must still
+        # be recorded as relayed BEFORE the scrub, or the guard sees a direct
+        # local call.
+        security_config.trust_no_proxies!
+
+        env = env_for(remote_addr: '127.0.0.1', headers: { header => 'attacker.example' })
+        status, = stack_call(env)
+
+        expect(env).not_to have_key(header)          # scrubbed: looks direct
+        expect(env['otto.peer_loopback']).to be true # and the peer check passes
+        expect(env['otto.peer_relayed']).to be true  # only this record denies
+        expect(status).to eq(401)
+        expect(downstream.calls).to be_empty
+      end
+    end
+
     it 'still allows a genuinely direct loopback call under trusted_proxies: :none' do
       security_config.trust_no_proxies!
 

--- a/spec/otto/configuration_methods_spec.rb
+++ b/spec/otto/configuration_methods_spec.rb
@@ -189,15 +189,15 @@ RSpec.describe Otto, 'Configuration Methods' do
     it 'adds trusted proxies when provided as array' do
       proxies = ['127.0.0.1', '10.0.0.0/8', '192.168.1.0/24']
 
-      proxies.each do |proxy|
-        expect(app).to receive(:add_trusted_proxy).with(proxy)
-      end
+      # The list is handed over whole so every entry is validated before any
+      # is registered (a list containing the :none sentinel is rejected outright).
+      expect(app).to receive(:add_trusted_proxy).with(proxies)
 
       app.send(:configure_security, { trusted_proxies: proxies })
     end
 
     it 'adds trusted proxy when provided as single value' do
-      expect(app).to receive(:add_trusted_proxy).with('127.0.0.1')
+      expect(app).to receive(:add_trusted_proxy).with(['127.0.0.1'])
 
       app.send(:configure_security, { trusted_proxies: '127.0.0.1' })
     end
@@ -225,7 +225,7 @@ RSpec.describe Otto, 'Configuration Methods' do
       expect(app).to receive(:enable_csrf_protection!)
       expect(app).to receive(:enable_request_validation!)
       expect(app).to receive(:enable_rate_limiting!).with({})
-      expect(app).to receive(:add_trusted_proxy).with('127.0.0.1')
+      expect(app).to receive(:add_trusted_proxy).with(['127.0.0.1'])
       expect(app).to receive(:set_security_headers).with({ 'X-Test' => 'value' })
 
       app.send(:configure_security, {

--- a/spec/otto/ip_privacy_spec.rb
+++ b/spec/otto/ip_privacy_spec.rb
@@ -2603,4 +2603,100 @@ RSpec.describe 'IP Privacy Features' do
       expect { otto.configure_ip_privacy(redis: false) }.not_to raise_error
     end
   end
+
+  describe 'trust-nobody assertion (trusted_proxies: :none, otto#259)' do
+    let(:app) { ->(_env) { [200, {}, ['OK']] } }
+    let(:security_config) do
+      Otto::Security::Config.new.tap do |config|
+        config.trust_no_proxies!
+        config.ip_privacy_config.disable!
+      end
+    end
+    let(:middleware) { Otto::Security::Middleware::IPPrivacyMiddleware.new(app, security_config) }
+
+    around do |example|
+      original_priority = Rack::Request.forwarded_priority.dup
+      example.run
+    ensure
+      Rack::Request.forwarded_priority = original_priority
+    end
+
+    it 'marks every peer as not via a trusted proxy and strips the host carriers' do
+      env = Rack::MockRequest.env_for(
+        'http://origin.example/path',
+        'REMOTE_ADDR' => '203.0.113.50',
+        'HTTP_X_FORWARDED_HOST' => 'attacker.example',
+        'HTTP_FORWARDED' => 'for=192.0.2.10;host=attacker.example;proto=https',
+        'HTTP_X_FORWARDED_PROTO' => 'https'
+      )
+
+      middleware.call(env)
+
+      expect(env['otto.via_trusted_proxy']).to be(false)
+      expect(env).not_to have_key('HTTP_X_FORWARDED_HOST')
+      expect(env).not_to have_key('HTTP_FORWARDED')
+      expect(env).not_to have_key('HTTP_X_FORWARDED_PROTO')
+      expect(Rack::Request.new(env).host).to eq('origin.example')
+    end
+
+    it 'is false for a loopback peer too (no loopback special case)' do
+      env = { 'REMOTE_ADDR' => '127.0.0.1', 'HTTP_X_FORWARDED_HOST' => 'attacker.example' }
+
+      middleware.call(env)
+
+      expect(env['otto.via_trusted_proxy']).to be(false)
+      expect(env).not_to have_key('HTTP_X_FORWARDED_HOST')
+    end
+
+    it 'ignores X-Forwarded-For when resolving the client IP' do
+      env = { 'REMOTE_ADDR' => '203.0.113.50', 'HTTP_X_FORWARDED_FOR' => '198.51.100.9' }
+
+      middleware.call(env)
+
+      expect(env['otto.client_ip']).to eq('203.0.113.50')
+    end
+
+    it 'strips carriers under the DEFAULT (masked) privacy profile too' do
+      masked = Otto::Security::Config.new
+      masked.trust_no_proxies!
+      env = Rack::MockRequest.env_for(
+        'http://origin.example/path',
+        'REMOTE_ADDR' => '203.0.113.50',
+        'HTTP_X_FORWARDED_HOST' => 'attacker.example',
+        'HTTP_FORWARDED' => 'for=192.0.2.10;host=attacker.example'
+      )
+
+      Otto::Security::Middleware::IPPrivacyMiddleware.new(app, masked).call(env)
+
+      expect(env['otto.via_trusted_proxy']).to be(false)
+      expect(env).not_to have_key('HTTP_X_FORWARDED_HOST')
+      expect(env).not_to have_key('HTTP_FORWARDED')
+      expect(Rack::Request.new(env).host).to eq('origin.example')
+    end
+
+    it 'records the pre-scrub relay verdict in otto.peer_relayed' do
+      env = { 'REMOTE_ADDR' => '127.0.0.1', 'HTTP_FORWARDED' => 'for=203.0.113.9' }
+
+      middleware.call(env)
+
+      expect(env).not_to have_key('HTTP_FORWARDED')
+      expect(env['otto.peer_relayed']).to be(true)
+      expect(env['otto.peer_loopback']).to be(true)
+    end
+
+    it 'leaves carriers intact when trust is simply unconfigured (tri-state preserved)' do
+      unconfigured = Otto::Security::Config.new
+      unconfigured.ip_privacy_config.disable!
+      env = Rack::MockRequest.env_for(
+        'http://origin.example/path',
+        'REMOTE_ADDR' => '203.0.113.50',
+        'HTTP_X_FORWARDED_HOST' => 'public.example'
+      )
+
+      Otto::Security::Middleware::IPPrivacyMiddleware.new(app, unconfigured).call(env)
+
+      expect(env).not_to have_key('otto.via_trusted_proxy')
+      expect(env['HTTP_X_FORWARDED_HOST']).to eq('public.example')
+    end
+  end
 end

--- a/spec/otto/ip_privacy_spec.rb
+++ b/spec/otto/ip_privacy_spec.rb
@@ -2698,5 +2698,115 @@ RSpec.describe 'IP Privacy Features' do
       expect(env).not_to have_key('otto.via_trusted_proxy')
       expect(env['HTTP_X_FORWARDED_HOST']).to eq('public.example')
     end
+
+    describe 'stacked behind a prior IPPrivacyMiddleware pass' do
+      # An outer instance mounted WITHOUT the application's security config
+      # (docs/guides/privacy.md warns against it, but it is the common mistake)
+      # resolves otto.client_ip and nothing else. The inner instance must not
+      # let that idempotency short-circuit skip its own trust enforcement.
+      let(:unconfigured) { Otto::Security::Config.new.tap { |c| c.ip_privacy_config.disable! } }
+
+      def stacked(outer_config, inner_config)
+        inner = Otto::Security::Middleware::IPPrivacyMiddleware.new(app, inner_config)
+        Otto::Security::Middleware::IPPrivacyMiddleware.new(inner, outer_config)
+      end
+
+      def hostile_env
+        Rack::MockRequest.env_for(
+          'http://origin.example/path',
+          'REMOTE_ADDR' => '203.0.113.50',
+          'HTTP_X_FORWARDED_HOST' => 'attacker.example',
+          'HTTP_FORWARDED' => 'for=192.0.2.10;host=attacker.example;proto=https',
+          'HTTP_X_FORWARDED_PROTO' => 'https',
+          'HTTP_X_FORWARDED_SSL' => 'on'
+        )
+      end
+
+      it 'enforces trust-nobody after an outer pass that configured no trust' do
+        env = hostile_env
+        stacked(unconfigured, security_config).call(env)
+
+        expect(env['otto.via_trusted_proxy']).to be(false)
+        expect(env).not_to have_key('HTTP_X_FORWARDED_HOST')
+        expect(env).not_to have_key('HTTP_FORWARDED')
+        expect(env).not_to have_key('HTTP_X_FORWARDED_PROTO')
+        expect(env).not_to have_key('HTTP_X_FORWARDED_SSL')
+        expect(Rack::Request.new(env).host).to eq('origin.example')
+        expect(Rack::Request.new(env).scheme).to eq('http')
+      end
+
+      it 'enforces trust-nobody after an outer pass that TRUSTED the peer' do
+        trusting = Otto::Security::Config.new.tap do |c|
+          c.add_trusted_proxy('203.0.113.50')
+          c.ip_privacy_config.disable!
+        end
+        env = hostile_env
+        stacked(trusting, security_config).call(env)
+
+        expect(env['otto.via_trusted_proxy']).to be(false)
+        expect(env).not_to have_key('HTTP_X_FORWARDED_HOST')
+        expect(Rack::Request.new(env).host).to eq('origin.example')
+      end
+
+      it 'still resolves the client IP only once (no double masking)' do
+        masked_none = Otto::Security::Config.new.tap(&:trust_no_proxies!)
+        env = { 'REMOTE_ADDR' => '203.0.113.50', 'HTTP_X_FORWARDED_HOST' => 'attacker.example' }
+        stacked(masked_none, masked_none).call(env)
+
+        expect(env['otto.client_ip']).to eq('203.0.113.0')
+        expect(env['REMOTE_ADDR']).to eq('203.0.113.0')
+        expect(env['otto.via_trusted_proxy']).to be(false)
+        expect(env).not_to have_key('HTTP_X_FORWARDED_HOST')
+      end
+
+      it 'keeps the verdict of a configured outer pass in CIDR mode (same-config stacking)' do
+        cidr = Otto::Security::Config.new.tap do |c|
+          c.add_trusted_proxy('203.0.113.50')
+          c.ip_privacy_config.disable!
+        end
+        env = hostile_env
+        expect(Otto.logger).not_to receive(:warn)
+        stacked(cidr, cidr).call(env)
+
+        expect(env['otto.via_trusted_proxy']).to be(true)
+        expect(env['HTTP_X_FORWARDED_HOST']).to eq('attacker.example')
+      end
+
+      it 'fails closed in CIDR mode when the outer pass configured no trust' do
+        cidr = Otto::Security::Config.new.tap do |c|
+          c.add_trusted_proxy('203.0.113.50')
+          c.ip_privacy_config.disable!
+        end
+        env = hostile_env
+        expect(Otto.logger).to receive(:warn).with(/prior pass with no proxy trust configured/)
+        stacked(unconfigured, cidr).call(env)
+
+        # The peer DID match the CIDR, but the inner instance can no longer
+        # prove that, so it denies rather than grant on a rewritten address.
+        expect(env['otto.via_trusted_proxy']).to be(false)
+        expect(env).not_to have_key('HTTP_X_FORWARDED_HOST')
+        expect(Rack::Request.new(env).host).to eq('origin.example')
+      end
+
+      it 'records depth-mode trust after an outer pass that configured no trust' do
+        depth = Otto::Security::Config.new.tap do |c|
+          c.trusted_proxy_depth = 1
+          c.ip_privacy_config.disable!
+        end
+        env = hostile_env
+        stacked(unconfigured, depth).call(env)
+
+        expect(env['otto.via_trusted_proxy']).to be(true)
+        expect(env['HTTP_X_FORWARDED_HOST']).to eq('attacker.example')
+      end
+
+      it 'does nothing extra when the inner instance configures no trust either' do
+        env = hostile_env
+        stacked(unconfigured, unconfigured).call(env)
+
+        expect(env).not_to have_key('otto.via_trusted_proxy')
+        expect(env['HTTP_X_FORWARDED_HOST']).to eq('attacker.example')
+      end
+    end
   end
 end

--- a/spec/otto/utils_spec.rb
+++ b/spec/otto/utils_spec.rb
@@ -230,14 +230,6 @@ RSpec.describe Otto::Utils do
       expect(Otto::Utils.private_ip?("203.0.113.5")).to be false
     end
 
-    it "treats RFC 6598 shared address space (CGNAT) as non-public" do
-      expect(Otto::Utils.private_ip?("100.64.0.1")).to be true
-      expect(Otto::Utils.private_ip?("100.127.255.255")).to be true
-      # Neighbours outside 100.64.0.0/10 stay public.
-      expect(Otto::Utils.private_ip?("100.63.255.255")).to be false
-      expect(Otto::Utils.private_ip?("100.128.0.1")).to be false
-    end
-
     it "keeps documentation ranges public so example clients are not skipped" do
       expect(Otto::Utils.private_ip?("203.0.113.10")).to be false
       expect(Otto::Utils.private_ip?("192.0.2.1")).to be false
@@ -273,6 +265,32 @@ RSpec.describe Otto::Utils do
       expect(Otto::Utils.private_ip?(nil)).to be false
       expect(Otto::Utils.private_ip?("")).to be false
       expect(Otto::Utils.private_ip?("not-an-ip")).to be false
+    end
+  end
+
+  describe "#relayed_request?" do
+    it "is false for a request carrying no forwarding header" do
+      expect(Otto::Utils.relayed_request?({ "REMOTE_ADDR" => "127.0.0.1" })).to be false
+    end
+
+    it "ignores blank marker values" do
+      expect(Otto::Utils.relayed_request?({ "HTTP_X_FORWARDED_HOST" => "  " })).to be false
+    end
+
+    # Every carrier IPPrivacyMiddleware may delete on the untrusted-peer path
+    # must count as a relay marker, or a request relayed with only that header
+    # would look direct once the scrub has run (LocalhostGuard, otto#259).
+    Otto::Utils::FORWARDED_AUTHORITY_HEADERS.each do |header|
+      it "counts the authority carrier #{header} alone as a relay marker" do
+        expect(Otto::Utils::RELAY_MARKER_HEADERS).to include(header)
+        expect(Otto::Utils.relayed_request?({ header => "attacker.example" })).to be true
+      end
+    end
+
+    Otto::Utils::FORWARDED_FOR_HEADERS.each do |header|
+      it "counts the client-IP carrier #{header} alone as a relay marker" do
+        expect(Otto::Utils.relayed_request?({ header => "203.0.113.9" })).to be true
+      end
     end
   end
 

--- a/spec/otto/utils_spec.rb
+++ b/spec/otto/utils_spec.rb
@@ -230,6 +230,21 @@ RSpec.describe Otto::Utils do
       expect(Otto::Utils.private_ip?("203.0.113.5")).to be false
     end
 
+    it "treats RFC 6598 shared address space (CGNAT) as non-public" do
+      expect(Otto::Utils.private_ip?("100.64.0.1")).to be true
+      expect(Otto::Utils.private_ip?("100.127.255.255")).to be true
+      # Neighbours outside 100.64.0.0/10 stay public.
+      expect(Otto::Utils.private_ip?("100.63.255.255")).to be false
+      expect(Otto::Utils.private_ip?("100.128.0.1")).to be false
+    end
+
+    it "keeps documentation ranges public so example clients are not skipped" do
+      expect(Otto::Utils.private_ip?("203.0.113.10")).to be false
+      expect(Otto::Utils.private_ip?("192.0.2.1")).to be false
+      expect(Otto::Utils.private_ip?("198.51.100.1")).to be false
+      expect(Otto::Utils.private_ip?("2001:db8::1")).to be false
+    end
+
     it "recognizes IPv6 loopback, ULA, link-local, multicast and unspecified" do
       expect(Otto::Utils.private_ip?("::1")).to be true             # loopback
       expect(Otto::Utils.private_ip?("fc00::1")).to be true         # ULA
@@ -325,6 +340,14 @@ RSpec.describe Otto::Utils do
         "HTTP_X_FORWARDED_FOR" => "203.0.113.50, 10.0.0.9, 10.0.0.1",
       }
       expect(Otto::Utils.resolve_client_ip(env, config_with("10.0.0.0/8"))).to eq("203.0.113.50")
+    end
+
+    it "walks past a CGNAT proxy hop to the documentation-range client" do
+      env = {
+        "REMOTE_ADDR" => "100.64.5.5",
+        "HTTP_X_FORWARDED_FOR" => "203.0.113.10, 100.64.5.5",
+      }
+      expect(Otto::Utils.resolve_client_ip(env, config_with("100.64.0.0/10"))).to eq("203.0.113.10")
     end
 
     it "honors X-Real-IP and X-Client-IP in addition to X-Forwarded-For" do

--- a/spec/otto/utils_spec.rb
+++ b/spec/otto/utils_spec.rb
@@ -360,14 +360,6 @@ RSpec.describe Otto::Utils do
       expect(Otto::Utils.resolve_client_ip(env, config_with("10.0.0.0/8"))).to eq("203.0.113.50")
     end
 
-    it "walks past a CGNAT proxy hop to the documentation-range client" do
-      env = {
-        "REMOTE_ADDR" => "100.64.5.5",
-        "HTTP_X_FORWARDED_FOR" => "203.0.113.10, 100.64.5.5",
-      }
-      expect(Otto::Utils.resolve_client_ip(env, config_with("100.64.0.0/10"))).to eq("203.0.113.10")
-    end
-
     it "honors X-Real-IP and X-Client-IP in addition to X-Forwarded-For" do
       real = { "REMOTE_ADDR" => "10.0.0.1", "HTTP_X_REAL_IP" => "203.0.113.7" }
       client = { "REMOTE_ADDR" => "10.0.0.1", "HTTP_X_CLIENT_IP" => "203.0.113.8" }

--- a/spec/security_config_spec.rb
+++ b/spec/security_config_spec.rb
@@ -354,6 +354,105 @@ RSpec.describe Otto::Security::Config do
     end
   end
 
+  describe '#trust_no_proxies! (explicit trust-nobody assertion, otto#259)' do
+    it 'is off by default' do
+      expect(config.trust_no_proxies?).to be false
+    end
+
+    it 'makes proxy trust configured without configuring any matcher' do
+      config.trust_no_proxies!
+
+      expect(config.trust_no_proxies?).to be true
+      expect(config.proxy_trust_configured?).to be true
+      expect(config.trusted_proxies_configured?).to be false
+      expect(config.trusted_proxy_depth_mode?).to be false
+    end
+
+    it 'trusts no peer, loopback included' do
+      config.trust_no_proxies!
+
+      expect(config.trusted_proxy?('127.0.0.1')).to be false
+      expect(config.trusted_proxy?('10.0.0.1')).to be false
+    end
+
+    it 'ignores forwarded chains when resolving the client IP' do
+      config.trust_no_proxies!
+      env = { 'REMOTE_ADDR' => '203.0.113.50', 'HTTP_X_FORWARDED_FOR' => '198.51.100.9' }
+
+      expect(Otto::Utils.resolve_client_ip(env, config)).to eq('203.0.113.50')
+    end
+
+    it 'stakes no claim on the process-global forwarding family' do
+      config.trust_no_proxies!
+      config.commit_rack_forwarding_family!
+
+      expect(config.forwarding_family_dependent?).to be false
+      expect(described_class.rack_forwarding_family).to be_nil
+    end
+
+    it 'rejects combining it with trusted proxies (either order)' do
+      config.trust_no_proxies!
+      expect { config.add_trusted_proxy('10.0.0.0/8') }
+        .to raise_error(ArgumentError, /trust no proxy/)
+
+      other = described_class.new
+      other.add_trusted_proxy('10.0.0.0/8')
+      expect { other.trust_no_proxies! }.to raise_error(ArgumentError, /trust no proxy/)
+    end
+
+    it 'rejects combining it with a depth >= 1 (either order)' do
+      config.trust_no_proxies!
+      expect { config.trusted_proxy_depth = 2 }.to raise_error(ArgumentError, /trust no proxy/)
+
+      other = described_class.new
+      other.trusted_proxy_depth = 2
+      expect { other.trust_no_proxies! }.to raise_error(ArgumentError, /trust no proxy/)
+    end
+
+    it 'still allows a depth of 0/nil (depth mode off)' do
+      config.trust_no_proxies!
+
+      expect { config.trusted_proxy_depth = 0 }.not_to raise_error
+      expect(config.proxy_trust_configured?).to be true
+    end
+
+    it 'is reachable through Otto.new via trusted_proxies: :none' do
+      otto = Otto.new(nil, trusted_proxies: :none)
+
+      expect(otto.security_config.trust_no_proxies?).to be true
+    end
+
+    it "accepts the String spelling 'none' (YAML/ENV-driven config), any case" do
+      expect(described_class.trust_no_proxies_option?(:none)).to be true
+      expect(described_class.trust_no_proxies_option?('none')).to be true
+      expect(described_class.trust_no_proxies_option?('None')).to be true
+      expect(described_class.trust_no_proxies_option?('10.0.0.0/8')).to be false
+      expect(described_class.trust_no_proxies_option?(nil)).to be false
+
+      otto = Otto.new(nil, trusted_proxies: 'none')
+
+      expect(otto.security_config.trust_no_proxies?).to be true
+      expect(otto.security_config.trusted_proxies).to be_empty
+    end
+
+    it 'is reachable through the security configurator' do
+      otto = Otto.new(nil)
+      otto.security.configure(trusted_proxies: :none)
+
+      expect(otto.security_config.trust_no_proxies?).to be true
+    end
+
+    it 'is reachable on the Otto instance and refuses after freeze' do
+      otto = Otto.new(nil)
+      otto.trust_no_proxies!
+      expect(otto.security_config.trust_no_proxies?).to be true
+
+      frozen = Otto.new(nil)
+      frozen.freeze_configuration!
+      expect { frozen.trust_no_proxies! }.to raise_error(FrozenError)
+    end
+  end
+
   describe 'trusted_proxy_depth (count-based proxy mode)' do
     it 'defaults to nil (depth mode off)' do
       expect(config.trusted_proxy_depth).to be_nil

--- a/spec/security_config_spec.rb
+++ b/spec/security_config_spec.rb
@@ -435,6 +435,45 @@ RSpec.describe Otto::Security::Config do
       expect(otto.security_config.trusted_proxies).to be_empty
     end
 
+    it "refuses the sentinel as a list ENTRY (trusted_proxies: ['none']) instead of installing a prefix matcher" do
+      # A YAML/JSON list naturally yields ['none']; registering it as a legacy
+      # string-prefix matcher would leave trust_no_proxies? false and stake a
+      # forwarding-family claim, silently replacing the assertion.
+      expect { config.add_trusted_proxy(['none']) }.to raise_error(ArgumentError, /not inside a list/)
+      expect { config.add_trusted_proxy('None') }.to raise_error(ArgumentError, /trust_no_proxies!/)
+      expect { config.add_trusted_proxy(:none) }.to raise_error(ArgumentError, /trust_no_proxies!/)
+      # A mixed list is rejected before any entry is registered.
+      expect { config.add_trusted_proxy(['10.0.0.0/8', 'none']) }.to raise_error(ArgumentError, /not inside a list/)
+
+      expect(config.trusted_proxies).to be_empty
+      expect(config.trusted_proxies_configured?).to be false
+      expect(config.trust_no_proxies?).to be false
+      expect(config.forwarding_family_dependent?).to be false
+    end
+
+    it 'refuses a list-shaped sentinel through Otto.new and the security configurator' do
+      expect { Otto.new(nil, trusted_proxies: ['none']) }.to raise_error(ArgumentError, /not inside a list/)
+
+      otto = Otto.new(nil)
+      expect { otto.security.configure(trusted_proxies: ['none']) }.to raise_error(ArgumentError, /not inside a list/)
+      expect(otto.security_config.trusted_proxies).to be_empty
+      expect(otto.security_config.trust_no_proxies?).to be false
+    end
+
+    it 'rejects a mixed list without installing the valid entries first (configurator and Otto.new)' do
+      # Both wiring paths hand the list to add_trusted_proxy whole; iterating
+      # it entry by entry would leave '10.0.0.0/8' registered (and the config
+      # forwarding-family dependent) before 'none' raised.
+      otto = Otto.new(nil)
+      expect { otto.security.configure(trusted_proxies: ['10.0.0.0/8', 'none']) }
+        .to raise_error(ArgumentError, /not inside a list/)
+      expect(otto.security_config.trusted_proxies).to be_empty
+      expect(otto.security_config.trusted_proxies_configured?).to be false
+      expect(otto.security_config.forwarding_family_dependent?).to be false
+
+      expect { Otto.new(nil, trusted_proxies: ['10.0.0.0/8', 'none']) }.to raise_error(ArgumentError, /not inside a list/)
+    end
+
     it 'is reachable through the security configurator' do
       otto = Otto.new(nil)
       otto.security.configure(trusted_proxies: :none)


### PR DESCRIPTION
Closes #259.

## Summary

#252 already gates the forwarded-host carriers on the trusted-proxy signal, but only once trust is configured. This PR adds the explicit trust-nobody assertion, fixes a relay-detection hole the review surfaced, documents the whole feature, and adds the changelog fragments #252 never got.

### Trust-nobody assertion

```ruby
Otto.new('routes', trusted_proxies: :none)
# or
otto.trust_no_proxies!
```

- `otto.via_trusted_proxy` is `false` for every peer, including loopback, so the #252 scrub deletes `Forwarded` / `X-Forwarded-Host/Proto/Scheme/SSL/Port` for direct clients and `Rack::Request#host` resolves only from `Host`.
- Client IP falls through to `REMOTE_ADDR`.
- No process-wide `Rack::Request.forwarded_priority` family claim is staked. New `Config#forwarding_family_dependent?` separates that question from `proxy_trust_configured?`.
- Combining `:none` with CIDRs or depth >= 1 raises at config time.

**Unconfigured apps are unchanged.** The #228 tri-state contract holds: no trust config means the env key stays absent and Rack keeps its defaults. `:none` is a sentinel rather than `nil` or `[]` because both of those already mean "unconfigured", and a value that can arrive from an unset ENV or YAML key must not silently become "strip everything".

### Relay state recorded before the scrub

The scrub deletes `HTTP_FORWARDED` before `CaddyTLS::LocalhostGuard` reads it, so a loopback relay emitting only RFC 7239 `Forwarded` would be admitted as a direct local call. Reachable on main under CIDR mode with an unlisted loopback peer; `:none` would have made it the documented configuration. `IPPrivacyMiddleware` now records `env['otto.peer_relayed']` from the untouched env and the guard prefers it. Regression specs cover the guard and stack order.

### Special-use ranges

`Otto::Utils::SPECIAL_USE_RANGES` is unchanged. An inline comment records why the documentation ranges are deliberately excluded. An earlier revision added `100.64.0.0/10` (RFC 6598 CGNAT); that was dropped in 28124de because it also changes `Otto::Request#local?` and belongs in its own change.

### Trust-nobody sentinel as a list entry

`trusted_proxies: ['none']` (what a YAML/JSON list naturally yields) is rejected with guidance to use `trusted_proxies: :none` or `trust_no_proxies!`, instead of registering a legacy string-prefix matcher that would leave `trust_no_proxies?` false and stake a forwarding-family claim.

### Docs and changelog

- New guide `docs/guides/forwarded-authority.md`, linked from the docs README and the privacy guide.
- Changelog fragments for #252 (was missing) and #259.

## Verification

- `bundle exec rspec`: 2476 examples, 0 failures (plus 3 new utils examples).
- `bundle exec rubocop` on changed files: clean. Three pre-existing offenses remain in untouched CSP specs.

## Out of scope, filed as follow-ups

- Version bump and release. onetimesecret on 2.9 has neither #252 nor this until the next tag.
- Broken relative links in `docs/guides/privacy.md` to the geo-country and enrichment guides.
- `docs/guides/ip_privacy.md` is stale and contradicts the new guide; already flagged in the docs README.

