### PR TITLE
Rewrite the guides for clarity and accuracy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,27 @@
 
 This file provides essential guidance to AI agents when working with Otto.
 
+## Project claims and source authority
+
+### Attribution
+
+Do not infer project terminology or guarantees from repetition. Before attributing a claim to the project, locate an authoritative primary source and provide its exact wording. Treat delivery notes, commit messages, agent output, and documents created or modified during the current task as leads, not evidence. If the wording is absent, call it an interpretation or proposal. Never place paraphrases in quotation marks.
+
+### Authoritative sources
+
+Authoritative sources must be identified explicitly; repository presence alone does not confer authority. Accepted specifications and ADRs may establish project claims only within their stated scope. Delivery notes, commit messages, issue discussions, summaries, and agent-authored text are non-authoritative unless an authoritative source incorporates them explicitly.
+
+### Normative claims
+
+For normative claims concerning security, privacy, compatibility, persistence, or data loss:
+
+1. Cite the authoritative source and its exact wording.
+2. Distinguish quotations, paraphrases, interpretations, and proposals.
+3. Do not use material created or modified during the current task to validate that task’s claims.
+4. If no authoritative wording exists, report the claim as unsupported.
+
+
+
 ## Error Handler Registration
 
 Register handlers for expected business logic errors to avoid logging them as 500 errors:

--- a/changelog.d/20260904_160500_delano_259_trust_no_proxies.rst
+++ b/changelog.d/20260904_160500_delano_259_trust_no_proxies.rst
@@ -13,9 +13,14 @@ Added
 Security
 --------
 
-- Proxy trust is now enforced when privacy middleware runs in both a shared Rack
-  stack and an Otto application. The application applies its own trust posture
-  before retaining forwarded authority metadata. (#259)
+- ``IPPrivacyMiddleware`` enforces its own proxy trust posture even when an
+  outer instance already resolved ``otto.client_ip``. ``trusted_proxies: :none``
+  always strips forwarded authority; a CIDR configuration that can no longer
+  match the connecting peer treats it as untrusted and logs a warning. (#259)
 
-- Caddy on-demand TLS authorization now rejects relayed loopback requests even
-  when untrusted forwarded authority metadata is stripped first. (#259)
+- ``env['otto.peer_relayed']`` records whether a request carried any relay
+  marker header, evaluated before forwarded carriers may be deleted, so
+  ``Otto::CaddyTLS::LocalhostGuard`` still refuses a relayed loopback call once
+  the carriers are stripped. The relay markers cover every carrier the scrub
+  deletes, including ``X-Forwarded-Host`` and the other authority headers, not
+  only the client-IP carriers. (#259)

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -42,9 +42,10 @@ A presented-but-invalid key is a terminal failure, so it aborts the strategy
 chain instead of falling through to a later strategy in a multi-strategy `OR`
 route.
 
-The strategy reads the `X-API-Key` header only. The query/form parameter path is
-opt-in via `param_name:`, because a key placed in a URL is captured by access
-logs, proxies, and browser history:
+By default, the strategy reads only the `X-API-Key` header. Use `header_name:`
+to select a different header. The query/form parameter path is opt-in via
+`param_name:`, because a key placed in a URL is captured by access logs,
+proxies, and browser history:
 
 ```ruby
 Otto::Security::Authentication::Strategies::APIKeyStrategy.new(
@@ -116,12 +117,13 @@ The rules are the same in every form:
 
 The strategy cannot make a black-box lookup constant-time. Store SHA-256
 digests rather than raw keys and look up by `APIKeyStrategy.digest(key)`, as
-in the example above. The digest step is constant-time by construction, the
-lookup that follows is an exact match on a fixed-width value, and a database
-dump of high-entropy keys (generate them with `SecureRandom`, 32 bytes or
-more) does not expose usable credentials. Unsalted SHA-256 is not a password
-hash, so do not accept user-chosen keys. `APIKeyStrategy.digest(key)` returns
-the full hex digest; the fingerprint in the result is its first 12 characters.
+in the example above. This produces a fixed-width lookup value and keeps raw
+keys out of storage, but it does not make the application's database or cache
+lookup constant-time. A database dump of high-entropy keys (generate them with
+`SecureRandom`, 32 bytes or more) does not expose usable credentials through a
+practical brute-force search. Unsalted SHA-256 is not a password hash, so do
+not accept user-chosen keys. `APIKeyStrategy.digest(key)` returns the full hex
+digest; the fingerprint in the result is its first 12 characters.
 
 ### What `APIKeyStrategy` does not provide
 
@@ -230,12 +232,46 @@ GET /admin     Admin::Dashboard auth=session role=admin
 GET /edit      Editorial#edit auth=session role=admin,editor
 ```
 
-Multiple roles use OR logic. The authenticated result can expose roles through,
-in precedence order:
+`role=` checks the successful strategy result; it does not read
+`env['rack.session']` independently. The built-in `SessionStrategy` returns a
+user containing only `id` and `user_id`, so it is sufficient for authentication
+but not for these role checks. If the application uses role-protected session
+routes, register a role-aware application strategy instead of the built-in
+strategy shown earlier:
 
-1. `result.user_roles`
-2. `result.user[:roles]` or `result.user['roles']`
-3. `result.metadata[:user_roles]`
+```ruby
+class RoleAwareSessionStrategy < Otto::Security::Authentication::AuthStrategy
+  def authenticate(env, _requirement)
+    session = env['rack.session']
+    return failure('No session available') unless session
+
+    user_id = session['user_id']
+    return failure('Not authenticated') unless user_id
+
+    success(
+      user: {
+        id: user_id,
+        roles: Array(session['user_roles']).map(&:to_s),
+      },
+      session: session,
+      auth_method: 'session'
+    )
+  end
+end
+
+otto.add_auth_strategy('session', RoleAwareSessionStrategy.new)
+```
+
+Multiple route roles use OR logic. The role check reads, in precedence order:
+
+1. `result.user_roles`, if the result exposes it
+2. `result.user[:roles]` or `result.user['roles']` for a Hash-backed user
+3. `result.user.roles`, falling back to `result.user.role`, for an object-backed user
+4. `result.metadata[:user_roles]`
+
+Use strings for result-level, Hash-backed, or metadata roles so they match the
+string values parsed from the route. Object-backed `#roles` and `#role` values
+are normalized to strings.
 
 Missing authentication returns `401`. A valid authenticated subject without one
 of the required roles returns `403`. `response=json` makes these route errors
@@ -294,7 +330,9 @@ result.strategy_name
 ```
 
 Application code should read the result created by Otto rather than constructing
-its own `StrategyResult`. The result is immutable.
+its own `StrategyResult`. The `Data` record does not allow member reassignment,
+but contained `session`, `user`, and `metadata` objects are not deep-frozen;
+their mutability remains the application's responsibility.
 
 ## Failure and response behavior
 
@@ -335,5 +373,5 @@ store.
 - [Route syntax](../reference/route-syntax.md) — `auth=`, `role=`, and route
   parsing rules.
 - [Routing guide](routing.md) — choosing controller, Logic, and lambda handlers.
-- Configuration freezing (`Otto::Core::Freezable`) — boot-time mutation
+- [Configuration freezing](configuration_freezing.md) — boot-time mutation
   boundary and multi-step setup.

--- a/docs/guides/caddy-tls.md
+++ b/docs/guides/caddy-tls.md
@@ -117,6 +117,18 @@ non-empty value:
 - `X-Real-IP`
 - `X-Client-IP`
 - `Forwarded`
+- `X-Forwarded-Host`
+- `X-Forwarded-Proto`
+- `X-Forwarded-Scheme`
+- `X-Forwarded-SSL`
+- `X-Forwarded-Port`
+
+The list is the full set (`Otto::Utils::RELAY_MARKER_HEADERS`): every forwarding
+carrier Otto knows, including the authority headers, not only the client-IP
+carriers. A front server that adds any of them to the permission request, even
+one that only records the scheme or port, turns the call into a relayed request
+and the guard returns `401`. Configure the permission endpoint so the request
+reaches Otto without forwarding headers.
 
 The guard is path-scoped. Other application routes pass through it unchanged,
 and path normalization is shared with the router so encoded or trailing-slash

--- a/docs/guides/caddy-tls.md
+++ b/docs/guides/caddy-tls.md
@@ -1,9 +1,10 @@
 # Caddy on-demand TLS
 
 `Otto::CaddyTLS` provides the permission endpoint Caddy calls before obtaining
-or loading a certificate for a domain. Otto owns the route, request validation,
-access guard, response semantics, and fail-closed behavior. The application
-supplies one decision block: whether the requested domain is allowed.
+or loading a certificate for a domain. Otto owns the route, parameter-shape
+checks, access guard, response semantics, and fail-closed behavior. The
+application supplies one decision block: whether the requested domain is
+allowed.
 
 This guide covers the shipped integration. [ADR-003: Caddy TLS route-based
 integration](../adr/adr-003-caddy-tls-route-based-integration.md) explains the
@@ -24,9 +25,13 @@ end
 run otto
 ```
 
-The block receives the stripped `domain` string from `?domain=`. A truthy result
-returns `200 OK`; a falsey result returns `403 Forbidden`. An exception raised by
-the block is logged and treated as a denial.
+The block receives the stripped `domain` string from `?domain=`. Otto checks
+that the parameter is a non-empty string, but does not validate DNS syntax,
+lowercase the value, remove a trailing dot, or convert internationalized names.
+Perform any application-specific hostname normalization and validation in the
+block before querying domain data. A truthy result returns `200 OK`; a falsey
+result returns `403 Forbidden`. An exception raised by the block is logged and
+treated as a denial.
 
 The default endpoint is `/_caddy/tls-permission`. No entry in the routes file is
 required. Enabling without a block raises `ArgumentError`, and repeated enable
@@ -34,27 +39,49 @@ calls are idempotent: the first configuration and decision block remain active.
 
 ## Configure Caddy
 
-Caddy's current HTTP permission module and the older `ask` directive use the
-same Otto endpoint contract:
+`on_demand_tls` is a global Caddy option, and configuring its permission check
+does not enable on-demand TLS for a site. A complete minimal configuration is:
 
 ```caddyfile
-on_demand_tls {
-  permission http {
-    endpoint http://127.0.0.1:PORT/_caddy/tls-permission
+{
+  on_demand_tls {
+    permission http http://127.0.0.1:PORT/_caddy/tls-permission
+  }
+}
+
+https:// {
+  tls {
+    on_demand
+  }
+
+  reverse_proxy 127.0.0.1:APP_PORT
+}
+```
+
+Replace `PORT` with the loopback port serving the Otto permission endpoint and
+`APP_PORT` with the application port receiving normal traffic. If the same Otto
+app serves both, the ports may be the same.
+
+Caddy also documents `ask` as a backwards-compatible shortcut for the built-in
+HTTP permission module:
+
+```caddyfile
+{
+  on_demand_tls {
+    ask http://127.0.0.1:PORT/_caddy/tls-permission
   }
 }
 ```
 
-For older configurations:
+Both forms append `?domain=<host>` and treat a non-`2xx` response as a denial.
+Validate the chosen form with the Caddy version you deploy:
 
-```caddyfile
-on_demand_tls {
-  ask http://127.0.0.1:PORT/_caddy/tls-permission
-}
+```sh
+caddy adapt --config Caddyfile --adapter caddyfile
 ```
 
-Replace `PORT` with the loopback port serving the Otto endpoint. Caddy treats a
-non-`2xx` response as a denial.
+See Caddy's [`on_demand_tls` documentation](https://caddyserver.com/docs/caddyfile/options#on-demand-tls)
+for the current module syntax and deployment requirements.
 
 ## Request contract
 
@@ -77,13 +104,14 @@ The localhost guard is enabled by default. For the protected endpoint, both
 conditions must hold:
 
 1. the raw socket peer is loopback; and
-2. no forwarding header indicates that the request was relayed through another
-   proxy.
+2. no non-empty forwarding header indicates that the request was relayed
+   through another proxy.
 
 The guard authenticates the original peer, not the resolved client address in
 `REMOTE_ADDR` or `otto.client_ip`. This matters when a loopback proxy is also a
 trusted proxy: forwarded headers must not be able to turn a remote caller into a
-local one. The guard rejects these forwarding headers on the endpoint:
+local one. The guard rejects the endpoint request when any of these headers has a
+non-empty value:
 
 - `X-Forwarded-For`
 - `X-Real-IP`
@@ -94,6 +122,13 @@ The guard is path-scoped. Other application routes pass through it unchanged,
 and path normalization is shared with the router so encoded or trailing-slash
 variants cannot bypass the check.
 
+This protection assumes the Rack server leaves the actual connecting peer in
+`REMOTE_ADDR` and that no earlier proxy or middleware removes relay-marker
+headers before Otto records them. If PROXY protocol or an outer middleware
+rewrites either input, verify that Otto still receives an authentic peer address
+and the original forwarding markers. The strongest boundary is a dedicated
+loopback-only listener.
+
 ## Deployment topology
 
 The recommended deployment is a small Otto app bound to a loopback-only port on
@@ -103,9 +138,12 @@ the same host as Caddy:
 Caddy -- loopback --> Otto CaddyTLS endpoint -- authenticated app channel --> domain data
 ```
 
-The permission app may query a database, internal API, or cache in its decision
-block. That data channel is an application responsibility; it does not widen
-the Caddy endpoint's network trust boundary.
+Caddy expects this decision in a few milliseconds. Prefer an indexed local
+lookup or in-process cache. If the permission app must call an internal service,
+use a short timeout and cache the result: an exception or timeout that reaches
+the block's fail-closed wrapper becomes a denial and can fail the TLS handshake.
+That data channel is an application responsibility; it does not widen the Caddy
+endpoint's network trust boundary.
 
 If the endpoint is mounted in a larger public app, add defense in depth:
 
@@ -148,7 +186,7 @@ change it after configuration freezes raises `FrozenError`.
   loopback port, includes a non-empty `domain`, and that the callback returns
   truthy for that exact stripped domain.
 - **The callback is never called:** a missing/blank domain produces `400`, while
-  a non-loopback peer or any forwarding header produces `401`.
+  a non-loopback peer or any non-empty forwarding header produces `401`.
 - **A proxied public request reaches the same app:** keep the forwarding-header
   rejection and add a proxy path block or a dedicated loopback-only endpoint.
 - **A second `enable_caddy_tls!` call does not change behavior:** this is

--- a/docs/guides/configuration_freezing.md
+++ b/docs/guides/configuration_freezing.md
@@ -1,110 +1,146 @@
-# Configuration Freezing Documentation
+# Configuration freezing
 
-Otto automatically freezes all configuration at the end of initialization to prevent runtime security bypasses.
+Otto supports multi-step boot configuration. In normal operation, it freezes the
+configured application immediately before processing the first request. When
+`RSpec` is defined, automatic request-time freezing is skipped so test suites can
+assemble applications incrementally.
 
-## How It Works
+Configuration must be complete before traffic reaches the application. For a
+more explicit boot boundary, call `freeze_configuration!` after setup and before
+starting the Rack server.
 
-1. **Lazy Freezing**: Configuration freezing is deferred until the first request to support multi-step initialization
-2. **Thread-Safe**: Uses mutex synchronization to ensure configuration is frozen exactly once
-3. **Deep Freezing**: Uses recursive freezing to prevent modification at any nesting level
-4. **Memoization-Compatible**: Pre-computes memoized values before freezing to avoid FrozenError
-
-This lazy approach allows multi-app architectures (like OneTime Secret's registry-based system) to:
-- Create Otto instances with `Otto.new(routes_file)`
-- Add authentication strategies via `otto.add_auth_strategy(name, strategy)`
-- Configure middleware with `otto.use(middleware)`
-- Add security features via `otto.enable_csrf_protection!`
-- All **before** the first request triggers freezing
-
-## What Gets Frozen
-
-- **Security Config**: All security settings including CSRF, validation, rate limiting, and headers
-- **Middleware Stack**: Prevents adding, removing, or modifying middleware after initialization
-- **Routes**: All route structures (`@routes`, `@routes_literal`, `@route_definitions`)
-- **Configuration Hashes**: `@auth_config`, `@locale_config`, `@option` and all nested structures
-
-## Security Guarantees
+## Configure before serving requests
 
 ```ruby
-# After first request, ALL of these will raise FrozenError:
-
-# Direct modification attempts
-otto.security_config.csrf_protection = false  # FrozenError!
-otto.middleware.add(MaliciousMiddleware)       # FrozenError!
-
-# Method-based modification attempts
-otto.enable_csrf_protection!                   # FrozenError!
-otto.add_trusted_proxy('evil.proxy')           # FrozenError!
-otto.add_rate_limit_rule('bypass', limit: 999999) # FrozenError!
-
-# Nested structure modification attempts
-otto.security_config.rate_limiting_config[:custom_rules] = {} # FrozenError!
-otto.auth_config[:auth_strategies] = {}        # FrozenError!
-```
-
-## Multi-Step Initialization Pattern
-
-For complex applications that need to configure Otto after creation (e.g., multi-app architectures):
-
-```ruby
-# Step 1: Create Otto instance
 otto = Otto.new('routes.txt')
 
-# Step 2: Configure after initialization (BEFORE first request)
-otto.add_auth_strategy('session', SessionStrategy.new(session_key: 'user_id'))
-otto.add_auth_strategy('api_key', APIKeyStrategy.new(api_keys: ENV.fetch('API_KEYS').split(',')))
+otto.add_auth_strategy(
+  'session',
+  Otto::Security::Authentication::Strategies::SessionStrategy.new(
+    session_key: 'user_id'
+  )
+)
+otto.add_auth_strategy(
+  'api_key',
+  Otto::Security::Authentication::Strategies::APIKeyStrategy.new(
+    api_keys: ENV.fetch('API_KEYS').split(',')
+  )
+)
 otto.enable_csrf_protection!
-otto.use CustomMiddleware
+otto.use MyApp::Middleware
+otto.register_error_handler(MyApp::NotFound, status: 404, log_level: :info)
 
-# Step 3: First request triggers automatic freezing
-# From this point on, configuration is immutable
-
-# Later requests: Configuration is already frozen
-# otto.add_auth_strategy(...)  # FrozenError!
+# Optional: make the end of boot explicit rather than waiting for a request.
+otto.freeze_configuration!
 ```
 
-This pattern is particularly useful for:
-- Registry-based multi-app systems (like OneTime Secret)
-- Applications that dynamically configure Otto based on environment
-- Testing scenarios where configuration needs to happen in multiple phases
-
-## Testing Considerations
-
-- Freezing is **automatically disabled** when `RSpec` is defined
-- For manual unfreezing in tests, use `Otto.unfreeze_for_testing(otto)` (requires RSpec to be defined)
-- **Never** use `unfreeze_for_testing` in production code - it raises an error if RSpec is not defined
-
-## Implementation Details
-
-- Lazy freezing occurs in `Otto#call` on first request (thread-safe with mutex)
-- `@configuration_frozen` flag tracks freeze state (checked by `ensure_not_frozen!`)
-- `Otto::Core::Freezable` module provides `deep_freeze!` method
-- `MiddlewareStack` and `Security::Config` override `deep_freeze!` to pre-compute memoized values
-- Uses `defined?()` pattern instead of `||=` for freeze-compatible memoization
-- All mutation methods check `frozen_configuration?` and raise `FrozenError` when frozen
-
-## Error Handler Registration and Freezing
-
-Error handlers must be registered before the first request (before configuration freezing):
+Calling a supported configuration method after freezing raises `FrozenError`:
 
 ```ruby
-otto = Otto.new('routes.txt')
-otto.register_error_handler(MyError, status: 404)  # ✓ OK
-
-# First request triggers freezing
-otto.call(env)
-
-otto.register_error_handler(AnotherError, status: 404)  # ✗ FrozenError!
+otto.add_auth_strategy('other', MyApp::OtherStrategy.new)
+# FrozenError: Cannot modify frozen configuration
 ```
 
-## Why Configuration Freezing Matters
+`freeze_configuration!` is idempotent and returns the Otto instance.
 
-Configuration freezing prevents several classes of security vulnerabilities:
+## What is frozen
 
-1. **Runtime Configuration Tampering**: Prevents malicious code from disabling security features
-2. **Middleware Injection**: Prevents insertion of malicious middleware after initialization
-3. **Route Hijacking**: Prevents modification of routing tables at runtime
-4. **Auth Strategy Bypass**: Prevents replacement of authentication strategies
-5. **Rate Limit Bypass**: Prevents modification of rate limiting rules
+`freeze_configuration!` freezes these owned structures:
 
-The lazy freezing approach balances security with flexibility, allowing complex initialization patterns while ensuring runtime immutability.
+- security and locale configuration objects;
+- the middleware stack;
+- authentication configuration and instance options;
+- dynamic and literal route tables;
+- route definitions and reverse-route indexes.
+
+Hashes and arrays inside those structures are recursively frozen. Configuration
+objects that implement `deep_freeze!` can prepare memoized values before they
+are frozen.
+
+The static-file route structure is an intentional exception. Its outer hash is
+frozen, but the `routes_static[:GET]` `Concurrent::Map` remains writable because
+Otto caches newly discovered static paths during requests.
+
+## Scope and current limitations
+
+Freezing is a guard around Otto's supported configuration APIs, not a complete
+object-capability boundary. In particular, the current implementation exposes
+some state that is not included in `freeze_configuration!`:
+
+- `error_handlers` remains a mutable Hash, although
+  `register_error_handler` rejects calls after freezing;
+- the `not_found` and `server_error` fallback response writers remain available;
+- the inner static-file cache remains mutable by design.
+
+Application code should not mutate those objects directly after boot. Do not
+state or depend on a guarantee that every object reachable from an Otto instance
+is deeply immutable.
+
+## Expected failures after freezing
+
+These supported mutation paths reject changes after the freeze boundary:
+
+```ruby
+# Security configuration
+otto.disable_csrf_protection!
+otto.add_trusted_proxy('192.0.2.10')
+otto.add_rate_limit_rule('uploads', limit: 5, period: 60)
+
+# Middleware and authentication
+otto.use MyApp::OtherMiddleware
+otto.add_auth_strategy('other', MyApp::OtherStrategy.new)
+
+# Helpers and expected-error handling
+otto.register_request_helpers(MyApp::RequestHelpers)
+otto.register_response_helpers(MyApp::ResponseHelpers)
+otto.register_error_handler(MyApp::RateLimited, status: 429)
+```
+
+Direct mutation of frozen nested structures also raises `FrozenError`:
+
+```ruby
+otto.security_config.rate_limiting_config[:custom_rules] = {}
+otto.auth_config[:auth_strategies] = {}
+otto.routes[:GET] = []
+```
+
+## Testing the boundary
+
+Otto deliberately skips automatic first-request freezing when `RSpec` is
+defined. A freeze-focused spec must freeze explicitly:
+
+```ruby
+RSpec.describe 'configuration freezing' do
+  it 'rejects configuration changes after the boot boundary' do
+    otto = Otto.new
+    otto.freeze_configuration!
+
+    expect(otto.frozen_configuration?).to be(true)
+    expect {
+      otto.add_auth_strategy('other', MyApp::OtherStrategy.new)
+    }.to raise_error(FrozenError, /Cannot modify frozen configuration/)
+  end
+end
+```
+
+Use a fresh Otto instance when a later example needs mutable configuration.
+`Otto.unfreeze_for_testing` is an internal test helper that only resets the
+`@configuration_frozen` flag; it cannot unfreeze Ruby objects that were already
+frozen by `freeze_configuration!`.
+
+## Thread behavior
+
+For the automatic production path, `Otto#call` guards the first freeze with a
+mutex and checks the frozen flag again inside the critical section. Concurrent
+first requests therefore do not run the freeze operation concurrently.
+
+## Related source and tests
+
+- [`Otto#call`](../../lib/otto.rb) — automatic first-request boundary and the
+  RSpec exception.
+- [`Otto::Core::Configuration`](../../lib/otto/core/configuration.rb) — exact
+  freeze scope and mutation guard.
+- [`Otto::Core::Freezable`](../../lib/otto/core/freezable.rb) — recursive
+  freezing behavior.
+- [Configuration-freezing specs](../../spec/otto/configuration_freezing_spec.rb).
+- [Static-file freezing specs](../../spec/otto/static_file_freezing_spec.rb).

--- a/docs/guides/configuration_freezing.md
+++ b/docs/guides/configuration_freezing.md
@@ -82,7 +82,7 @@ These supported mutation paths reject changes after the freeze boundary:
 
 ```ruby
 # Security configuration
-otto.disable_csrf_protection!
+otto.security_config.disable_csrf_protection!
 otto.add_trusted_proxy('192.0.2.10')
 otto.add_rate_limit_rule('uploads', limit: 5, period: 60)
 

--- a/docs/guides/enrichment.md
+++ b/docs/guides/enrichment.md
@@ -14,65 +14,91 @@ publishes a client-ASN or anonymizer header with meaningful deployment, so
 there is no header tier and none of geo's header-trust machinery applies —
 including the `geo_header`/`trusted_proxy_depth` boot conflict.
 
-Every signal keeps the same three-state contract:
+For requests that pass through the privacy fingerprint pipeline, each signal
+uses these values:
 
 | Value | Meaning |
 | --- | --- |
-| `nil` | the signal is switched off |
-| `'**'` | switched on, but nothing resolved (no database, or lookup failed) |
-| a label | a real answer |
+| `nil` | no enrichment value was produced: the signal is off, IP privacy is disabled, no client IP resolved, or the client is exempt from fingerprinting |
+| `'**'` | the signal is on, but no database answered or the lookup failed |
+| a label | the configured reader returned a usable answer |
+
+By default, private and localhost clients are exempt from fingerprinting. Their
+enrichment environment keys are absent even when the signals are enabled. Use
+the `:anonymous` privacy profile only if those clients should also be masked and
+enriched.
 
 ## Configuration
 
+Add the optional reader gem when configuring an MMDB path:
+
 ```ruby
-otto.configure_ip_privacy(
-  asn: true,
-  asn_db_path: 'data/origin-asn.mmdb',
-  anonymizer: true,
-  anonymizer_db_path: 'data/anonymizer.mmdb',
-)
+# Gemfile
+gem 'maxmind-db', '~> 1.2'
 ```
 
-Both accept the same bring-your-own-reader seam as geo (`asn_db_reader:` /
-`anonymizer_db_reader:` — any object responding to `#get(ip)`; a reader
-supplied in the same call wins over a path). Bad paths raise at boot, not
-per-request. The [`maxmind-db`](https://rubygems.org/gems/maxmind-db) gem is
-required only when a `*_db_path` is configured; Otto supports version 1.2.0 or
-newer in the 1.x series (`gem 'maxmind-db', '~> 1.2'`). Missing or incompatible
-versions raise `Otto::OptionalDependencyError` during configuration.
+Then install an ASN database and enable the signal before the first request:
 
-## ASN: which address is looked up, and why that's safe
-
-The ASN lookup uses the **masked** IP, same as geo. This is not a compromise:
-IPv4 BGP routes are not announced longer than /24, so a /24-masked address
-falls inside the same announced prefix — and therefore the same ASN — as the
-real one. (IPv6 is coarser: at `octet_precision: 1` Otto zeroes the last 80
-bits, wider than many IPv6 announcements, so treat IPv6 ASN as best-effort.)
-
-### Data file
-
-> **Naming caution:** the country database this project recommends,
-> `geo-whois-asn-country`, does **not** contain ASN data. In
-> sapics/ip-location-db naming, `geo-whois-asn` describes the *sources* the
-> country data was derived from; the final token (`-country`) is what the
-> records contain. ASN data is a separate file type in that project.
-
-The recommended ASN file is
-[`origin-asn`](https://github.com/sapics/ip-location-db/tree/main/origin-asn/)
-from sapics/ip-location-db — like `geo-whois-asn-country` it is **PDDL v1.0
-(public domain)** and rebuilt daily, so the licensing/freshness posture
-matches the geo guidance:
-
-```bash
+```sh
+bundle install
+mkdir -p data
 curl -fsSL -o data/origin-asn.mmdb \
   https://github.com/sapics/ip-location-db/releases/download/latest/origin-asn.mmdb
 ```
 
-Its records carry a flat `autonomous_system_number` (verified against the
-published file), which is the primary key `AsnResolver` reads. GeoLite2-ASN
-and DB-IP ASN Lite MMDBs work too (same key; GeoLite2's EULA caveats from the
-geo doc apply). Reserved ASNs (0 per RFC 7607, the AS_TRANS placeholder 23456
-per RFC 6793) resolve to `'**'` rather than being reported as operators.
+```ruby
+otto.configure_ip_privacy(
+  asn: true,
+  asn_db_path: 'data/origin-asn.mmdb'
+)
+```
+
+Anonymizer classification requires a separate compatible database that Otto
+does not provide:
+
+```ruby
+otto.configure_ip_privacy(
+  anonymizer: true,
+  anonymizer_db_path: 'data/your-anonymous-ip.mmdb'
+)
+```
+
+Do not use that placeholder path until the file exists. Both signals also accept
+a bring-your-own reader (`asn_db_reader:` / `anonymizer_db_reader:`): any object
+responding to `#get(ip)`. A reader supplied in the same call wins over a path.
+
+The `maxmind-db` gem is loaded only when an enabled signal has a `*_db_path`.
+Otto supports version 1.2.0 or newer in the 1.x series. Missing or incompatible
+versions raise `Otto::OptionalDependencyError` during configuration. An
+unreadable path also raises during configuration when its signal is enabled; a
+path attached to a disabled signal is stored but not opened.
+
+## ASN: which address is looked up, and why that's safe
+
+The ASN lookup always uses the **masked** IP, same as geo. With the default
+IPv4 `/24` masking, accuracy depends on the chosen database assigning the same
+ASN across that `/24`; Otto accepts arbitrary MMDBs and injected readers, so it
+cannot guarantee that equivalence. IPv6 is coarser: at `octet_precision: 1`
+Otto zeroes the last 80 bits to produce a `/48`, which is wider than many IPv6
+announcements. Treat masked ASN results as best-effort and verify the behavior
+of the data source used by policy code.
+
+### Data file
+
+> **Dataset distinction:** sapics/ip-location-db publishes country and ASN data
+> as separate file types. Current country files such as `user-country.mmdb` do
+> not contain ASN records. Use an ASN file such as `origin-asn.mmdb` for this
+> signal.
+
+The recommended ASN file is
+[`origin-asn`](https://github.com/sapics/ip-location-db/tree/main/origin-asn/)
+from sapics/ip-location-db. It is **PDDL v1.0 (public domain)**, rebuilt daily,
+and downloaded by the setup command above.
+
+Compatible records must provide an integer `autonomous_system_number` either at
+the top level or inside an `asn` map; Otto also accepts a bare integer `asn`
+field. Reserved ASNs (0 per RFC 7607 and the AS_TRANS placeholder 23456 per RFC
+6793) resolve to `'**'` rather than being reported as operators.
 
 ## Anonymizer: the one unmasked lookup
 
@@ -83,10 +109,12 @@ masked geo and ASN lookups does not hold. A masked lookup would flag a whole
 /24 because one host in it runs a Tor exit, and miss the exit node itself —
 wrong in both directions.
 
-The privacy containment is the same one Otto already relies on for
-`hash_ip` and `env['otto.ip_match']`, which also consume the full IP: **only
-the derived value leaves**. The resolver returns a label; the address is
-never persisted, serialized, or handed downstream.
+Otto passes the full address to the configured
+`anonymizer_db_reader#get(ip)` and retains only the returned label. Because the
+reader may be any application-provided object, Otto cannot guarantee that the
+reader does not log, persist, or transmit the address. Use a trusted local
+reader and review its network, logging, and retention behavior. Otto itself does
+not place the raw address in the enrichment result or downstream environment.
 
 ### Reading the labels
 
@@ -96,10 +124,11 @@ provider), the **most specific** label wins: `tor` > `proxy` > `vpn` >
 
 Two labels deserve care:
 
-- **`'none'`** means the database was consulted and does not list the
-  address. For an anonymizer database that is a real answer (these files
-  record only flagged addresses), but it is *not* a positive assertion the
-  visitor is residential — it is only as fresh as your database file.
+- **`'none'`** means the reader was consulted and returned no record or no
+  recognized true flag. For an anonymous-IP MMDB, this normally means the
+  address is not listed, but it is *not* a positive assertion that the visitor
+  is residential. The result is only as reliable and current as the reader's
+  data.
 - **`'**'`** means no database answered at all. Do not collapse it into
   `'none'`: `'none'` is evidence, `'**'` is the absence of evidence. A
   "block anonymizers" rule that treats `'**'` as `'none'` fails open when
@@ -107,24 +136,26 @@ Two labels deserve care:
 
 ### Data file
 
-There is no public-domain anonymizer dataset of `origin-asn`'s quality; this
-signal is bring-your-own-database. `AnonymizerResolver` reads the MaxMind
-GeoIP2 Anonymous-IP flag schema (`is_tor_exit_node`, `is_public_proxy`,
-`is_anonymous_vpn`, `is_residential_proxy`, `is_hosting_provider`,
-`is_anonymous`), which commercial and self-built MMDBs alike use. A workable
-self-built option: compile the [Tor bulk exit
-list](https://check.torproject.org/torbulkexitlist) into an MMDB with
-`is_tor_exit_node` set — that covers the highest-signal label with fully
-public data.
+This signal is bring-your-own-database. `AnonymizerResolver` expects top-level
+fields matching the MaxMind GeoIP2 Anonymous-IP schema:
+`is_tor_exit_node`, `is_public_proxy`, `is_anonymous_vpn`,
+`is_residential_proxy`, `is_hosting_provider`, and `is_anonymous`. Verify the
+record shape before choosing a commercial or self-built MMDB.
+
+The [Tor bulk exit list](https://check.torproject.org/torbulkexitlist) can be an
+input to a self-built database, but Otto does not include an MMDB compiler or an
+update job. A generated record must set `is_tor_exit_node` at the top level, and
+the deployment must refresh and verify the file on its own schedule.
 
 ## Acceptance behavior summary
 
 | Scenario | Result |
 | --- | --- |
-| Signal not enabled | `nil` everywhere (env key absent for exempt IPs) |
-| Enabled, no database configured | `'**'` |
+| Signal not enabled | `nil` when read; a processed public request may carry an env key whose value is `nil` |
+| IP privacy disabled or no client IP resolves | `nil`; no enrichment values are written |
+| Enabled, no database configured | `'**'` for a non-exempt request |
 | Database read raises | `'**'` (a lookup must never crash a request) |
 | ASN lookup | masked IP only (re-masked defensively in the resolver) |
-| Anonymizer lookup | unmasked IP in, label out, nothing else retained |
-| Private/localhost client (privacy-exempt) | no enrichment keys in env |
-| Bad `*_db_path` | raises at boot, not per-request |
+| Anonymizer lookup | the configured reader receives the unmasked IP; Otto exposes only its label |
+| Private/localhost client under the default profile | no enrichment keys in env |
+| Bad `*_db_path` for an enabled signal | raises during configuration, not per-request |

--- a/docs/guides/forwarded-authority.md
+++ b/docs/guides/forwarded-authority.md
@@ -29,6 +29,13 @@ Rack may also use forwarded host, scheme, and port values.
 | Proxy addresses cannot be enumerated, but the hop count is fixed | `trusted_proxy_depth: N` | Otto trusts the carriers on every request. The application origin must accept traffic only from the proxy tier. |
 | Another layer owns the trust decision | Leave proxy trust unconfigured | Otto leaves the carriers unchanged and makes no trust assertion. |
 
+> [!WARNING]
+> These settings control forwarded authority only. They do not validate the
+> ordinary `Host` header. After forwarded carriers are stripped, Rack falls back
+> to `Host`, which a direct client can still choose. If redirects, generated
+> links, WebAuthn, OAuth, or cookie policy require a canonical host, enforce a
+> host allowlist in the front server or application.
+
 For a directly exposed application:
 
 ```ruby
@@ -149,10 +156,17 @@ header itself, so nothing is lost.
 
 ## Choose the forwarding family for depth mode
 
-`Rack::Request.forwarded_priority` is a process-wide setting that determines
-which forwarding family Rack reads: `X-Forwarded-*`, RFC 7239 `Forwarded`, or
-both. Otto pins it to the family selected by `trusted_proxy_header` so Otto and
-Rack interpret the same request metadata.
+`Rack::Request.forwarded_priority` is a process-wide setting that selects the
+main forwarding family Rack reads: `X-Forwarded-*`, RFC 7239 `Forwarded`, or
+both. Otto pins it to the family selected by `trusted_proxy_header` so client-IP
+resolution and Rack's main forwarded host, port, and scheme parsing agree.
+
+This is not a complete sanitizer for requests from a trusted peer. Rack checks
+some compatibility carriers independently, notably `X-Forwarded-SSL`. Otto
+keeps forwarded carriers from trusted peers because it cannot distinguish
+values created by the proxy from values the proxy passed through. Configure the
+trusted proxy to remove client-supplied forwarding headers before setting its
+own authoritative values.
 
 The pin governs host, port, and the `X-Forwarded-Proto` / `proto=` scheme
 lookup. It does not govern `X-Forwarded-SSL`: Rack (3.2.x) honors

--- a/docs/guides/geo-country.md
+++ b/docs/guides/geo-country.md
@@ -1,183 +1,168 @@
 # Geo-country resolution
 
-Otto resolves a country-level ISO 3166-1 alpha-2 code for each request and
-exposes it as `req.geo_country` / `env['otto.privacy.geo_country']`. Resolution
-is country-only by design — that is the privacy posture; there is no city or
-region lookup. (Two opt-in, database-only companion signals — ASN and
-anonymizer classification — are covered in [enrichment](enrichment.md).)
+Otto exposes a country-level ISO 3166-1 alpha-2 code as `req.geo_country` and
+`env['otto.privacy.geo_country']`. It does not expose city or region data. For a
+request that enters the privacy fingerprint, enabled but unresolved geo returns
+`**`. The value is `nil` when IP privacy or geo resolution is disabled, or when
+a private/loopback request is exempt from the fingerprint.
+
+For the surrounding privacy profiles and environment-key contracts, see
+[Privacy-preserving request data](privacy.md). ASN and anonymizer signals are
+covered separately in [ASN and anonymizer enrichment](enrichment.md).
 
 ## Resolution order
 
-`Otto::Privacy::GeoResolver.resolve` returns the first hit from:
+For requests handled by Otto, the first valid result wins:
 
-1. **Application-configured header** (`geo_header:`) — e.g. `X-Client-Country`.
-2. **Known provider headers** — Cloudflare (`CF-IPCountry`), AWS CloudFront,
-   Fastly, Akamai Edgescape, Azure Front Door, **Vercel**
-   (`X-Vercel-IP-Country`), and a few semi-standard names
-   (`X-Geo-Country`, `X-Country-Code`, `Country-Code`).
-3. **Custom resolver** (`GeoResolver.custom_resolver`) — your own callable.
-   Unlike the other geo settings, this is **class-level** (see
-   [Configuration](#configuration)).
-4. **Local MMDB database** (`geo_db_path:` / `geo_db_reader:`) — a MaxMind-DB
-   country database.
-5. **`'**'`** — the unknown sentinel, when nothing else matches.
+1. the application-configured `geo_header`;
+2. built-in provider headers for Cloudflare, AWS CloudFront, Fastly, Akamai,
+   Azure Front Door, Vercel, and several semi-standard country headers;
+3. the process-wide `Otto::Privacy::GeoResolver.custom_resolver` callable;
+4. a local MMDB reader configured with `geo_db_path` or `geo_db_reader`;
+5. `**` when no source resolves a country.
 
-Steps 1 and 2 are **only consulted when geo headers can be trusted** (see
-[Header trust](#header-trust-and-spoofing) below).
+Header sources are consulted only when the request arrived through a configured
+CIDR trusted proxy. See [Trust geo headers](#trust-geo-headers).
 
-Resolution is **honest**: Otto does not guess from a hardcoded IP-range table.
-When no header, custom resolver, or database resolves a country, the result is
-`'**'`.
+The middleware gives custom resolvers a copy of the Rack environment with the
+client address masked or removed. The local database lookup also masks the IP
+again before calling its reader. A custom resolver called directly outside the
+middleware does not receive that additional environment protection.
 
-### Privacy: masked IP and masked env
+## Configure a trusted header or local database
 
-The database lookup in step 4 runs on the request's **masked** IP
-(e.g. `203.0.113.0`), never the real address. `check_geo_database` masks the IP
-internally with the config's `octet_precision` before the lookup, so even a
-direct `GeoResolver.resolve` caller passing a real IP does not expose it to the
-database. Country-level MMDB networks are almost always ≥ /24, so the default
-/24-masked value (`octet_precision: 1`) resolves to the same country.
-
-In the middleware path Otto additionally hands `resolve` a **masked env view**:
-`REMOTE_ADDR`, `X-Forwarded-For`, `X-Real-IP`, `X-Client-IP`, and the RFC 7239
-`Forwarded` header are masked. So a `custom_resolver` cannot read the raw client
-IP out of `env` either — use the `ip` argument (already masked), not `env`.
-
-> **`octet_precision: 2`** masks two octets (a /16). That is coarser than most
-> country networks, so it can reduce database hit rate for the small share of
-> countries whose ranges are finer than /16 — those requests fall through to
-> `'**'`. Header and custom-resolver sources are unaffected (they ignore the
-> IP). Keep the default precision if you rely on the MMDB fallback.
-
-## Configuration
-
-All geo configuration is **boot-time only** (set once during single-threaded
-initialization, before serving requests), matching `custom_resolver`'s
-contract. `geo_header`, `geo_db_path`, and `geo_db_reader` are stored on the
-instance's `Otto::Privacy::Config`, so separate Otto instances hold independent
-geo configuration.
-
-> **`custom_resolver` is the exception — it is class-level, not per-instance.**
-> `GeoResolver.custom_resolver=` sets a singleton on the `GeoResolver` class, so
-> it is **shared across every Otto instance in the process** (last write wins).
-> If you run multiple Otto instances that need different resolver strategies,
-> the custom resolver cannot distinguish them — branch inside a single resolver
-> on `env`, or use per-instance `geo_db_reader` instead.
+All configuration is boot-time only and must be complete before the first
+request:
 
 ```ruby
 otto.configure_ip_privacy(
-  geo:           true,                                # default; false disables geo entirely
-  geo_header:    'X-Client-Country',                 # trusted app header (optional)
-  geo_db_path:   'data/geo-whois-asn-country.mmdb',  # local MMDB fallback (optional)
-  # geo_db_reader: MaxMind::DB.new(path),            # or bring your own reader (optional)
+  geo: true,                              # default
+  geo_header: 'X-Client-Country',         # optional trusted header
+  geo_db_path: 'data/user-country.mmdb'   # optional local fallback
 )
 ```
 
-- **`geo: false`** short-circuits everything: no header reads, and any loaded
-  database is unloaded from memory (`req.geo_country` becomes `nil`).
-- **`geo_header:`** accepts either the HTTP header name (`X-Client-Country`) or
-  the Rack CGI env key (`HTTP_X_CLIENT_COUNTRY`), in any case, and is
-  canonicalized to the env-key form. Pass `''` to clear.
-- **`geo_db_path:`** is loaded once at boot in `MODE_MEMORY`. An unreadable
-  path, a corrupt/non-MMDB file, or a missing `maxmind-db` gem raises
-  `ArgumentError` **at configuration time**, not per-request. Pass `''` to
-  unload.
-- **`geo_db_reader:`** injects any object responding to `#get(ip)` (a
-  preconfigured `MaxMind::DB` reader or a test double), keeping the reader and
-  data-source choice independent of Otto. It **overrides** `geo_db_path` when
-  both are given in the same call; supplying `geo_db_path` alone in a later call
-  clears a prior reader override.
+- `geo: false` disables all country resolution and releases the loaded reader.
+- `geo_header:` accepts an HTTP header name such as `X-Client-Country` or its
+  Rack key, `HTTP_X_CLIENT_COUNTRY`. A blank string clears the setting.
+- `geo_db_path:` opens the database in memory during configuration. A blank
+  string clears the path. An unreadable or invalid file raises `ArgumentError`;
+  a missing or incompatible `maxmind-db` gem raises
+  `Otto::OptionalDependencyError`.
+- `geo_db_reader:` accepts an object responding to `#get(ip)`. It wins over a
+  path supplied in the same call and lets applications use another MMDB reader
+  or a test double.
 
-Each keyword follows a `nil` = "leave unchanged" contract; pass `''` to a header
-or path to clear it. Any geo-affecting change triggers the boot-time database
-(re)load, so a bad `geo_db_path` fails at the `configure_ip_privacy` call.
+Omitting a keyword leaves its current value unchanged. Supplying a new path
+without a reader clears an earlier reader override.
 
-## The database: gem and datafile
+`Otto::Privacy::GeoResolver.custom_resolver` is different from the options
+above: it is shared by every Otto instance in the process. Set it once during
+single-threaded initialization. For per-application behavior, prefer
+`geo_db_reader:`.
 
-The reader and the data file are independent — the MMDB format is the interop
-point.
+## Install the MMDB reader
 
-### Reader gem (`maxmind-db`)
+The [`maxmind-db`](https://rubygems.org/gems/maxmind-db) gem is optional. Otto
+accepts versions 1.2 or newer within the 1.x series. Add it to the application:
 
-The [`maxmind-db`](https://rubygems.org/gems/maxmind-db) gem (official MaxMind
-reader, Apache-2.0, pure Ruby, zero runtime deps) is an **optional**
-dependency. Otto supports version 1.2.0 or newer in the 1.x series and only
-loads it when a database path is configured. A missing or incompatible gem
-raises `Otto::OptionalDependencyError` at configuration time. Add it to your
-app when you use the database fallback:
+```sh
+bundle add maxmind-db --version '~> 1.2'
+```
+
+Applications that manage `Gemfile` entries manually can instead add
+`gem 'maxmind-db', '~> 1.2'` and run `bundle install`.
+
+## Download a current country database
+
+Otto does not bundle country data. The current
+[`user-country`](https://github.com/sapics/ip-location-db/tree/main/user-country/)
+dataset from `sapics/ip-location-db` is an IPv4-and-IPv6 country MMDB updated
+daily. Upstream recommends it for general end-user country lookup and publishes
+it under PDDL 1.0. Review the upstream methodology and license for the version
+you deploy.
+
+The older `geo-whois-asn-country.mmdb` asset is no longer published. Use the
+current release asset and checksum URLs:
+
+```sh
+mkdir -p data
+curl -fL --retry 3 \
+  -o data/user-country.mmdb \
+  https://github.com/sapics/ip-location-db/releases/download/latest/user-country.mmdb
+curl -fL --retry 3 \
+  -o data/user-country.mmdb.sha256 \
+  https://github.com/sapics/ip-location-db/releases/download/checksum/user-country.mmdb.sha256
+```
+
+Verify the download from the directory containing both files:
+
+```sh
+(cd data && shasum -a 256 -c user-country.mmdb.sha256)      # macOS/BSD
+# or
+(cd data && sha256sum --check user-country.mmdb.sha256)     # GNU/Linux
+```
+
+Inspect a lookup before configuring Otto:
+
+```sh
+bundle exec ruby -rmaxmind/db -e \
+  "p MaxMind::DB.new('data/user-country.mmdb', mode: MaxMind::DB::MODE_MEMORY).get('8.8.8.8')"
+```
+
+The result should be a hash containing a two-letter `country_code`. Otto also
+accepts GeoLite2-style nested `country.iso_code` records and a bare string in
+the `country` field. Other MMDB datasets can therefore work, but their licenses,
+update requirements, schemas, and accuracy remain the operator's responsibility.
+
+Refresh the data on an operational schedule and verify the checksum before
+replacing the active file. Because Otto opens the file at boot, restart the
+application after replacement.
+
+## Understand masking and accuracy
+
+Database and custom-resolver lookups in the middleware receive a masked address.
+For IPv4, the default `octet_precision: 1` keeps a `/24`; `octet_precision: 2`
+keeps a `/16`. For IPv6, those settings keep `/48` and `/32`, respectively.
+Masking can therefore reduce lookup accuracy when a database has more-specific
+country ranges, especially for IPv6 and the coarser precision setting. Such a
+miss falls through to `**`.
+
+Header results do not depend on the masked address. Keep the default precision
+and test representative IPv4 and IPv6 ranges if the MMDB fallback is important
+to the application.
+
+## Trust geo headers
+
+Country headers are client-spoofable unless Otto can verify the connecting
+proxy. Configure the CDN or reverse proxy addresses as trusted CIDRs:
 
 ```ruby
-# Gemfile
-gem 'maxmind-db', '~> 1.2'
+otto = Otto.new(
+  'routes',
+  trusted_proxies: ['10.0.0.0/8', '192.0.2.0/24']
+)
 ```
 
-### Data file (`geo-whois-asn-country`)
+Otto ignores configured and built-in geo headers when:
 
-The recommended data file is
-[`geo-whois-asn-country`](https://github.com/sapics/ip-location-db) from
-sapics/ip-location-db: **PDDL v1.0 (public domain, no attribution required)**,
-rebuilt daily, shipped as MMDB. Otto vendors no database — country data goes
-stale, and a public-domain file you refresh on your own schedule keeps
-licensing and freshness in your control.
+- proxy trust is not configured;
+- `trusted_proxies: :none` is configured;
+- the connecting peer does not match a configured trusted proxy; or
+- count-based `trusted_proxy_depth` mode is used.
 
-Download it (IPv4+IPv6) into a path of your choosing:
+A configured `geo_header` and `trusted_proxy_depth` are rejected together at
+configuration time. In depth-mode deployments, use `geo_db_path` or
+`geo_db_reader` instead. For the broader forwarded-header boundary, see
+[Forwarded host authority](forwarded-authority.md).
 
-```bash
-mkdir -p data
-curl -fsSL -o data/geo-whois-asn-country.mmdb \
-  https://github.com/sapics/ip-location-db/releases/download/latest/geo-whois-asn-country.mmdb
-```
-
-Refresh it on your own schedule (e.g. a daily cron job running the same curl).
-Any MMDB country database works — GeoLite2-Country, DB-IP Country Lite,
-iplocate, etc. — since `GeoResolver` tolerates the record shapes country
-databases actually use: nested `country.iso_code` (GeoLite2-Country style), a
-flat `country_code` string, and a bare-string `country`.
-
-> **Note on GeoLite2:** its EULA requires a MaxMind account/license key and
-> obliges consumers to refresh within 30 days of each release. A PDDL dataset
-> avoids both obligations.
-
-## Header trust and spoofing
-
-Every geo header is trivially client-spoofable unless the request actually
-arrived through the CDN that sets it. Otto trusts geo headers — both the
-configured `geo_header` and the provider headers — **only** for a request that
-demonstrably arrived via a configured **CIDR trusted proxy**
-(`env['otto.via_trusted_proxy']` with `trusted_proxies` configured). A spoofed
-header on a direct connection is ignored, and resolution falls through to the
-custom resolver / database.
-
-Origins Otto cannot verify are **not** trusted:
-
-- **No trusted-proxy configuration.** A direct internet client could otherwise
-  pick its own country by sending `CF-IPCountry` / `X-Client-Country`, so with
-  no `trusted_proxies` configured, header steps are skipped and resolution falls
-  to the resolver / database (`'**'` if neither is set).
-- **Count-based `trusted_proxy_depth` mode.** The header-setting hop cannot be
-  verified as a geo-CDN, so depth mode does not enable header trust. This
-  conflict fails loud: configuring a `geo_header` together with a
-  `trusted_proxy_depth` raises `ArgumentError` at configuration time (in
-  either order) instead of silently ignoring the header per-request.
-  Database-backed geo remains fully supported under depth. The built-in
-  provider headers stay legal (there is nothing to configure, so nothing
-  can raise) but are equally inert — header trust requires CIDR-verified
-  proxies — so only an explicitly configured `geo_header` is rejected, and
-  depth deployments that want geo should set `geo_db_path`.
-
-**Migration:** to keep header-based geo, configure `trusted_proxies` (CIDR
-matchers) so Otto can verify the proxy origin. Depth-mode and header-only
-deployments should set `geo_db_path` for a local database instead; otherwise
-resolution returns `'**'`.
-
-## Acceptance behavior summary
+## Behavior summary
 
 | Scenario | Result |
 | --- | --- |
-| Configured `geo_header` present and trusted | wins over provider headers |
-| Request not via a verified CIDR trusted proxy | geo headers skipped |
-| No `trusted_proxies` configured | geo headers skipped (not trusted) |
-| Database lookup | uses the masked IP only |
-| `geo: false` | `nil`, no database in memory |
-| Bad `geo_db_path` | raises at boot, not per-request |
-| Nothing matches | `'**'` |
+| Trusted configured header contains a valid code | Wins over provider headers |
+| Geo headers are not trusted | Headers are skipped; resolver/database fallback continues |
+| Local database lookup | Receives only the masked IP |
+| `geo: false`, IP privacy disabled, or privacy-exempt request | `nil` |
+| Enabled, but nothing resolves | `**` |
+| Invalid path or database | Configuration fails at boot |

--- a/docs/guides/ip_privacy.md
+++ b/docs/guides/ip_privacy.md
@@ -1,248 +1,39 @@
-# IP Privacy Documentation
+# Configure IP privacy
 
-Otto automatically masks public IP addresses by default to enhance privacy and comply with data protection regulations (GDPR, CCPA, etc.). Private and localhost IPs are never masked for development convenience.
+This page is a short entry point for existing links and searches. The canonical
+[privacy guide](privacy.md) documents Otto's current profiles, request helpers,
+environment keys, proxy trust boundary, and middleware placement.
 
-## How It Works
+## Choose a profile
 
-1. **Privacy by Default**: `IPPrivacyMiddleware` is added FIRST in the middleware stack during initialization
-2. **Consistent Architecture**: Privacy middleware **replaces `env` values directly** for all sensitive data:
-   - `env['REMOTE_ADDR']` → masked IP (e.g., `'9.9.9.0'`)
-   - `env['HTTP_USER_AGENT']` → anonymized UA (versions stripped)
-   - `env['HTTP_REFERER']` → anonymized referer (query params stripped)
-3. **Smart Masking**:
-   - **Public IPs**: Automatically masked (192.0.2.100 → 192.0.2.0)
-   - **Private IPs**: Never masked (192.168.1.100, 10.0.0.5, 172.16.0.1)
-   - **Localhost**: Never masked (127.0.0.1, ::1)
-4. **No Original Values Storage**: When privacy is enabled, original public values are NEVER stored in `env`
-5. **Middleware Runs First**: Processes all values before authentication, rate limiting, logging, or any application code
-6. **Pit of Success**: Downstream code (logging, rate limiting, third-party gems) automatically gets anonymized values
-
-## Multi-Layer Middleware Architecture
-
-For complex applications with multiple middleware layers (common in monolith/multi-app architectures), IPPrivacyMiddleware should be added to your **common middleware stack** before logging/monitoring middleware:
+Configure privacy before the first request:
 
 ```ruby
-# ❌ WRONG: Adding privacy only to Otto's internal stack
-# Problem: CommonLogger runs before Otto, logging real IPs
-builder.use Rack::CommonLogger
-builder.use OtherMiddleware
-# ... later: Otto router with its internal privacy middleware
-# CommonLogger already logged real IP!
-
-# ✅ CORRECT: Add privacy to common stack FIRST
-builder.use Otto::Security::Middleware::IPPrivacyMiddleware  # <-- FIRST!
-builder.use Rack::CommonLogger  # Now logs masked IPs
-builder.use Rack::Parser
-builder.use YourSessionMiddleware
-builder.use Sentry::Rack::CaptureExceptions  # Captures masked IPs
-# ... later: Otto router (its internal privacy middleware is redundant but harmless)
+otto = Otto.new('routes')
+otto.configure_ip_privacy(profile: :masked)     # default: mask public IPs
+otto.configure_ip_privacy(profile: :anonymous)  # also mask private and loopback IPs
 ```
 
-**Why this matters:**
+Use `profile: :audit` only when the application must retain resolved client IPs
+and the deployment has its own access, logging, and retention controls. See
+[Profiles](privacy.md#profiles) for the exact behavior of each profile.
 
-Otto's internal middleware stack only runs when the request reaches the Otto router. If you have logging, error monitoring (Sentry), or other middleware that runs **before** the router, they will see and potentially log real IP addresses, defeating the purpose of IP privacy.
+These profiles are technical data-minimization controls. They do not determine
+whether an application complies with GDPR, CCPA, or another legal regime.
+Compliance also depends on the application's purposes, notices, retention,
+access controls, vendors, and jurisdiction.
 
-**Architecture layers:**
-1. **Common Middleware** (all apps): Rack::CommonLogger, Sentry, Session, etc.
-2. **App-Specific Middleware**: Request setup, error handling, etc.
-3. **Otto Internal Middleware**: Privacy (redundant but harmless), CSRF, rate limiting, etc.
+## Complete common tasks
 
-**Key insight:** IP privacy is a **Rack concern**, not a routing concern. It should run before any middleware that touches IPs (logging, monitoring, rate limiting).
+- Read the current request helpers and Rack environment keys in
+  [Privacy-safe request values](privacy.md#privacy-safe-request-values).
+- Put privacy ahead of logging and monitoring middleware outside Otto's own
+  stack by following [Middleware placement](privacy.md#middleware-placement).
+- Configure forwarded client-IP trust in
+  [Trusted proxy and matching boundaries](privacy.md#trusted-proxy-and-matching-boundaries).
+- Configure country lookup in [Geo-country resolution](geo-country.md).
+- Configure opt-in ASN or anonymizer lookup in
+  [ASN and anonymizer enrichment](enrichment.md).
 
-## What Gets Anonymized
-
-**IMPORTANT**: Privacy middleware **replaces env values directly**. Downstream code automatically gets anonymized values without special handling.
-
-```ruby
-# PUBLIC IPs (privacy enabled - default):
-env['REMOTE_ADDR']                  # => '9.9.9.0' (REPLACED with masked IP)
-env['HTTP_USER_AGENT']              # => 'Mozilla/*.* (Windows NT *.*; Win64; x64) AppleWebKit/*.*' (REPLACED, versions stripped)
-env['HTTP_REFERER']                 # => 'https://example.com/page' (REPLACED, query params stripped)
-env['otto.privacy.masked_ip']       # => '9.9.9.0' (same as REMOTE_ADDR)
-env['otto.privacy.hashed_ip']       # => 'a3f8b2...' (daily-rotating hash)
-env['otto.privacy.geo_country']     # => 'US' (country-level only)
-env['otto.privacy.fingerprint']     # => RedactedFingerprint object
-env['otto.original_ip']             # => nil (NOT available - prevents leakage)
-env['otto.original_user_agent']    # => nil (NOT available - prevents leakage)
-env['otto.original_referer']       # => nil (NOT available - prevents leakage)
-
-# PRIVATE/LOCALHOST IPs (never masked by default):
-env['REMOTE_ADDR']                  # => '127.0.0.1' (unchanged)
-env['HTTP_USER_AGENT']              # => '...' (unchanged, raw value)
-env['HTTP_REFERER']                 # => 'https://...' (unchanged, raw value)
-env['otto.original_ip']             # => '127.0.0.1' (available for debugging)
-env['otto.privacy.masked_ip']       # => nil
-env['otto.privacy.hashed_ip']       # => nil
-env['otto.privacy.fingerprint']     # => nil (not created)
-
-# PRIVACY DISABLED (otto.disable_ip_privacy!):
-env['REMOTE_ADDR']                  # => '9.9.9.9' (unchanged, real IP)
-env['HTTP_USER_AGENT']              # => 'Mozilla/5.0 Chrome/141.0.0.0' (unchanged, raw UA)
-env['HTTP_REFERER']                 # => 'https://example.com/page?token=secret' (unchanged, with query params)
-env['otto.original_ip']             # => '9.9.9.9' (available for explicit access)
-env['otto.original_user_agent']    # => 'Mozilla/5.0 Chrome/141.0.0.0' (available for explicit access)
-env['otto.original_referer']       # => 'https://example.com/page?token=secret' (available for explicit access)
-env['otto.privacy.fingerprint']     # => nil (not created when disabled)
-```
-
-## Configuration
-
-```ruby
-# Default: Privacy enabled, 1 octet masked (public IPs only)
-otto = Otto.new(routes_file)
-# Public IPs masked: 9.9.9.9 → 9.9.9.0
-# Private IPs unchanged: 127.0.0.1, 192.168.1.100, 10.0.0.5
-
-# Customize privacy settings (still enabled)
-otto.configure_ip_privacy(
-  octet_precision: 2,     # Mask 2 octets (9.9.0.0)
-  hash_rotation: 12.hours, # Rotate hashing key every 12 hours
-  geo: false              # Disable geo-location
-)
-
-# Multi-server environment with Redis (atomic key generation)
-redis = Redis.new(url: ENV['REDIS_URL'])
-otto.configure_ip_privacy(redis: redis)
-# All servers share same rotation key via Redis SET NX GET EX
-# Single source of truth for IP hashing across cluster
-
-# Explicitly disable privacy (NOT recommended)
-otto.disable_ip_privacy!
-# ALL IPs unmasked (including public IPs)
-# env['REMOTE_ADDR'] contains real IP
-# env['otto.original_ip'] also available
-```
-
-## Multi-Server Support with Redis
-
-For applications running across multiple servers, Otto supports Redis-based atomic key generation to ensure all servers use the same rotation key:
-
-```ruby
-# Single-server (default): In-memory Concurrent::Hash
-otto = Otto.new(routes_file)
-# Each server generates its own keys
-# Works fine for single-server deployments
-
-# Multi-server: Redis-based atomic key generation
-redis = Redis.new(url: ENV['REDIS_URL'])
-otto = Otto.new(routes_file)
-otto.configure_ip_privacy(redis: redis)
-# All servers share keys via Redis SET NX GET EX
-# Guaranteed consistency across entire cluster
-```
-
-**How Redis key generation works:**
-1. Uses `SET key value NX GET EX ttl` for atomic operations
-2. Returns existing key if present, otherwise sets and returns new key
-3. Keys auto-expire after 1.2× rotation period (20% buffer)
-4. No manual cleanup required
-5. Single source of truth across all application servers
-
-**Redis key format:**
-```
-rotation_key:{timestamp}  # e.g., rotation_key:1704067200
-```
-
-## Use Cases
-
-**Session Correlation Without Tracking:**
-```ruby
-# Use hashed IP for rate limiting/analytics without storing real IPs
-Rack::Attack.throttle('requests/ip', limit: 100, period: 60) do |req|
-  req.hashed_ip  # Daily-rotating hash allows session tracking
-end
-```
-
-**Geo-Analytics Without Privacy Invasion:**
-```ruby
-# Country-level analytics without precise location
-class Analytics
-  def track_request(req)
-    log({
-      country: req.geo_country,      # 'US' (country-level only)
-      masked_ip: req.masked_ip,      # '192.168.1.0'
-      path: req.path
-    })
-  end
-end
-```
-
-## Proxy Support
-
-Otto's IP privacy middleware fully supports proxy scenarios by resolving the actual client IP from X-Forwarded-For headers before applying privacy masking.
-
-### How Proxy Resolution Works
-
-1. **Trusted Proxy Configuration**: Configure proxies via `otto.add_trusted_proxy(ip_or_pattern)`
-2. **Client IP Resolution**: Middleware checks X-Forwarded-For headers from trusted proxies
-3. **Privacy Masking**: Resolved client IP is then masked (if public) or exempted (if private)
-4. **Header Replacement**: Both `REMOTE_ADDR` and forwarded headers are replaced with masked values
-
-### Configuration
-
-```ruby
-# Configure trusted proxies (load balancers, reverse proxies, CDNs)
-otto.add_trusted_proxy('10.0.0.1')                  # Exact IP
-otto.add_trusted_proxy('172.16.0.0/12')             # CIDR range (not yet implemented)
-otto.add_trusted_proxy(/^192\.168\./)               # Regex pattern
-```
-
-### Behavior Examples
-
-**Scenario 1: Direct Connection (No Proxy)**
-```ruby
-# Request from client 203.0.113.50
-env['REMOTE_ADDR'] = '203.0.113.50'
-
-# After IPPrivacyMiddleware:
-env['REMOTE_ADDR']          # => '203.0.113.0' (masked)
-env['otto.masked_ip']       # => '203.0.113.0'
-```
-
-**Scenario 2: Trusted Proxy with Public Client IP**
-```ruby
-# Request: Client 203.0.113.50 → Proxy 10.0.0.1 → Otto
-env['REMOTE_ADDR'] = '10.0.0.1'                # Trusted proxy
-env['HTTP_X_FORWARDED_FOR'] = '203.0.113.50'   # Real client IP
-
-# After IPPrivacyMiddleware:
-env['REMOTE_ADDR']          # => '203.0.113.0' (resolved & masked)
-env['HTTP_X_FORWARDED_FOR'] # => '203.0.113.0' (masked to prevent leaks)
-env['otto.masked_ip']       # => '203.0.113.0'
-```
-
-**Scenario 3: Untrusted Proxy (Security)**
-```ruby
-# Request: Malicious client trying to spoof X-Forwarded-For
-env['REMOTE_ADDR'] = '198.51.100.1'            # NOT in trusted proxies
-env['HTTP_X_FORWARDED_FOR'] = '203.0.113.50'  # Untrusted header (ignored)
-
-# After IPPrivacyMiddleware:
-env['REMOTE_ADDR']          # => '198.51.100.0' (proxy IP masked, header ignored)
-env['HTTP_X_FORWARDED_FOR'] # => '198.51.100.0' (masked to match REMOTE_ADDR)
-env['otto.masked_ip']       # => '198.51.100.0'
-```
-
-## Geo-Location Resolution
-
-Otto provides country-level geo-location without requiring external databases or API calls. It checks CDN/infrastructure provider headers with intelligent fallback to IP range detection.
-
-**Supported CDN/Infrastructure Headers** (checked in priority order):
-
-1. **Cloudflare**: `CF-IPCountry` (most widely deployed)
-2. **AWS CloudFront**: `CloudFront-Viewer-Country`
-3. **Fastly**: `Fastly-Client-IP-Country`
-4. **Akamai**: `X-Akamai-Edgescape` (extracts from `country_code=XX` format)
-5. **Azure Front Door**: `X-Azure-ClientIP-Country`
-6. **Semi-standard headers**: `X-Geo-Country`, `X-Country-Code`, `Country-Code` (least reliable)
-7. **IP Range Detection**: Basic detection for major providers (Google, AWS, etc.)
-8. **Unknown Fallback**: Returns '**' for unresolved IPs
-
-## Privacy Guarantees
-
-1. **No Accidental Leaks**: Original public IPs never stored (private/localhost IPs available)
-2. **GDPR Compliant**: Masked public IPs are not personally identifiable
-3. **Session Correlation**: Daily-rotating hashed IPs enable analytics without tracking
-4. **Geo-Analytics**: Country-level location data without privacy invasion
-5. **User Agent Privacy**: Version numbers stripped to reduce fingerprinting
-6. **Development Friendly**: Localhost and private IPs never masked for debugging
+Do not copy configuration or environment-key examples from older versions of
+this page; use the linked canonical sections instead.

--- a/docs/guides/ipaddr-encoding-quirk.md
+++ b/docs/guides/ipaddr-encoding-quirk.md
@@ -1,34 +1,56 @@
-# IPAddr#to_s Encoding Quirk in Ruby 3
+# Implementation note: `IPAddr#to_s` string encoding
 
-Ruby's `IPAddr#to_s` returns inconsistent encodings: IPv4 addresses use US-ASCII, IPv6 addresses use UTF-8.
+This note documents why Otto normalizes IP strings produced by its masking
+helpers. It is an implementation detail, not a claim about every Ruby 3 release
+or every version of the `ipaddr` default gem.
 
-## Behavior
+## Verified behavior
+
+Otto's blocking compatibility targets are Ruby 3.2, 3.3, and 3.4. The following
+behavior was reproduced locally with representative installed patch releases:
+
+| Ruby | `ipaddr` | IPv4 `IPAddr#to_s` | IPv6 `IPAddr#to_s` |
+| --- | --- | --- | --- |
+| 3.2.4 | 1.2.5 | `US-ASCII` | `UTF-8` |
+| 3.3.5 | 1.2.7 | `US-ASCII` | `UTF-8` |
+| 3.4.10 | 1.2.7 | `US-ASCII` | `UTF-8` |
+
+Ruby 4.0.6 with `ipaddr` 1.2.8 showed the same result, but Ruby 4.0 is a
+provisional, non-blocking Otto target. See the
+[runtime and dependency security policy](../reference/runtime-and-dependency-security.md)
+for the current support matrix.
+
+You can check the active runtime directly:
 
 ```ruby
-IPAddr.new('192.168.1.1').to_s.encoding  # => #<Encoding:US-ASCII>
-IPAddr.new('::1').to_s.encoding          # => #<Encoding:UTF-8>
+require 'ipaddr'
+
+puts RUBY_DESCRIPTION
+puts IPAddr::VERSION if defined?(IPAddr::VERSION)
+p IPAddr.new('192.168.1.1').to_s.encoding
+p IPAddr.new('::1').to_s.encoding
 ```
 
-## Cause
+The result comes from the `ipaddr` implementation's separate IPv4 and IPv6
+formatting paths. Treat it as version-specific behavior and rerun the check when
+changing Ruby or overriding the default `ipaddr` gem.
 
-Different string construction in IPAddr's `_to_string` method:
+## Otto's normalization
 
-- **IPv4**: `Array#join('.')` → US-ASCII optimization
-- **IPv6**: `String#%` → UTF-8 default
+An IP address string contains only ASCII bytes, so relabeling a generated
+`US-ASCII` address as `UTF-8` does not change its bytes. Otto uses this at the
+boundary where `IPPrivacy.mask_ip` creates IPv4 and IPv6 strings:
 
-## Impact
+```ruby
+IPAddr.new(masked_integer, address_family).to_s.force_encoding(Encoding::UTF_8)
+```
 
-- Rack expects UTF-8 strings
-- Mixed encodings cause `Encoding::CompatibilityError`
-- String operations fail on encoding mismatches
+This gives downstream Rack code one encoding for Otto-generated masked
+addresses. A `US-ASCII` string is normally compatible with UTF-8 text; the
+encoding difference alone does not imply an error. Normalization prevents code
+that requires an explicit UTF-8 label from receiving different labels for IPv4
+and IPv6.
 
-## Solution
-
-Use `force_encoding('UTF-8')` instead of `encode('UTF-8')`:
-
-- IP addresses contain only ASCII characters
-- ASCII bytes are identical in US-ASCII and UTF-8
-- `force_encoding` changes label only (O(1))
-- `encode` creates new string (O(n))
-
-This ensures consistent UTF-8 encoding across all IP strings.
+Use `force_encoding` here only because Otto constructed the value from an IP
+address and therefore knows every byte is ASCII. Do not apply the same operation
+to arbitrary external bytes without validating or transcoding them first.

--- a/docs/guides/privacy.md
+++ b/docs/guides/privacy.md
@@ -12,15 +12,21 @@ With the default `:masked` profile:
 
 - public IP addresses are masked by the configured octet precision (one octet
   by default: `203.0.113.9` becomes `203.0.113.0`);
-- private and localhost addresses remain unmasked for development by default;
-- public user agents have version details anonymized;
-- public referers have query parameters removed;
-- the original public values are not retained in the Rack environment;
-- country resolution is country-level only and returns an unknown sentinel when
-  no configured source answers.
+- requests from private and loopback addresses are exempt from the privacy
+  fingerprint by default, so their IP, user agent, and referer remain unchanged;
+- for requests that are masked, user-agent version details are anonymized and
+  referer query parameters are removed;
+- original public values are not retained in the Rack environment; and
+- country resolution is country-level only and returns `**` when enabled but no
+  configured source answers.
 
-Downstream code should read `req.ip`, `req.masked_ip`, and the privacy environment
-keys rather than recovering a raw address from forwarded headers.
+Downstream code should read `req.ip`, `req.masked_ip`, and the documented privacy
+environment keys rather than re-resolving an address from forwarded headers.
+
+These profiles are technical data-minimization controls, not a compliance
+certification. Whether a deployment meets GDPR, CCPA, or another legal regime
+also depends on its purposes, notices, retention, access controls, vendors, and
+jurisdiction.
 
 ## Profiles
 
@@ -75,13 +81,14 @@ Common values are also available in the Rack environment:
 
 | Value | Environment key | Contract |
 | --- | --- | --- |
-| Canonical client IP | `otto.client_ip` | Privacy-applied client IP used downstream. |
-| Masked IP | `otto.privacy.masked_ip` | Present for a public address when masking applies. |
-| Rotating IP hash | `otto.privacy.hashed_ip` | Privacy-safe correlation value using Otto's rotating key. |
-| Stable correlation hash | `otto.privacy.correlation_hash` | Present only when `correlation_secret:` is configured and the privacy pipeline produces it. |
-| Country | `otto.privacy.geo_country` | ISO 3166-1 alpha-2 code or `'**'`; `nil` when privacy is disabled. |
-| ASN | `otto.privacy.asn` | `nil` when off, `'**'` when enabled but unresolved, or a value such as `'AS15169'`. |
-| Anonymizer | `otto.privacy.anonymizer` | `nil` when off, `'**'` when no database answers, or a classification label. |
+| Canonical client IP | `otto.client_ip` | Masked IP when masking applies; resolved full IP under `:audit` or for an exempt private/loopback request. |
+| Precise CIDR verdict | `otto.ip_match` | Callable that checks the resolved full IP against CIDRs and returns only `true` or `false`. |
+| Masked IP | `otto.privacy.masked_ip` | Set when the request runs through the privacy fingerprint; absent for exempt or `:audit` requests. |
+| Rotating IP hash | `otto.privacy.hashed_ip` | Correlation value computed with Otto's rotating key; absent for exempt or `:audit` requests. |
+| Stable correlation hash | `otto.privacy.correlation_hash` | HMAC value when `correlation_secret:` is configured; otherwise `nil`. |
+| Country | `otto.privacy.geo_country` | ISO 3166-1 alpha-2 code, `**` when enabled but unresolved, or `nil` when geo/privacy is disabled. |
+| ASN | `otto.privacy.asn` | `nil` when off, `**` when enabled but unresolved, or a value such as `AS15169`. |
+| Anonymizer | `otto.privacy.anonymizer` | `nil` when off, `**` when no database answers, or a classification label. |
 
 `req.hashed_ip` is designed for short-lived correlation using a rotating key.
 For long-lived correlation, explicitly configure a stable secret and protect
@@ -92,12 +99,11 @@ correlation hash.
 
 These signals have different trust and precision models:
 
-- [Geo-country resolution](../geo-country.md) documents trusted provider
-  headers, CIDR trusted-proxy requirements, masked MMDB lookup, and the unknown
-  sentinel.
-- [ASN and anonymizer enrichment](../enrichment.md) documents the opt-in
-  database contracts. ASN uses a masked address; anonymizer classification
-  deliberately uses the unmasked address internally and emits only a label.
+- [Geo-country resolution](geo-country.md) documents trusted provider headers,
+  CIDR trusted-proxy requirements, masked MMDB lookup, and the unknown sentinel.
+- [ASN and anonymizer enrichment](enrichment.md) documents the opt-in database
+  contracts. ASN uses a masked address; anonymizer classification deliberately
+  uses the unmasked address internally and emits only a label.
 
 Enable optional signals explicitly:
 
@@ -139,10 +145,14 @@ that `Rack::Request#host` reads. See
 `trusted_proxies: :none` assertion for directly exposed applications.
 
 For precise access control without exposing the address to application code,
-configure or call the verdict-only `env['otto.ip_match']` capability. It matches
+call the automatically installed `env['otto.ip_match']` capability. It matches
 the resolved full client IP against application CIDRs and returns only
 `true`/`false`; it fails closed when no client IP resolves. Do not log or persist
-the closure's captured address.
+the closure.
+
+```ruby
+allowed = req.env.fetch('otto.ip_match').call(['192.0.2.0/24', '2001:db8::/32'])
+```
 
 ## Middleware placement
 

--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -6,20 +6,20 @@ response contract. The exact route grammar is in the [route syntax reference](..
 
 ## Choose a handler style
 
-| Use this when | Route target | Handler receives |
+| Use this when | Route target | Invocation |
 | --- | --- | --- |
-| You need direct Rack request/response access and a small controller-style method | `App#index` or `App#show` | `req`, `res` |
-| You want a constrained, testable application operation | `App::Operation` | authentication result, merged params, locale |
-| You need a small pre-registered endpoint function | `&name` | `req`, `res`, extra params |
+| You need a class method with direct Rack access | `App.index` | `App.index(req, res)` |
+| You need an object with direct Rack access | `App#show` | `App.new(req, res).show` |
+| You want a constrained, testable application operation | `App::Operation` | `App::Operation.new(strategy_result, params, locale)` |
+| You need a small pre-registered endpoint function | `&name` | `call(req, res, captured_path_params)` |
 
 ## Controller-style handlers
 
 Routes can call a class method or instantiate a class for an instance method:
 
 ```text
-GET /                         App#index
+GET /                         App.index
 GET /products/:id             App#show
-GET /robots.txt               App.robots
 ```
 
 ```ruby
@@ -101,7 +101,8 @@ GET /health &health_check
 ```
 
 The registry is normalized and frozen during configuration. A lambda must
-accept three positional arguments: request, response, and extra parameters.
+accept three positional arguments: request, response, and captured path
+parameters. Query and form parameters remain available through `req.params`.
 The route name is an exact registry key; it is not evaluated as Ruby code.
 
 ## Response selection
@@ -119,6 +120,18 @@ GET  /data          Data#show response=auto
 `response=default` is the default. Keep response selection in the route file
 so the HTTP contract is visible beside the endpoint.
 
+| Response type | Handler contract |
+| --- | --- |
+| `default` | Mutate `res` directly. The handler's return value is ignored. |
+| `json` | Return a Hash for direct JSON serialization. `nil` becomes `{ "success": true }`; another value is wrapped as `data`. A Logic class may instead provide `response_data`. |
+| `view` | Return a value rendered with `to_s`, or provide `view.render` on a Logic object. |
+| `redirect` | Return a path String, or provide `redirect_path` on a Logic object. The fallback path is `/`. |
+| `auto` | A Hash becomes JSON, a path-like String becomes a redirect, and a Logic object with `view` uses the view handler; other results use default behavior. |
+
+An unknown response name currently falls back to `default`. Treat response
+names as a fixed set; a typo otherwise changes the route to direct-response
+behavior.
+
 ## Route parameters
 
 Named path segments are available in request parameters:
@@ -130,7 +143,10 @@ GET /products/:id  Products::Show
 A handler can read `req.params[:id]` or a Logic class can read `params[:id]`.
 Request query and body parameters are merged according to the handler's request
 contract. JSON bodies are parsed for Logic-class parameters when the content
-type is JSON and the body is a JSON object.
+type is JSON and the body is a JSON object. A valid non-object JSON body is
+ignored. Malformed JSON is logged and the Logic class still runs with its other
+parameters; perform application validation when malformed JSON must return a
+client error.
 
 ## Security options in routes
 
@@ -153,7 +169,10 @@ Construct and configure the Otto instance before the first request:
 
 ```ruby
 otto = Otto.new('routes')
-otto.add_auth_strategy('session', SessionStrategy.new)
+otto.add_auth_strategy(
+  'session',
+  Otto::Security::Authentication::Strategies::SessionStrategy.new
+)
 otto.register_request_helpers(MyApp::RequestHelpers)
 # Add middleware and other boot-time options here.
 ```

--- a/docs/guides/structured_logging.md
+++ b/docs/guides/structured_logging.md
@@ -1,25 +1,30 @@
-# Structured Logging Documentation
+# Structured logging
 
-Otto uses simple, explicit structured logging with timing capabilities. Avoid creating abstraction layers or event classes.
+Otto provides explicit logging helpers for request context, microsecond timing,
+and backtrace path reduction. The helpers do not sanitize arbitrary metadata;
+callers remain responsible for excluding secrets and personal data.
 
-## LoggingHelpers Module
+## Logging helpers
 
 Otto provides several helper methods for consistent logging:
 
 ```ruby
 # Request context extraction
 Otto::LoggingHelpers.request_context(env)
-# Returns: { method:, path:, ip:, country:, user_agent: }
+# May include: { method:, path:, ip:, country:, user_agent: }
 
 # Timed operation logging
 Otto::LoggingHelpers.log_timed_operation(level, message, env, **metadata) { block }
 ```
 
-## Logging Patterns
+## Logging patterns
 
-Use `Otto.structured_log` with `LoggingHelpers.request_context(env).merge()` for all structured logging:
+For request-scoped structured logging, use `Otto.structured_log` with
+`LoggingHelpers.request_context(env).merge()`:
 
-**Thread Safety Note**: The base context pattern is thread-safe for concurrent requests. Each request has its own `env` hash, so `request_context(env)` creates isolated context hashes per request. The pattern extracts immutable values (strings, symbols) from `env`, and the `.merge()` creates a new hash rather than mutating shared state. This makes it safe for use in multi-threaded Rack servers (Puma, Falcon, etc.).
+`request_context(env)` creates a new context hash, and `.merge` creates another
+hash rather than mutating shared state. Treat the request `env` and values inside
+it as request-owned data; the helper does not deep-copy mutable strings.
 
 ```ruby
 # Route logging
@@ -62,7 +67,7 @@ Otto::LoggingHelpers.log_timed_operation(:debug, "User lookup", env,
 end
 ```
 
-## Timing Conventions
+## Timing conventions
 
 Otto uses **microseconds** for all timing measurements via `Otto::Utils.now_in_μs`:
 
@@ -88,26 +93,26 @@ Otto::LoggingHelpers.log_timed_operation(:info, "Database query", env,
 end
 ```
 
-## Required Fields
+## Request fields
 
-All structured logs should include:
-- **method** - HTTP method (GET, POST, etc.)
-- **path** - Request path
-- **ip** - Client IP (automatically masked by IPPrivacyMiddleware for public IPs)
-- **duration** - Operation timing in microseconds (for timed operations)
-- **Event-specific data** - Handler, type, error message, etc.
+Request-scoped events should normally merge `request_context(env)`, which adds
+available values for:
 
-## Optional Fields
+- **method** - HTTP method (`GET`, `POST`, etc.)
+- **path** - request path
+- **ip** - canonical client IP under the configured privacy profile
+- **country** - resolved country when available
+- **user_agent** - current request user agent, truncated to 100 characters
 
-Include when relevant:
-- **country** - Geo-location country code (from IPPrivacyMiddleware)
-- **user_agent** - Browser/client info (truncated to 100 chars)
-- **user_id** - Authenticated user ID
-- **referrer** - HTTP Referer header
-- **error** - Error message
-- **error_class** - Error class name (for exceptions)
+Unavailable values are omitted. Non-request events, such as configuration or
+startup logs, should include only relevant event-specific fields. Timed events
+also include **duration** in microseconds.
 
-## Error Handling in Timed Operations
+Additional fields such as `user_id`, `handler`, `error`, or `error_class` may be
+useful, but Otto does not redact them. Do not log credentials, session tokens,
+raw request parameters, or exception messages that may contain secrets.
+
+## Error handling in timed operations
 
 `log_timed_operation` automatically handles exceptions:
 
@@ -126,28 +131,44 @@ end
 # Then re-raises the original exception
 ```
 
-## Privacy Awareness
+## Privacy behavior
 
-- IP addresses in logs are **already masked** by `IPPrivacyMiddleware` (public IPs only)
-- Private IPs (127.0.0.1, 192.168.x.x, 10.x.x.x) are **never masked**
-- `env['REMOTE_ADDR']` contains masked IP for public addresses
-- User agents are automatically truncated to prevent log bloat
+`request_context` prefers `env['otto.client_ip']`, the canonical value produced
+by `IPPrivacyMiddleware`:
 
-## Backtrace Sanitization (Security by Default)
+- Under the normal privacy profiles, public addresses are masked.
+- Under the `:audit` profile or after `disable_ip_privacy!`, the canonical public
+  address is raw and `request_context` logs it unchanged.
+- Private and localhost addresses remain raw under the default `:masked` profile;
+  the `:anonymous` profile masks them too.
+- Outside Otto's middleware, when `otto.client_ip` is absent,
+  `privacy_safe_ip` masks a public `REMOTE_ADDR` using the default precision and
+  returns `[redacted]` for an unparseable address.
+- `request_context` truncates the current `HTTP_USER_AGENT` to 100 characters.
+  It is anonymized only if the privacy middleware has already anonymized it.
 
-Otto automatically sanitizes exception backtraces to prevent exposing sensitive system information in logs. This is critical for both security and compliance.
+The helper does not make arbitrary metadata privacy-safe. Review every field
+added by the caller.
 
-**Security Risks of Raw Backtraces:**
+## Backtrace path reduction
+
+Otto reduces filesystem details in recognized Ruby backtrace lines. This is
+defense in depth, not a confidentiality boundary: custom or unrecognized lines
+are returned unchanged.
+
+**Risks of raw backtraces:**
 - Expose absolute paths revealing usernames (`/Users/alice/`, `/home/admin/`)
 - Reveal project structure and internal organization
 - Show gem installation paths and Ruby versions
 - Leak system architecture details
 
-**Automatic Sanitization in Otto.structured_log:**
+**Automatic path reduction in `Otto.structured_log`:**
 
-Otto automatically sanitizes backtraces in `Otto.structured_log` when a `:backtrace` key contains an Array.
+`Otto.structured_log` applies the backtrace sanitizer only when the metadata is
+a hash whose exact `:backtrace` key contains an array. Other fields and arrays
+are passed unchanged.
 
-**Sanitization Rules:**
+**Path-reduction rules:**
 
 ```ruby
 # Project files → relative paths only
@@ -178,7 +199,8 @@ Otto automatically sanitizes backtraces in `Otto.structured_log` when a `:backtr
 
 **Usage:**
 
-Sanitization happens automatically when using `log_backtrace`:
+Path reduction happens automatically when using `log_backtrace`. This helper
+logs at `:error` and limits the backtrace to its first 20 lines:
 
 ```ruby
 # In error handlers (Otto does this automatically)
@@ -193,7 +215,7 @@ Otto::LoggingHelpers.log_backtrace(error,
 sanitized = Otto::LoggingHelpers.sanitize_backtrace(error.backtrace)
 ```
 
-## Anti-Patterns
+## Anti-patterns
 
 **❌ Don't create event classes:**
 ```ruby
@@ -234,19 +256,26 @@ Otto.structured_log(:info, "Operation completed",
 )
 ```
 
-## Output Examples
+## Output behavior
 
-**Example Output (with SemanticLogger or similar structured logger):**
+`Otto.logger` defaults to Ruby's `Logger`. With that logger, metadata is rendered
+inside a formatted string:
+
+```text
+I, [2025-01-21T14:39:39.462833 #82244] INFO -- : [Otto] Template compiled -- {method: "GET", path: "/users", ip: "192.0.2.0", template_type: "handlebars", cached: false, duration: 68}
 ```
-I, [2025-01-21T14:39:39.462833 #82244] INFO -- : Template compiled -- {method: "GET", path: "/users", ip: "192.0.2.0", template_type: "handlebars", cached: false, duration: 68}
-I, [2025-01-21T14:39:39.462926 #82244] INFO -- : View rendered -- {method: "GET", path: "/users", ip: "192.0.2.0", template: "user_profile", layout: "application", partials: ["header", "sidebar"], duration: 1118, response_size_bytes: 2048}
-```
+
+For a logger whose level method has a fixed arity greater than one, Otto calls
+that method as `logger.info(message, metadata)`. Other logger APIs use the
+formatted-string fallback. Verify the adapter for a third-party structured
+logger before relying on separately indexed fields; Otto does not ship or test
+a SemanticLogger adapter.
 
 ## Rationale
 
 - **Simplicity**: Direct logging calls are easier to understand than abstraction layers
 - **Explicitness**: You can see exactly what's being logged at the call site
 - **Flexibility**: Easy to add one-off fields without modifying event classes
-- **Performance**: No object allocation overhead for disabled debug logs
+- **Performance**: Disabled debug events are not sent to the logger; guard expensive metadata construction with `if Otto.debug` because method arguments are evaluated first
 - **Consistency**: All timing in microseconds, automatic error handling for timed operations
 - **Maintainability**: One helper file vs multiple event classes/helpers

--- a/docs/guides/testing-guide.md
+++ b/docs/guides/testing-guide.md
@@ -1,1934 +1,386 @@
-# Testing Guide for Otto 2 Applications
+# Testing Otto applications
 
-A guide to testing Otto 2 applications, covering Logic classes, authentication strategies, routes, authorization, and full-stack request specs.
+This guide covers the smallest useful testing workflow for an Otto application.
+It favors requests through a real `Otto` instance and links to Otto's maintained
+specs for implementation-level details.
 
-Updated: 2025-11-22
+## Prerequisites and commands
 
-## Table of Contents
+Otto supports Ruby `>= 3.2, < 4.1`. From an Otto source checkout, enable the
+optional development and test groups before installing dependencies:
 
-1. [Testing Principles](#testing-principles)
-2. [Test Environment Setup](#test-environment-setup)
-3. [Testing Logic Classes](#testing-logic-classes)
-4. [Testing Authentication Strategies](#testing-authentication-strategies)
-5. [Testing Route Definitions](#testing-route-definitions)
-6. [Testing Authorization](#testing-authorization)
-7. [Request Specs (Full-Stack)](#request-specs-full-stack)
-8. [Testing Error Handlers](#testing-error-handlers)
-9. [Testing Middleware](#testing-middleware)
-10. [Shared Examples](#shared-examples)
-11. [Best Practices](#best-practices)
+```sh
+bundle config set --local with 'development test'
+bundle install
+bundle exec rspec
+```
 
-## Testing Principles
+Run one file while developing:
 
-Otto 2 testing follows these core principles:
+```sh
+bundle exec rspec spec/otto/security/route_auth_wrapper_spec.rb
+```
 
-1. **Handler-Level Authentication**: Test authentication at the handler level (RouteAuthWrapper), not middleware
-2. **Two-Layer Authorization**: Test both route-level (auth=, role=) and resource-level (raise_concerns) authorization
-3. **Strategy Result Pattern**: Use `env['otto.strategy_result']` for authentication state
-4. **Direct Rack Testing**: Use Rack::Test for full-stack integration tests
-5. **Security by Default**: All tests should verify security headers and IP privacy
-6. **Configuration Freezing**: Test configuration freeze after first request
+The root `Rakefile` also makes `bundle exec rake` run the specs when RSpec is
+installed. Otto's CI runs `bundle exec rspec`; use that command when checking the
+same test entry point locally.
 
-## Test Environment Setup
+Applications consuming Otto need RSpec and `rack-test` in their own test bundle
+if they use the examples below.
 
-### spec_helper.rb
+## Minimal test setup
+
+Use Rack's environment builder rather than constructing partial Rack hashes by
+hand:
 
 ```ruby
 # spec/spec_helper.rb
 require 'bundler/setup'
-require 'rack'
-require 'rack/test'
 require 'json'
-require_relative '../lib/otto'
+require 'rack/mock'
+require 'rspec'
+require 'tempfile'
+require 'otto'
 
-# Configure Otto for testing
-Otto.debug = ENV['OTTO_DEBUG'] == 'true'
-Otto.logger.level = Logger::WARN unless Otto.debug
+module OttoAppSpecHelpers
+  def rack_env(path = '/', method: 'GET', headers: {}, params: {})
+    env = Rack::MockRequest.env_for(path, method: method, params: params)
+    headers.each do |name, value|
+      env["HTTP_#{name.upcase.tr('-', '_')}"] = value
+    end
+    env
+  end
+
+  def build_otto(route_lines, **options)
+    file = Tempfile.new(['routes', '.txt'])
+    file.write(route_lines.join("\n") + "\n")
+    file.close
+    (@route_files ||= []) << file
+
+    Otto.new(file.path, options)
+  end
+end
 
 RSpec.configure do |config|
-  config.mock_with :rspec do |mocks|
-    mocks.verify_partial_doubles = true
-  end
+  config.include OttoAppSpecHelpers
 
-  config.include Rack::Test::Methods
-  config.disable_monkey_patching!
-  config.expect_with :rspec do |c|
-    c.syntax = :expect
-  end
-
-  config.before(:each) do
-    ENV['RACK_ENV'] = 'test'
-  end
-end
-
-# Load support files
-Dir[File.join(__dir__, 'support', '**', '*.rb')].each { |f| require f }
-```
-
-### Test Helpers
-
-```ruby
-# spec/support/test_helpers.rb
-module OttoTestHelpers
-  # Create a mock Rack environment
-  def mock_rack_env(method: 'GET', path: '/', headers: {})
-    {
-      'REQUEST_METHOD' => method,
-      'PATH_INFO' => path,
-      'QUERY_STRING' => '',
-      'rack.input' => StringIO.new,
-      'rack.session' => {},
-      'REMOTE_ADDR' => '127.0.0.1',
-    }.tap do |env|
-      headers.each do |key, value|
-        env["HTTP_#{key.to_s.upcase.tr('-', '_')}"] = value
-      end
-    end
-  end
-
-  # Create minimal Otto instance for testing
-  def create_minimal_otto
-    Otto.new
-  end
-
-  # Create Otto instance with security enabled
-  def create_secure_otto
-    Otto.new.tap do |otto|
-      otto.security_config.enable_security_headers = true
-    end
-  end
-
-  # Extract security headers from response
-  def extract_security_headers(response)
-    headers = response[1]
-    headers.select { |k, _| k.start_with?('x-') || k == 'referrer-policy' }
+  config.after do
+    Array(@route_files).each(&:unlink)
   end
 end
 ```
 
-## Testing Logic Classes
+Within Otto itself, use the existing helpers in
+[`spec/support/test_helpers.rb`](../../spec/support/test_helpers.rb) instead of
+copying this application-level helper.
 
-Logic classes are Otto's equivalent to Rails controllers. They follow a specific lifecycle:
-1. Initialize with `context`, `params`, `locale`
-2. Execute `raise_concerns` (optional validation/authorization)
-3. Execute `process` (main business logic)
-4. Return `response_data` (for JSON responses)
+## Test Logic classes as plain Ruby objects
 
-### Basic Logic Class Test
+Logic classes receive an authentication result, merged parameters, and a locale.
+Test business rules without a Rack request when request parsing is not part of
+the behavior under test:
 
 ```ruby
-# spec/logic/dashboard_logic_spec.rb
-require 'spec_helper'
-
-RSpec.describe DashboardLogic do
-  let(:strategy_result) do
+RSpec.describe Products::Show do
+  let(:context) do
     Otto::Security::Authentication::StrategyResult.new(
-      user: { id: 123, name: 'Test User' },
-      session: { 'user_id' => 123 },
+      session: { 'user_id' => 7 },
+      user: { id: 7, roles: ['customer'] },
       auth_method: 'session',
       metadata: {},
       strategy_name: 'session'
     )
   end
 
-  let(:params) { { filter: 'recent' } }
-  let(:locale) { 'en' }
+  it 'rejects a product owned by another user' do
+    product = instance_double(Product, owner_id: 9)
+    allow(Product).to receive(:find).with('42').and_return(product)
 
-  describe '#initialize' do
-    it 'accepts context, params, and locale' do
-      logic = described_class.new(strategy_result, params, locale)
+    logic = described_class.new(context, { id: '42' }, 'en')
 
-      expect(logic.context).to eq(strategy_result)
-      expect(logic.params).to eq(params)
-      expect(logic.locale).to eq(locale)
-    end
-  end
-
-  describe '#raise_concerns' do
-    it 'raises error when user is not authenticated' do
-      anonymous = Otto::Security::Authentication::StrategyResult.anonymous
-      logic = described_class.new(anonymous, params, locale)
-
-      expect { logic.raise_concerns }.to raise_error(Otto::Security::AuthorizationError)
-    end
-
-    it 'passes when user is authenticated' do
-      logic = described_class.new(strategy_result, params, locale)
-
-      expect { logic.raise_concerns }.not_to raise_error
-    end
-  end
-
-  describe '#process' do
-    it 'returns dashboard data for authenticated user' do
-      logic = described_class.new(strategy_result, params, locale)
-
-      result = logic.process
-
-      expect(result).to be_a(Hash)
-      expect(result[:user_id]).to eq(123)
-      expect(result[:filter]).to eq('recent')
-    end
-
-    it 'applies filter from params' do
-      params[:filter] = 'all'
-      logic = described_class.new(strategy_result, params, locale)
-
-      result = logic.process
-
-      expect(result[:filter]).to eq('all')
-    end
-  end
-
-  describe '#response_data' do
-    it 'wraps process result in response structure' do
-      logic = described_class.new(strategy_result, params, locale)
-
-      result = logic.response_data
-
-      expect(result).to have_key(:dashboard)
-      expect(result[:dashboard][:user_id]).to eq(123)
-    end
+    expect { logic.raise_concerns }
+      .to raise_error(Otto::Security::AuthorizationError)
   end
 end
 ```
 
-### Testing Logic Class with Resource Authorization
+Constructing a `StrategyResult` directly is appropriate in an isolated unit
+test. Application request handling should use the result Otto places in
+`env['otto.strategy_result']`.
+
+Otto invokes `raise_concerns` before `process`. For `response=json`, the JSON
+handler may call an optional `response_data` formatting hook after `process`.
+Do not implement `response_data` by rerunning mutating business logic.
+
+See [`spec/otto/route_handlers_spec.rb`](../../spec/otto/route_handlers_spec.rb)
+for lifecycle, parameter, locale, and JSON-body coverage.
+
+## Test route definitions against the current contract
+
+`RouteDefinition` uses symbols for verbs and handler kinds. Multi-value accessors
+return arrays:
 
 ```ruby
-# spec/logic/post_edit_logic_spec.rb
-require 'spec_helper'
-
-RSpec.describe PostEditLogic do
-  let(:user_id) { 123 }
-  let(:strategy_result) do
-    Otto::Security::Authentication::StrategyResult.new(
-      user: { id: user_id },
-      session: { 'user_id' => user_id },
-      auth_method: 'session',
-      metadata: {},
-      strategy_name: 'session'
-    )
-  end
-
-  let(:post) { double('Post', id: 1, user_id: user_id, title: 'Test Post') }
-  let(:params) { { id: 1, title: 'Updated Title' } }
-
-  before do
-    allow(Post).to receive(:find).with(1).and_return(post)
-  end
-
-  describe '#raise_concerns' do
-    context 'when user owns the post' do
-      it 'allows access' do
-        logic = described_class.new(strategy_result, params, 'en')
-
-        expect { logic.raise_concerns }.not_to raise_error
-      end
-    end
-
-    context 'when user does not own the post' do
-      let(:other_user_post) { double('Post', id: 1, user_id: 456) }
-
-      before do
-        allow(Post).to receive(:find).with(1).and_return(other_user_post)
-      end
-
-      it 'raises AuthorizationError' do
-        logic = described_class.new(strategy_result, params, 'en')
-
-        expect { logic.raise_concerns }.to raise_error(
-          Otto::Security::AuthorizationError,
-          /Cannot edit another user's post/
-        )
-      end
-
-      it 'includes resource context in error' do
-        logic = described_class.new(strategy_result, params, 'en')
-
-        begin
-          logic.raise_concerns
-        rescue Otto::Security::AuthorizationError => e
-          expect(e.resource).to eq('Post')
-          expect(e.action).to eq('edit')
-          expect(e.user_id).to eq(123)
-        end
-      end
-    end
-
-    context 'when post does not exist' do
-      before do
-        allow(Post).to receive(:find).with(999).and_raise(ActiveRecord::RecordNotFound)
-      end
-
-      it 'raises RecordNotFound' do
-        params[:id] = 999
-        logic = described_class.new(strategy_result, params, 'en')
-
-        expect { logic.raise_concerns }.to raise_error(ActiveRecord::RecordNotFound)
-      end
-    end
-  end
-
-  describe '#process' do
-    it 'updates post with new title' do
-      logic = described_class.new(strategy_result, params, 'en')
-      logic.raise_concerns
-
-      expect(post).to receive(:update!).with(title: 'Updated Title')
-      logic.process
-    end
-
-    it 'returns updated post data' do
-      allow(post).to receive(:update!)
-      logic = described_class.new(strategy_result, params, 'en')
-      logic.raise_concerns
-
-      result = logic.process
-
-      expect(result[:post_id]).to eq(1)
-      expect(result[:title]).to eq('Updated Title')
-    end
-  end
-end
-```
-
-### Testing Logic Class with JSON Body Parsing
-
-```ruby
-# spec/logic/api_create_logic_spec.rb
-require 'spec_helper'
-
-RSpec.describe ApiCreateLogic do
-  let(:strategy_result) do
-    Otto::Security::Authentication::StrategyResult.new(
-      user: { id: 123, api_key: 'test_key' },
-      session: nil,
-      auth_method: 'api_key',
-      metadata: {},
-      strategy_name: 'apikey'
-    )
-  end
-
-  describe '#process with JSON params' do
-    it 'merges JSON body data with query params' do
-      json_params = { name: 'Widget', price: 99.99 }
-      query_params = { category: 'electronics' }
-      merged_params = query_params.merge(json_params)
-
-      logic = described_class.new(strategy_result, merged_params, 'en')
-      result = logic.process
-
-      expect(result[:name]).to eq('Widget')
-      expect(result[:price]).to eq(99.99)
-      expect(result[:category]).to eq('electronics')
-    end
-  end
-end
-```
-
-## Testing Authentication Strategies
-
-Authentication strategies are handler-level components that execute before route handlers.
-
-### Testing Built-in SessionStrategy
-
-```ruby
-# spec/strategies/session_strategy_spec.rb
-require 'spec_helper'
-
-RSpec.describe Otto::Security::Authentication::Strategies::SessionStrategy do
-  let(:strategy) { described_class.new(session_key: 'user_id') }
-
-  describe '#authenticate' do
-    context 'with valid session' do
-      it 'returns StrategyResult with user data' do
-        env = mock_rack_env
-        env['rack.session'] = { 'user_id' => 123 }
-
-        result = strategy.authenticate(env, 'session')
-
-        expect(result).to be_a(Otto::Security::Authentication::StrategyResult)
-        expect(result.authenticated?).to be true
-        expect(result.user[:id]).to eq(123)
-        expect(result.user_id).to eq(123)
-        expect(result.auth_method).to eq('session')
-      end
-
-      it 'preserves session object reference' do
-        env = mock_rack_env
-        session = { 'user_id' => 123 }
-        env['rack.session'] = session
-
-        result = strategy.authenticate(env, 'session')
-
-        expect(result.session.object_id).to eq(session.object_id)
-      end
-    end
-
-    context 'without valid session' do
-      it 'returns AuthFailure when session is missing' do
-        env = mock_rack_env
-        # No rack.session set
-
-        result = strategy.authenticate(env, 'session')
-
-        expect(result).to be_a(Otto::Security::Authentication::AuthFailure)
-        expect(result.failure_reason).to match(/No session/)
-      end
-
-      it 'returns AuthFailure when user_id is missing' do
-        env = mock_rack_env
-        env['rack.session'] = {}
-
-        result = strategy.authenticate(env, 'session')
-
-        expect(result).to be_a(Otto::Security::Authentication::AuthFailure)
-        expect(result.failure_reason).to match(/Not authenticated/)
-      end
-    end
-  end
-end
-```
-
-### Testing Custom Authentication Strategy
-
-```ruby
-# spec/strategies/custom_token_strategy_spec.rb
-require 'spec_helper'
-
-RSpec.describe CustomTokenStrategy do
-  let(:valid_token) { 'valid_token_12345' }
-  let(:strategy) { described_class.new(token_validator: double('Validator')) }
-
-  describe '#authenticate' do
-    context 'with valid Authorization header' do
-      it 'returns StrategyResult with user data' do
-        env = mock_rack_env(headers: { 'Authorization' => "Bearer #{valid_token}" })
-        allow(strategy.token_validator).to receive(:validate)
-          .with(valid_token)
-          .and_return({ id: 456, email: 'user@example.com' })
-
-        result = strategy.authenticate(env, 'token')
-
-        expect(result).to be_a(Otto::Security::Authentication::StrategyResult)
-        expect(result.authenticated?).to be true
-        expect(result.user[:id]).to eq(456)
-        expect(result.user[:email]).to eq('user@example.com')
-        expect(result.auth_method).to eq('token')
-      end
-    end
-
-    context 'with invalid token' do
-      it 'returns AuthFailure' do
-        env = mock_rack_env(headers: { 'Authorization' => 'Bearer invalid_token' })
-        allow(strategy.token_validator).to receive(:validate)
-          .with('invalid_token')
-          .and_return(nil)
-
-        result = strategy.authenticate(env, 'token')
-
-        expect(result).to be_a(Otto::Security::Authentication::AuthFailure)
-        expect(result.failure_reason).to match(/Invalid token/)
-      end
-    end
-
-    context 'without Authorization header' do
-      it 'returns AuthFailure' do
-        env = mock_rack_env
-
-        result = strategy.authenticate(env, 'token')
-
-        expect(result).to be_a(Otto::Security::Authentication::AuthFailure)
-        expect(result.failure_reason).to match(/No token provided/)
-      end
-    end
-  end
-
-  describe '#user_context' do
-    it 'returns additional user metadata' do
-      env = mock_rack_env(headers: { 'Authorization' => "Bearer #{valid_token}" })
-      allow(strategy.token_validator).to receive(:validate)
-        .and_return({ id: 456, roles: ['editor'] })
-
-      context = strategy.user_context(env)
-
-      expect(context[:roles]).to eq(['editor'])
-    end
-  end
-end
-```
-
-### Testing APIKeyStrategy
-
-```ruby
-# spec/strategies/api_key_strategy_spec.rb
-require 'spec_helper'
-
-RSpec.describe Otto::Security::Authentication::Strategies::APIKeyStrategy do
-  let(:valid_keys) { ['key_123', 'key_456'] }
-  # param_name: is opt-in; the default reads the X-API-Key header only.
-  let(:strategy) { described_class.new(api_keys: valid_keys, param_name: 'api_key') }
-
-  describe '#authenticate' do
-    context 'with valid API key in header' do
-      it 'returns StrategyResult' do
-        env = mock_rack_env(headers: { 'X-API-Key' => 'key_123' })
-
-        result = strategy.authenticate(env, 'apikey')
-
-        expect(result).to be_a(Otto::Security::Authentication::StrategyResult)
-        expect(result.authenticated?).to be true
-        expect(result.user[:api_key_fingerprint]).to eq(described_class.digest('key_123')[0, 12])
-      end
-    end
-
-    context 'with valid API key in query parameter' do
-      it 'returns StrategyResult' do
-        env = mock_rack_env(path: '/api/data?api_key=key_123')
-        env['QUERY_STRING'] = 'api_key=key_123'
-
-        result = strategy.authenticate(env, 'apikey')
-
-        expect(result).to be_a(Otto::Security::Authentication::StrategyResult)
-        expect(result.authenticated?).to be true
-      end
-    end
-
-    context 'with invalid API key' do
-      it 'returns AuthFailure' do
-        env = mock_rack_env(headers: { 'X-API-Key' => 'invalid_key' })
-
-        result = strategy.authenticate(env, 'apikey')
-
-        expect(result).to be_a(Otto::Security::Authentication::AuthFailure)
-        expect(result.failure_reason).to match(/Invalid API key/)
-      end
-    end
-
-    context 'without API key' do
-      it 'returns AuthFailure' do
-        env = mock_rack_env
-
-        result = strategy.authenticate(env, 'apikey')
-
-        expect(result).to be_a(Otto::Security::Authentication::AuthFailure)
-        expect(result.failure_reason).to match(/No API key provided/)
-      end
-    end
-  end
-end
-```
-
-## Testing Route Definitions
-
-Test route parsing and definition creation.
-
-### Testing Route Parsing
-
-```ruby
-# spec/routes/route_definition_spec.rb
-require 'spec_helper'
-
 RSpec.describe Otto::RouteDefinition do
-  describe 'parsing route with auth requirement' do
-    it 'extracts auth requirement from definition' do
-      definition = described_class.new('GET', '/protected', 'Logic auth=session')
-
-      expect(definition.verb).to eq('GET')
-      expect(definition.path).to eq('/protected')
-      expect(definition.auth_requirement).to eq('session')
-      expect(definition.kind).to eq(:logic_class)
-    end
-
-    it 'extracts multiple auth strategies' do
-      definition = described_class.new('GET', '/api', 'Logic auth=session,apikey')
-
-      expect(definition.auth_requirement).to eq('session,apikey')
-      expect(definition.auth_strategies).to eq(['session', 'apikey'])
-    end
-  end
-
-  describe 'parsing route with role requirement' do
-    it 'extracts role requirement' do
-      definition = described_class.new('GET', '/admin', 'Logic auth=session role=admin')
-
-      expect(definition.auth_requirement).to eq('session')
-      expect(definition.role_requirement).to eq('admin')
-    end
-
-    it 'extracts multiple roles' do
-      definition = described_class.new('GET', '/content', 'Logic auth=session role=admin,editor')
-
-      expect(definition.role_requirement).to eq('admin,editor')
-      expect(definition.roles).to eq(['admin', 'editor'])
-    end
-  end
-
-  describe 'parsing route with response type' do
-    it 'extracts response type' do
-      definition = described_class.new('GET', '/api/data', 'Logic auth=apikey response=json')
-
-      expect(definition.response_type).to eq('json')
-      expect(definition.auth_requirement).to eq('apikey')
-    end
-  end
-
-  describe 'parsing handler types' do
-    it 'identifies logic class handler' do
-      definition = described_class.new('GET', '/logic', 'DashboardLogic')
-
-      expect(definition.kind).to eq(:logic_class)
-      expect(definition.handler_class).to eq('DashboardLogic')
-    end
-
-    it 'identifies instance method handler' do
-      definition = described_class.new('GET', '/show', 'Controller#show')
-
-      expect(definition.kind).to eq(:instance_method)
-      expect(definition.handler_class).to eq('Controller')
-      expect(definition.handler_method).to eq('show')
-    end
-
-    it 'identifies class method handler' do
-      definition = described_class.new('GET', '/index', 'Controller.index')
-
-      expect(definition.kind).to eq(:class_method)
-      expect(definition.handler_class).to eq('Controller')
-      expect(definition.handler_method).to eq('index')
-    end
-  end
-end
-```
-
-## Testing Authorization
-
-Otto uses two-layer authorization: route-level (RouteAuthWrapper) and resource-level (raise_concerns in Logic classes).
-
-### Testing Route-Level Authorization (RouteAuthWrapper)
-
-```ruby
-# spec/security/route_auth_wrapper_spec.rb
-require 'spec_helper'
-
-RSpec.describe Otto::Security::Authentication::RouteAuthWrapper do
-  let(:mock_handler) do
-    lambda do |env, _extra_params|
-      [200, { 'Content-Type' => 'text/plain' }, ['handler called']]
-    end
-  end
-
-  let(:session_strategy) { Otto::Security::SessionStrategy.new }
-
-  let(:auth_config) do
-    {
-      auth_strategies: { 'session' => session_strategy },
-      login_path: '/signin',
-    }
-  end
-
-  describe 'authentication enforcement' do
-    let(:route_definition) do
-      Otto::RouteDefinition.new('GET', '/protected', 'Logic auth=session')
-    end
-
-    let(:wrapper) do
-      described_class.new(mock_handler, route_definition, auth_config)
-    end
-
-    context 'with authenticated user' do
-      it 'allows access and calls handler' do
-        env = mock_rack_env
-        env['rack.session'] = { 'user_id' => 123 }
-
-        status, _headers, body = wrapper.call(env)
-
-        expect(status).to eq(200)
-        expect(body).to eq(['handler called'])
-        expect(env['otto.strategy_result']).to be_authenticated
-      end
-
-      it 'sets strategy_result in env' do
-        env = mock_rack_env
-        env['rack.session'] = { 'user_id' => 123 }
-
-        wrapper.call(env)
-
-        result = env['otto.strategy_result']
-        expect(result).to be_a(Otto::Security::Authentication::StrategyResult)
-        expect(result.user_id).to eq(123)
-        expect(result.strategy_name).to eq('session')
-      end
-    end
-
-    context 'without authentication' do
-      it 'returns 401 for JSON requests' do
-        env = mock_rack_env(headers: { 'Accept' => 'application/json' })
-        env['rack.session'] = {}
-
-        status, headers, body = wrapper.call(env)
-
-        expect(status).to eq(401)
-        expect(headers['content-type']).to eq('application/json')
-        expect(JSON.parse(body.first)['error']).to eq('Authentication Required')
-      end
-
-      it 'redirects to login for HTML requests' do
-        env = mock_rack_env
-        env['rack.session'] = {}
-
-        status, headers, _body = wrapper.call(env)
-
-        expect(status).to eq(302)
-        expect(headers['location']).to eq('/signin')
-      end
-    end
-  end
-
-  describe 'multi-strategy authentication' do
-    let(:apikey_strategy) do
-      Otto::Security::Authentication::Strategies::APIKeyStrategy.new(
-        api_keys: ['valid_key']
-      )
-    end
-
-    let(:multi_auth_config) do
-      {
-        auth_strategies: {
-          'session' => session_strategy,
-          'apikey' => apikey_strategy,
-        },
-      }
-    end
-
-    let(:route_definition) do
-      Otto::RouteDefinition.new('GET', '/api', 'Logic auth=session,apikey')
-    end
-
-    let(:wrapper) do
-      described_class.new(mock_handler, route_definition, multi_auth_config)
-    end
-
-    it 'succeeds with first strategy (session)' do
-      env = mock_rack_env
-      env['rack.session'] = { 'user_id' => 123 }
-
-      status, _headers, _body = wrapper.call(env)
-
-      expect(status).to eq(200)
-      expect(env['otto.strategy_result'].strategy_name).to eq('session')
-    end
-
-    it 'succeeds with second strategy (apikey) when first fails' do
-      env = mock_rack_env(headers: { 'X-API-Key' => 'valid_key' })
-      env['rack.session'] = {}
-
-      status, _headers, _body = wrapper.call(env)
-
-      expect(status).to eq(200)
-      expect(env['otto.strategy_result'].strategy_name).to eq('apikey')
-    end
-
-    it 'fails when all strategies fail' do
-      env = mock_rack_env(headers: { 'Accept' => 'application/json' })
-      env['rack.session'] = {}
-
-      status, _headers, _body = wrapper.call(env)
-
-      expect(status).to eq(401)
-    end
-  end
-
-  describe 'role-based authorization' do
-    let(:role_strategy) do
-      Class.new do
-        def authenticate(env, _requirement)
-          session = env['rack.session']
-          user_roles = session['user_roles'] || []
-          Otto::Security::Authentication::StrategyResult.new(
-            user: { id: 123, roles: user_roles },
-            session: session,
-            auth_method: 'session',
-            metadata: {},
-            strategy_name: nil
-          )
-        end
-      end.new
-    end
-
-    let(:auth_config) do
-      {
-        auth_strategies: { 'session' => role_strategy },
-      }
-    end
-
-    let(:route_definition) do
-      Otto::RouteDefinition.new('GET', '/admin', 'Logic auth=session role=admin')
-    end
-
-    let(:wrapper) do
-      described_class.new(mock_handler, route_definition, auth_config)
-    end
-
-    context 'with required role' do
-      it 'allows access' do
-        env = mock_rack_env
-        env['rack.session'] = { 'user_id' => 123, 'user_roles' => ['admin'] }
-
-        status, _headers, _body = wrapper.call(env)
-
-        expect(status).to eq(200)
-      end
-    end
-
-    context 'without required role' do
-      it 'returns 403 for JSON requests' do
-        env = mock_rack_env(headers: { 'Accept' => 'application/json' })
-        env['rack.session'] = { 'user_id' => 123, 'user_roles' => ['user'] }
-
-        status, headers, body = wrapper.call(env)
-
-        expect(status).to eq(403)
-        expect(headers['content-type']).to eq('application/json')
-        expect(JSON.parse(body.first)['error']).to eq('Forbidden')
-      end
-
-      it 'returns 403 for HTML requests' do
-        env = mock_rack_env
-        env['rack.session'] = { 'user_id' => 123, 'user_roles' => ['user'] }
-
-        status, _headers, _body = wrapper.call(env)
-
-        expect(status).to eq(403)
-      end
-    end
-
-    context 'with OR logic for multiple roles' do
-      let(:route_definition) do
-        Otto::RouteDefinition.new('GET', '/content', 'Logic auth=session role=admin,editor')
-      end
-
-      it 'allows access with first role' do
-        env = mock_rack_env
-        env['rack.session'] = { 'user_id' => 123, 'user_roles' => ['admin'] }
-
-        status, _headers, _body = wrapper.call(env)
-
-        expect(status).to eq(200)
-      end
-
-      it 'allows access with second role' do
-        env = mock_rack_env
-        env['rack.session'] = { 'user_id' => 123, 'user_roles' => ['editor'] }
-
-        status, _headers, _body = wrapper.call(env)
-
-        expect(status).to eq(200)
-      end
-
-      it 'denies access without any required role' do
-        env = mock_rack_env
-        env['rack.session'] = { 'user_id' => 123, 'user_roles' => ['viewer'] }
-
-        status, _headers, _body = wrapper.call(env)
-
-        expect(status).to eq(403)
-      end
-    end
-  end
-end
-```
-
-### Testing Resource-Level Authorization (raise_concerns)
-
-```ruby
-# spec/logic/authorization_spec.rb
-require 'spec_helper'
-
-RSpec.describe 'Resource-Level Authorization' do
-  let(:user_id) { 123 }
-  let(:strategy_result) do
-    Otto::Security::Authentication::StrategyResult.new(
-      user: { id: user_id, roles: [] },
-      session: { 'user_id' => user_id },
-      auth_method: 'session',
-      metadata: {},
-      strategy_name: 'session'
+  it 'parses authentication, roles, and a Logic target' do
+    route = described_class.new(
+      'GET',
+      '/admin',
+      'Admin::Dashboard auth=session,api_key role=admin,editor response=json'
     )
-  end
 
-  describe 'ownership-based authorization' do
-    let(:post) { double('Post', id: 1, user_id: user_id) }
-
-    context 'when user owns resource' do
-      it 'allows access' do
-        allow(Post).to receive(:find).and_return(post)
-        logic = PostEditLogic.new(strategy_result, { id: 1 }, 'en')
-
-        expect { logic.raise_concerns }.not_to raise_error
-      end
-    end
-
-    context 'when user does not own resource' do
-      let(:other_post) { double('Post', id: 2, user_id: 456) }
-
-      it 'raises AuthorizationError' do
-        allow(Post).to receive(:find).and_return(other_post)
-        logic = PostEditLogic.new(strategy_result, { id: 2 }, 'en')
-
-        expect { logic.raise_concerns }.to raise_error(
-          Otto::Security::AuthorizationError,
-          /Cannot edit another user's post/
-        )
-      end
-    end
-  end
-
-  describe 'multi-condition authorization' do
-    let(:organization) { double('Organization', id: 1, owner_id: 999) }
-    let(:admin_strategy_result) do
-      Otto::Security::Authentication::StrategyResult.new(
-        user: { id: user_id, roles: ['admin'] },
-        session: { 'user_id' => user_id, 'user_roles' => ['admin'] },
-        auth_method: 'session',
-        metadata: {},
-        strategy_name: 'session'
-      )
-    end
-
-    before do
-      allow(Organization).to receive(:find).and_return(organization)
-    end
-
-    it 'allows admin access' do
-      logic = OrganizationDeleteLogic.new(admin_strategy_result, { id: 1 }, 'en')
-
-      expect { logic.raise_concerns }.not_to raise_error
-    end
-
-    it 'allows owner access' do
-      owner_result = Otto::Security::Authentication::StrategyResult.new(
-        user: { id: 999, roles: [] },
-        session: { 'user_id' => 999 },
-        auth_method: 'session',
-        metadata: {},
-        strategy_name: 'session'
-      )
-      logic = OrganizationDeleteLogic.new(owner_result, { id: 1 }, 'en')
-
-      expect { logic.raise_concerns }.not_to raise_error
-    end
-
-    it 'denies access for non-admin, non-owner' do
-      logic = OrganizationDeleteLogic.new(strategy_result, { id: 1 }, 'en')
-
-      expect { logic.raise_concerns }.to raise_error(
-        Otto::Security::AuthorizationError,
-        /Requires admin role or organization ownership/
-      )
-    end
+    expect(route.verb).to eq(:GET)
+    expect(route.kind).to eq(:logic)
+    expect(route.klass_name).to eq('Admin::Dashboard')
+    expect(route.method_name).to eq('Dashboard')
+    expect(route.auth_requirement).to eq('session')
+    expect(route.auth_requirements).to eq(%w[session api_key])
+    expect(route.role_requirement).to eq('admin,editor')
+    expect(route.role_requirements).to eq(%w[admin editor])
+    expect(route.response_type).to eq('json')
   end
 end
 ```
 
-## Request Specs (Full-Stack)
+Handler kinds are `:class`, `:instance`, `:logic`, and `:lambda`. The complete
+parser contract is covered by
+[`spec/otto/route_definition_spec.rb`](../../spec/otto/route_definition_spec.rb).
 
-Full-stack tests through Rack for end-to-end validation.
+## Test a strategy directly
 
-### Basic Request Spec
-
-```ruby
-# spec/requests/dashboard_spec.rb
-require 'spec_helper'
-
-RSpec.describe 'Dashboard Requests', type: :request do
-  let(:app) { MyOttoApp.new }
-
-  describe 'GET /dashboard' do
-    context 'when authenticated' do
-      before do
-        # Set up session
-        env 'rack.session', { 'user_id' => 123 }
-      end
-
-      it 'returns 200 with dashboard data' do
-        get '/dashboard'
-
-        expect(last_response.status).to eq(200)
-        expect(last_response.content_type).to include('application/json')
-
-        data = JSON.parse(last_response.body)
-        expect(data['user_id']).to eq(123)
-      end
-
-      it 'includes security headers' do
-        get '/dashboard'
-
-        expect(last_response.headers['x-content-type-options']).to eq('nosniff')
-        expect(last_response.headers['x-xss-protection']).to eq('1; mode=block')
-      end
-    end
-
-    context 'when not authenticated' do
-      it 'redirects to login for HTML requests' do
-        header 'Accept', 'text/html'
-        get '/dashboard'
-
-        expect(last_response.status).to eq(302)
-        expect(last_response.headers['location']).to eq('/signin')
-      end
-
-      it 'returns 401 for JSON requests' do
-        header 'Accept', 'application/json'
-        get '/dashboard'
-
-        expect(last_response.status).to eq(401)
-        data = JSON.parse(last_response.body)
-        expect(data['error']).to eq('Authentication Required')
-      end
-    end
-  end
-end
-```
-
-### Request Spec with API Key Authentication
+A strategy unit test should cover successful credentials, missing credentials,
+and rejected credentials. Explicit credentials that were examined and rejected
+should normally produce a terminal failure so a later anonymous strategy cannot
+accept the request.
 
 ```ruby
-# spec/requests/api_spec.rb
-require 'spec_helper'
-
-RSpec.describe 'API Requests', type: :request do
-  let(:app) { MyOttoApp.new }
-  let(:valid_api_key) { 'test_api_key_123' }
-
-  describe 'GET /api/data' do
-    context 'with valid API key in header' do
-      it 'returns 200 with data' do
-        header 'X-API-Key', valid_api_key
-        get '/api/data'
-
-        expect(last_response.status).to eq(200)
-        data = JSON.parse(last_response.body)
-        expect(data).to have_key('results')
-      end
-    end
-
-    context 'with valid API key in query parameter' do
-      it 'returns 200 with data' do
-        get "/api/data?api_key=#{valid_api_key}"
-
-        expect(last_response.status).to eq(200)
-      end
-    end
-
-    context 'with invalid API key' do
-      it 'returns 401' do
-        header 'X-API-Key', 'invalid_key'
-        get '/api/data'
-
-        expect(last_response.status).to eq(401)
-        data = JSON.parse(last_response.body)
-        expect(data['error']).to match(/Invalid API key/)
-      end
-    end
-
-    context 'without API key' do
-      it 'returns 401' do
-        get '/api/data'
-
-        expect(last_response.status).to eq(401)
-      end
-    end
-  end
-end
-```
-
-### Request Spec with Role-Based Access
-
-```ruby
-# spec/requests/admin_spec.rb
-require 'spec_helper'
-
-RSpec.describe 'Admin Requests', type: :request do
-  let(:app) { MyOttoApp.new }
-
-  describe 'GET /admin/users' do
-    context 'with admin role' do
-      before do
-        env 'rack.session', {
-          'user_id' => 123,
-          'user_roles' => ['admin'],
-        }
-      end
-
-      it 'returns 200 with user list' do
-        get '/admin/users'
-
-        expect(last_response.status).to eq(200)
-        data = JSON.parse(last_response.body)
-        expect(data['users']).to be_an(Array)
-      end
-    end
-
-    context 'with non-admin role' do
-      before do
-        env 'rack.session', {
-          'user_id' => 123,
-          'user_roles' => ['user'],
-        }
-      end
-
-      it 'returns 403' do
-        header 'Accept', 'application/json'
-        get '/admin/users'
-
-        expect(last_response.status).to eq(403)
-        data = JSON.parse(last_response.body)
-        expect(data['error']).to eq('Forbidden')
-      end
-    end
-
-    context 'without authentication' do
-      it 'returns 401' do
-        header 'Accept', 'application/json'
-        get '/admin/users'
-
-        expect(last_response.status).to eq(401)
-      end
-    end
-  end
-end
-```
-
-### Request Spec with Multi-Strategy Auth
-
-```ruby
-# spec/requests/multi_auth_spec.rb
-require 'spec_helper'
-
-RSpec.describe 'Multi-Strategy Auth Requests', type: :request do
-  let(:app) { MyOttoApp.new }
-
-  describe 'GET /protected' do
-    context 'authenticates with session' do
-      before do
-        env 'rack.session', { 'user_id' => 123 }
-      end
-
-      it 'returns 200 and uses session strategy' do
-        get '/protected'
-
-        expect(last_response.status).to eq(200)
-        # Strategy name is available in response if exposed
-      end
-    end
-
-    context 'authenticates with API key when session absent' do
-      it 'returns 200 and uses apikey strategy' do
-        header 'X-API-Key', 'valid_key'
-        get '/protected'
-
-        expect(last_response.status).to eq(200)
-      end
-    end
-
-    context 'both strategies fail' do
-      it 'returns 401' do
-        header 'Accept', 'application/json'
-        get '/protected'
-
-        expect(last_response.status).to eq(401)
-      end
-    end
-  end
-end
-```
-
-## Testing Error Handlers
-
-Otto allows registering custom error handlers for expected business logic errors.
-
-### Testing Error Handler Registration
-
-```ruby
-# spec/error_handling/registration_spec.rb
-require 'spec_helper'
-
-RSpec.describe 'Error Handler Registration' do
-  class NotFoundError < StandardError; end
-  class RateLimitError < StandardError
-    attr_reader :retry_after
-
-    def initialize(message, retry_after: 60)
-      super(message)
-      @retry_after = retry_after
-    end
-  end
-
-  let(:otto) { create_minimal_otto }
-
-  describe '#register_error_handler' do
-    it 'registers handler with status code' do
-      otto.register_error_handler(NotFoundError, status: 404, log_level: :info)
-
-      expect(otto.error_handlers['NotFoundError']).to include(
-        status: 404,
-        log_level: :info
-      )
-    end
-
-    it 'registers handler with custom block' do
-      custom_handler = lambda { |error, _req|
-        { error: 'Custom', message: error.message }
-      }
-
-      otto.register_error_handler(NotFoundError, status: 404, &custom_handler)
-
-      config = otto.error_handlers['NotFoundError']
-      expect(config[:handler]).to eq(custom_handler)
-    end
-
-    it 'raises error when called after configuration freeze' do
-      Otto.unfreeze_for_testing(otto)
-      otto.send(:freeze_configuration!)
-
-      expect {
-        otto.register_error_handler(NotFoundError, status: 404)
-      }.to raise_error(FrozenError, /Cannot modify frozen configuration/)
-    end
-  end
-
-  describe 'error handler execution' do
-    let(:env) { mock_rack_env(headers: { 'Accept' => 'application/json' }) }
-
-    before do
-      otto.register_error_handler(NotFoundError, status: 404, log_level: :info)
-    end
-
-    it 'returns configured status code' do
-      error = NotFoundError.new('Resource not found')
-      allow(Otto.logger).to receive(:info)
-
-      response = otto.send(:handle_error, error, env)
-
-      expect(response[0]).to eq(404)
-    end
-
-    it 'logs at configured level' do
-      error = NotFoundError.new('Resource not found')
-
-      expect(Otto).to receive(:structured_log).with(:info, 'Expected error in request', hash_including(
-        error: 'Resource not found',
-        error_class: 'NotFoundError',
-        expected: true
-      ))
-
-      otto.send(:handle_error, error, env)
-    end
-
-    it 'returns JSON response for JSON requests' do
-      error = NotFoundError.new('Resource not found')
-      allow(Otto.logger).to receive(:info)
-
-      response = otto.send(:handle_error, error, env)
-
-      expect(response[1]['content-type']).to eq('application/json')
-      body = JSON.parse(response[2].first)
-      expect(body['error']).to eq('NotFoundError')
-      expect(body['message']).to eq('Resource not found')
-    end
-
-    it 'uses custom handler block' do
-      otto.register_error_handler(RateLimitError, status: 429) do |error, _req|
-        {
-          error: 'RateLimited',
-          message: error.message,
-          retry_after: error.retry_after,
-        }
-      end
-
-      error = RateLimitError.new('Too many requests', retry_after: 120)
-      allow(Otto.logger).to receive(:warn)
-
-      response = otto.send(:handle_error, error, env)
-      body = JSON.parse(response[2].first)
-
-      expect(response[0]).to eq(429)
-      expect(body['error']).to eq('RateLimited')
-      expect(body['retry_after']).to eq(120)
-    end
-
-    it 'falls back to default response if custom handler fails' do
-      otto.register_error_handler(NotFoundError, status: 404) do |_error, _req|
-        raise StandardError, 'Handler failed'
-      end
-
-      error = NotFoundError.new('Resource not found')
-      allow(Otto).to receive(:structured_log).with(:info, anything, anything)
-
-      expect(Otto).to receive(:structured_log).with(:warn, 'Error in custom error handler', anything)
-
-      response = otto.send(:handle_error, error, env)
-
-      expect(response[0]).to eq(404)
-    end
-
-    it 'does not log backtrace for expected errors' do
-      error = NotFoundError.new('Resource not found')
-      allow(Otto).to receive(:structured_log)
-
-      expect(Otto::LoggingHelpers).not_to receive(:log_backtrace)
-
-      otto.send(:handle_error, error, env)
-    end
-  end
-
-  describe 'unregistered errors' do
-    class UnexpectedError < StandardError; end
-
-    let(:env) { mock_rack_env(headers: { 'Accept' => 'application/json' }) }
-
-    it 'handles as 500' do
-      error = UnexpectedError.new('Something went wrong')
-      allow(Otto.logger).to receive(:error)
-
-      response = otto.send(:handle_error, error, env)
-
-      expect(response[0]).to eq(500)
-    end
-
-    it 'logs at error level with backtrace' do
-      error = UnexpectedError.new('Something went wrong')
-
-      expect(Otto).to receive(:structured_log).with(:error, 'Unhandled error in request', anything)
-      expect(Otto::LoggingHelpers).to receive(:log_backtrace)
-
-      otto.send(:handle_error, error, env)
-    end
-  end
-end
-```
-
-## Testing Middleware
-
-### Testing IP Privacy Middleware
-
-```ruby
-# spec/middleware/ip_privacy_spec.rb
-require 'spec_helper'
-
-RSpec.describe Otto::Privacy::IPPrivacyMiddleware do
-  let(:app) { ->(env) { [200, {}, ["Hello #{env['REMOTE_ADDR']}"]] } }
-  let(:middleware) { described_class.new(app) }
-
-  describe 'IP masking' do
-    context 'with public IPv4' do
-      it 'masks last octet' do
-        env = mock_rack_env
-        env['REMOTE_ADDR'] = '203.0.113.45'
-
-        status, _headers, body = middleware.call(env)
-
-        expect(status).to eq(200)
-        expect(env['REMOTE_ADDR']).to eq('203.0.113.0')
-        expect(body.first).to eq('Hello 203.0.113.0')
-      end
-    end
-
-    context 'with private IPv4' do
-      it 'does not mask' do
-        env = mock_rack_env
-        env['REMOTE_ADDR'] = '192.168.1.100'
-
-        middleware.call(env)
-
-        expect(env['REMOTE_ADDR']).to eq('192.168.1.100')
-      end
-
-      it 'does not mask localhost' do
-        env = mock_rack_env
-        env['REMOTE_ADDR'] = '127.0.0.1'
-
-        middleware.call(env)
-
-        expect(env['REMOTE_ADDR']).to eq('127.0.0.1')
-      end
-    end
-
-    context 'with IPv6' do
-      it 'masks public IPv6' do
-        env = mock_rack_env
-        env['REMOTE_ADDR'] = '2001:0db8:85a3::8a2e:0370:7334'
-
-        middleware.call(env)
-
-        expect(env['REMOTE_ADDR']).to match(/^2001:db8:85a3::/)
-      end
-    end
-  end
-
-  describe 'user agent anonymization' do
-    it 'masks user agent string' do
-      env = mock_rack_env(headers: {
-        'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/91.0',
-      })
-
-      middleware.call(env)
-
-      expect(env['HTTP_USER_AGENT']).not_to include('Windows NT 10.0')
-      expect(env['HTTP_USER_AGENT']).to include('Chrome')
-    end
-  end
-
-  describe 'referer sanitization' do
-    it 'removes query parameters from referer' do
-      env = mock_rack_env(headers: {
-        'Referer' => 'https://example.com/page?session_id=abc123&user=john',
-      })
-
-      middleware.call(env)
-
-      expect(env['HTTP_REFERER']).to eq('https://example.com/page')
-    end
-  end
-
-  describe 'configuration options' do
-    it 'respects masking level configuration' do
-      middleware_level2 = described_class.new(app, masking_level: 2)
-      env = mock_rack_env
-      env['REMOTE_ADDR'] = '203.0.113.45'
-
-      middleware_level2.call(env)
-
-      expect(env['REMOTE_ADDR']).to eq('203.0.0.0')
-    end
-
-    it 'respects skip_private_ips configuration' do
-      middleware_mask_all = described_class.new(app, skip_private_ips: false)
-      env = mock_rack_env
-      env['REMOTE_ADDR'] = '192.168.1.100'
-
-      middleware_mask_all.call(env)
-
-      expect(env['REMOTE_ADDR']).to eq('192.168.1.0')
-    end
-  end
-end
-```
-
-### Testing CSRF Middleware
-
-```ruby
-# spec/middleware/csrf_spec.rb
-require 'spec_helper'
-
-RSpec.describe Otto::Security::CSRFMiddleware do
-  let(:app) { ->(env) { [200, { 'Content-Type' => 'text/html' }, ['<html></html>']] } }
-  let(:middleware) { described_class.new(app) }
-
-  describe 'CSRF token validation' do
-    context 'for safe methods (GET, HEAD, OPTIONS)' do
-      it 'allows request without token' do
-        env = mock_rack_env(method: 'GET')
-
-        status, _headers, _body = middleware.call(env)
-
-        expect(status).to eq(200)
-      end
-    end
-
-    context 'for unsafe methods (POST, PUT, DELETE)' do
-      it 'rejects request without token' do
-        env = mock_rack_env(method: 'POST')
-        env['rack.session'] = {}
-
-        status, _headers, _body = middleware.call(env)
-
-        expect(status).to eq(403)
-      end
-
-      it 'allows request with valid token' do
-        env = mock_rack_env(method: 'POST')
-        env['rack.session'] = { 'csrf_token' => 'valid_token' }
-        env['HTTP_X_CSRF_TOKEN'] = 'valid_token'
-
-        status, _headers, _body = middleware.call(env)
-
-        expect(status).to eq(200)
-      end
-
-      it 'rejects request with invalid token' do
-        env = mock_rack_env(method: 'POST')
-        env['rack.session'] = { 'csrf_token' => 'valid_token' }
-        env['HTTP_X_CSRF_TOKEN'] = 'invalid_token'
-
-        status, _headers, _body = middleware.call(env)
-
-        expect(status).to eq(403)
-      end
-    end
-  end
-
-  describe 'token injection' do
-    it 'injects meta tag into HTML head' do
-      env = mock_rack_env(method: 'GET')
-      env['rack.session'] = { 'csrf_token' => 'test_token_123' }
-
-      _status, _headers, body = middleware.call(env)
-
-      html = body.first
-      expect(html).to include('<meta name="csrf-token" content="test_token_123"')
-    end
-
-    it 'does not inject into non-HTML responses' do
-      json_app = ->(env) { [200, { 'Content-Type' => 'application/json' }, ['{"data": "value"}']] }
-      middleware = described_class.new(json_app)
-      env = mock_rack_env(method: 'GET')
-      env['rack.session'] = { 'csrf_token' => 'test_token' }
-
-      _status, _headers, body = middleware.call(env)
-
-      expect(body.first).not_to include('csrf-token')
-    end
-  end
-end
-```
-
-## Shared Examples
-
-Create reusable test patterns for common scenarios.
-
-### Shared Examples for Authenticated Endpoints
-
-```ruby
-# spec/support/shared_examples/authenticated_endpoint.rb
-RSpec.shared_examples 'an authenticated endpoint' do |method, path|
-  context 'when not authenticated' do
-    it 'returns 401 for JSON requests' do
-      header 'Accept', 'application/json'
-      send(method, path)
-
-      expect(last_response.status).to eq(401)
-      data = JSON.parse(last_response.body)
-      expect(data['error']).to eq('Authentication Required')
-    end
-
-    it 'redirects to login for HTML requests' do
-      header 'Accept', 'text/html'
-      send(method, path)
-
-      expect(last_response.status).to eq(302)
-      expect(last_response.headers['location']).to eq('/signin')
-    end
-  end
-
-  context 'when authenticated' do
-    before do
-      env 'rack.session', { 'user_id' => 123 }
-    end
-
-    it 'allows access' do
-      send(method, path)
-
-      expect(last_response.status).not_to eq(401)
-      expect(last_response.status).not_to eq(302)
-    end
-  end
-end
-
-# Usage:
-RSpec.describe 'Dashboard API' do
-  include Rack::Test::Methods
-  let(:app) { MyOttoApp.new }
-
-  describe 'GET /dashboard' do
-    it_behaves_like 'an authenticated endpoint', :get, '/dashboard'
-
-    # Additional specific tests...
-  end
-end
-```
-
-### Shared Examples for Role-Protected Endpoints
-
-```ruby
-# spec/support/shared_examples/role_protected_endpoint.rb
-RSpec.shared_examples 'a role-protected endpoint' do |method, path, required_role|
-  context 'without authentication' do
-    it 'returns 401' do
-      header 'Accept', 'application/json'
-      send(method, path)
-
-      expect(last_response.status).to eq(401)
-    end
-  end
-
-  context 'with authentication but without role' do
-    before do
-      env 'rack.session', {
-        'user_id' => 123,
-        'user_roles' => ['user'],
-      }
-    end
-
-    it 'returns 403' do
-      header 'Accept', 'application/json'
-      send(method, path)
-
-      expect(last_response.status).to eq(403)
-      data = JSON.parse(last_response.body)
-      expect(data['error']).to eq('Forbidden')
-    end
-  end
-
-  context 'with authentication and required role' do
-    before do
-      env 'rack.session', {
-        'user_id' => 123,
-        'user_roles' => [required_role],
-      }
-    end
-
-    it 'allows access' do
-      send(method, path)
-
-      expect(last_response.status).not_to eq(401)
-      expect(last_response.status).not_to eq(403)
-    end
-  end
-end
-
-# Usage:
-RSpec.describe 'Admin API' do
-  include Rack::Test::Methods
-  let(:app) { MyOttoApp.new }
-
-  describe 'GET /admin/users' do
-    it_behaves_like 'a role-protected endpoint', :get, '/admin/users', 'admin'
-
-    # Additional specific tests...
-  end
-end
-```
-
-### Shared Examples for Resource Authorization
-
-```ruby
-# spec/support/shared_examples/resource_authorization.rb
-RSpec.shared_examples 'resource ownership authorization' do |resource_class, logic_class|
-  let(:owner_id) { 123 }
-  let(:other_id) { 456 }
-
-  let(:owner_context) do
-    Otto::Security::Authentication::StrategyResult.new(
-      user: { id: owner_id },
-      session: { 'user_id' => owner_id },
-      auth_method: 'session',
-      metadata: {},
-      strategy_name: 'session'
+RSpec.describe Otto::Security::Authentication::Strategies::APIKeyStrategy do
+  subject(:strategy) { described_class.new(api_keys: ['test-key']) }
+
+  it 'authenticates the configured header value without exposing it' do
+    result = strategy.authenticate(
+      rack_env('/', headers: { 'X-API-Key' => 'test-key' }),
+      'api_key'
     )
+
+    expect(result).to be_authenticated
+    expect(result.metadata[:api_key_fingerprint]).to be_a(String)
+    expect(result.to_h.inspect).not_to include('test-key')
   end
 
-  let(:other_context) do
-    Otto::Security::Authentication::StrategyResult.new(
-      user: { id: other_id },
-      session: { 'user_id' => other_id },
-      auth_method: 'session',
-      metadata: {},
-      strategy_name: 'session'
+  it 'rejects an invalid explicit key terminally' do
+    result = strategy.authenticate(
+      rack_env('/', headers: { 'X-API-Key' => 'wrong-key' }),
+      'api_key'
     )
-  end
 
-  context 'when user owns resource' do
-    it 'allows access' do
-      resource = double(resource_class, id: 1, user_id: owner_id)
-      allow(resource_class).to receive(:find).and_return(resource)
-
-      logic = logic_class.new(owner_context, { id: 1 }, 'en')
-
-      expect { logic.raise_concerns }.not_to raise_error
-    end
-  end
-
-  context 'when user does not own resource' do
-    it 'raises AuthorizationError' do
-      resource = double(resource_class, id: 1, user_id: owner_id)
-      allow(resource_class).to receive(:find).and_return(resource)
-
-      logic = logic_class.new(other_context, { id: 1 }, 'en')
-
-      expect { logic.raise_concerns }.to raise_error(Otto::Security::AuthorizationError)
-    end
-  end
-end
-
-# Usage:
-RSpec.describe PostEditLogic do
-  it_behaves_like 'resource ownership authorization', Post, PostEditLogic
-
-  # Additional specific tests...
-end
-```
-
-### Shared Examples for Security Headers
-
-```ruby
-# spec/support/shared_examples/security_headers.rb
-RSpec.shared_examples 'response with security headers' do
-  it 'includes X-Content-Type-Options header' do
-    expect(last_response.headers['x-content-type-options']).to eq('nosniff')
-  end
-
-  it 'includes X-XSS-Protection header' do
-    expect(last_response.headers['x-xss-protection']).to eq('1; mode=block')
-  end
-
-  it 'includes Referrer-Policy header' do
-    expect(last_response.headers['referrer-policy']).to eq('strict-origin-when-cross-origin')
-  end
-
-  it 'includes X-Frame-Options header' do
-    expect(last_response.headers['x-frame-options']).to eq('SAMEORIGIN')
-  end
-end
-
-# Usage:
-RSpec.describe 'API Endpoint' do
-  describe 'GET /api/data' do
-    before do
-      header 'X-API-Key', 'valid_key'
-      get '/api/data'
-    end
-
-    it_behaves_like 'response with security headers'
+    expect(result).to be_a(Otto::Security::Authentication::AuthFailure)
+    expect(result.failure_reason).to eq('Invalid API key')
+    expect(result).to be_terminal
   end
 end
 ```
 
-## Best Practices
+Query/form API keys are ignored unless the strategy is created with
+`param_name:`. Prefer header authentication because URLs are commonly logged.
+The complete static-list and resolver contract is covered by
+[`spec/otto/security/authentication/strategies/api_key_strategy_spec.rb`](../../spec/otto/security/authentication/strategies/api_key_strategy_spec.rb).
 
-### 1. Test Authentication at Handler Level
+For a custom strategy, subclass
+`Otto::Security::Authentication::AuthStrategy` and test the result returned by
+`authenticate(env, requirement)`. Use `failure(reason, terminal: true)` only
+when an explicit credential was presented and rejected. See the
+[authentication guide](authentication.md) for the chain semantics.
 
-Otto uses handler-level authentication via RouteAuthWrapper, not middleware:
+## Test a complete request through Otto
 
-```ruby
-# Good - Test RouteAuthWrapper directly
-let(:wrapper) do
-  Otto::Security::Authentication::RouteAuthWrapper.new(
-    handler, route_definition, auth_config
-  )
-end
-
-# Avoid - Don't test authentication as middleware
-# (Otto doesn't use middleware for authentication)
-```
-
-### 2. Use StrategyResult for Authentication State
-
-Always use `env['otto.strategy_result']` for authentication state:
+A full-stack test should exercise a real route file, handler factory,
+authentication wrapper, response handler, and Rack response tuple. A registered
+lambda keeps this fixture self-contained:
 
 ```ruby
-# Good
-result = env['otto.strategy_result']
-expect(result).to be_authenticated
-expect(result.user_id).to eq(123)
-
-# Avoid - Don't read session directly
-expect(env['rack.session']['user_id']).to eq(123)
-```
-
-### 3. Test Both Authorization Layers
-
-Test both route-level and resource-level authorization:
-
-```ruby
-# Layer 1: Route-level (RouteAuthWrapper)
-describe 'route authentication' do
-  it 'requires admin role' do
-    # Test RouteAuthWrapper with role=admin
-  end
-end
-
-# Layer 2: Resource-level (Logic#raise_concerns)
-describe '#raise_concerns' do
-  it 'verifies resource ownership' do
-    # Test Logic class authorization
-  end
-end
-```
-
-### 4. Use Factory Methods for Test Data
-
-Create reusable factory methods for common test objects:
-
-```ruby
-# spec/support/factories.rb
-module TestFactories
-  def authenticated_result(user_id: 123, roles: [])
-    Otto::Security::Authentication::StrategyResult.new(
-      user: { id: user_id, roles: roles },
-      session: { 'user_id' => user_id, 'user_roles' => roles },
-      auth_method: 'session',
-      metadata: {},
-      strategy_name: 'session'
+RSpec.describe 'a protected endpoint' do
+  let(:otto) do
+    app = build_otto(
+      ['GET /protected &protected auth=session response=json'],
+      lambda_handlers: {
+        protected: ->(_req, _res, _path_params) { { ok: true } },
+      }
     )
+    app.add_auth_strategy(
+      'session',
+      Otto::Security::Authentication::Strategies::SessionStrategy.new
+    )
+    app
   end
 
-  def anonymous_result
-    Otto::Security::Authentication::StrategyResult.anonymous
-  end
-end
+  it 'returns JSON for an authenticated session' do
+    env = rack_env('/protected')
+    env['rack.session'] = { 'user_id' => 7 }
 
-RSpec.configure do |config|
-  config.include TestFactories
+    status, headers, body = otto.call(env)
+
+    expect(status).to eq(200)
+    expect(headers['Content-Type']).to eq('application/json')
+    expect(JSON.parse(body.join)).to eq('ok' => true)
+  end
+
+  it 'returns a JSON 401 without a session' do
+    status, headers, body = otto.call(
+      rack_env('/protected', headers: { 'Accept' => 'application/json' })
+    )
+
+    expect(status).to eq(401)
+    expect(headers['content-type']).to eq('application/json')
+    expect(JSON.parse(body.join)['error']).to eq('Authentication Required')
+  end
 end
 ```
 
-### 5. Test Configuration Freezing
+For API-key failures, the JSON response uses `"Authentication Required"` in
+`error` and places the specific reason, such as `"Invalid API key"`, in
+`message`.
 
-Verify configuration cannot be changed after first request:
+Use a role-aware strategy when testing `role=`. The built-in `SessionStrategy`
+exposes the user ID but does not copy roles from `rack.session`; `role=` checks
+the successful strategy result, not the session independently. See
+[`spec/otto/security/authentication/route_auth_wrapper/role_authorization_spec.rb`](../../spec/otto/security/authentication/route_auth_wrapper/role_authorization_spec.rb)
+for supported user shapes.
+
+## Test JSON request parsing through a handler
+
+Do not manually merge JSON and query hashes when the behavior under test is
+Otto's parser. Send an `application/json` body through a real Otto instance or
+`LogicClassHandler`, then assert on the parameters received by the Logic object.
+
+Current behavior to cover explicitly:
+
+- a JSON object is merged into the Logic parameters;
+- a valid non-object JSON value is ignored;
+- malformed JSON is logged and the Logic class continues with other parameters;
+- non-JSON bodies are not parsed by the Logic handler.
+
+The maintained executable examples are in the “JSON request body parsing”
+context of
+[`spec/otto/route_handlers_spec.rb`](../../spec/otto/route_handlers_spec.rb).
+
+## Test configuration freezing explicitly
+
+`Otto#call` does not automatically freeze configuration while `RSpec` is
+defined. Freeze the instance directly in tests that assert the production boot
+boundary:
 
 ```ruby
-describe 'configuration freezing' do
-  it 'prevents auth strategy changes after first request' do
-    otto = Otto.new
-    otto.call(mock_rack_env) # First request freezes config
+RSpec.describe 'configuration freezing' do
+  it 'rejects later strategy registration' do
+    otto = build_otto(['GET / &health'], lambda_handlers: {
+      health: ->(_req, res, _path_params) { res.body = 'ok' },
+    })
+    otto.freeze_configuration!
 
+    expect(otto.frozen_configuration?).to be(true)
     expect {
-      otto.add_auth_strategy('new_strategy', strategy)
-    }.to raise_error(FrozenError)
+      otto.add_auth_strategy('other', Object.new)
+    }.to raise_error(FrozenError, /Cannot modify frozen configuration/)
   end
 end
 ```
 
-### 6. Test IP Privacy by Default
+Use a fresh Otto instance after an explicit freeze. `Otto.unfreeze_for_testing`
+only resets an internal flag; it cannot unfreeze nested Ruby objects. See the
+[configuration-freezing guide](configuration_freezing.md) and
+[`spec/otto/configuration_freezing_spec.rb`](../../spec/otto/configuration_freezing_spec.rb).
 
-Verify public IPs are masked while private IPs are preserved:
+## Test CSRF at the correct layers
+
+CSRF has two distinct components:
+
+- `Otto::Security::Middleware::CSRFMiddleware` injects generated tokens into
+  HTML responses containing a `<head>` element.
+- `Otto::Security::CSRFEnforcementWrapper` validates unsafe requests after route
+  matching, where it can honor `csrf=exempt`.
+
+Enable CSRF on an `Otto::Security::Config` before testing either component.
+Valid request tokens must come from `config.generate_csrf_token(session_id)` and
+must use the matching session ID; an arbitrary value copied into the session and
+header is not a valid token.
+
+Use these maintained specs as executable examples:
+
+- [`spec/security_csrf_spec.rb`](../../spec/security_csrf_spec.rb) — response injection.
+- [`spec/otto/security/csrf_enforcement_wrapper_spec.rb`](../../spec/otto/security/csrf_enforcement_wrapper_spec.rb) — safe methods, unsafe methods, valid tokens, and `csrf=exempt`.
+- [`spec/otto/security/csrf_validation_spec.rb`](../../spec/otto/security/csrf_validation_spec.rb) — token and session extraction.
+
+## Test IP privacy with the application configuration
+
+The middleware class is
+`Otto::Security::Middleware::IPPrivacyMiddleware`. It receives a security
+configuration object, not `masking_level:` or `skip_private_ips:` keywords:
 
 ```ruby
-describe 'IP privacy' do
-  it 'masks public IPs' do
-    env = mock_rack_env
+RSpec.describe Otto::Security::Middleware::IPPrivacyMiddleware do
+  it 'masks a public IPv4 address' do
+    inner = ->(_env) { [200, {}, ['ok']] }
+    security_config = Otto::Security::Config.new
+    middleware = described_class.new(inner, security_config)
+    env = rack_env('/')
     env['REMOTE_ADDR'] = '203.0.113.45'
 
-    app.call(env)
+    middleware.call(env)
 
     expect(env['REMOTE_ADDR']).to eq('203.0.113.0')
   end
-
-  it 'preserves private IPs' do
-    env = mock_rack_env
-    env['REMOTE_ADDR'] = '192.168.1.100'
-
-    app.call(env)
-
-    expect(env['REMOTE_ADDR']).to eq('192.168.1.100')
-  end
 end
 ```
 
-### 7. Test Multi-Strategy Authentication
+Set `security_config.ip_privacy_config.octet_precision = 2` to mask two IPv4
+octets, or set `mask_private_ips = true` to include private and localhost
+addresses. For application-facing tests, prefer a real Otto instance configured
+through `configure_ip_privacy`.
 
-Test OR logic for multiple authentication strategies:
+See the [privacy guide](privacy.md) and the maintained privacy specs:
 
-```ruby
-describe 'multi-strategy authentication' do
-  let(:route) { 'Logic auth=session,apikey' }
+- [`spec/otto/ip_privacy_spec.rb`](../../spec/otto/ip_privacy_spec.rb)
+- [`spec/otto/ip_precision_capability_spec.rb`](../../spec/otto/ip_precision_capability_spec.rb)
 
-  it 'succeeds with first strategy' do
-    env['rack.session'] = { 'user_id' => 123 }
-    # Should succeed without checking apikey
-  end
+## Test expected errors through the public request path
 
-  it 'tries second strategy when first fails' do
-    env['HTTP_X_API_KEY'] = 'valid_key'
-    # Should succeed with apikey when session absent
-  end
+Register expected business errors before the freeze boundary, trigger them from
+a route, and assert the returned status and response format. This verifies route
+content negotiation and centralized error handling together. Direct calls to
+private methods such as `handle_error` are useful for Otto's own unit tests but
+should not be the main application-level pattern.
 
-  it 'fails only when all strategies fail' do
-    # No session, no API key
-    # Should return 401
-  end
-end
-```
+The maintained coverage is in:
 
-### 8. Use Descriptive Test Names
+- [`spec/otto/error_handler_registration_spec.rb`](../../spec/otto/error_handler_registration_spec.rb)
+- [`spec/otto/error_handling_spec.rb`](../../spec/otto/error_handling_spec.rb)
 
-Write clear test names that explain what's being tested:
+## Security-header expectations
 
-```ruby
-# Good
-it 'returns 403 when user lacks required role'
-it 'allows admin access to organization owned by another user'
-it 'masks last octet of public IPv4 addresses'
+Otto's default route responses include:
 
-# Avoid
-it 'works'
-it 'handles authentication'
-it 'tests the thing'
-```
+- `x-content-type-options: nosniff`
+- `x-xss-protection: 1; mode=block`
+- `referrer-policy: strict-origin-when-cross-origin`
 
-### 9. Test Error Handler Registration
+`x-frame-options` is not a default header. Call
+`otto.enable_frame_protection!` before the first request if a test should expect
+`x-frame-options: SAMEORIGIN`.
 
-Test both registration and execution of error handlers:
+Test security behavior at the narrowest useful level, but do not require every
+unrelated unit test to repeat header and privacy assertions. Keep those checks in
+focused middleware or request specs.
 
-```ruby
-describe 'error handlers' do
-  it 'registers handler before first request' do
-    otto.register_error_handler(NotFoundError, status: 404)
-    expect(otto.error_handlers).to have_key('NotFoundError')
-  end
+## Maintained examples by task
 
-  it 'executes handler and returns configured status' do
-    otto.register_error_handler(NotFoundError, status: 404)
-    # Trigger error and verify 404 response
-  end
-
-  it 'prevents registration after first request' do
-    otto.call(env) # Freeze configuration
-    expect {
-      otto.register_error_handler(NotFoundError, status: 404)
-    }.to raise_error(FrozenError)
-  end
-end
-```
-
-### 10. Test Logic Class Lifecycle
-
-Test the complete Logic class lifecycle:
-
-```ruby
-describe PostCreateLogic do
-  it 'follows complete lifecycle' do
-    logic = described_class.new(context, params, locale)
-
-    # 1. Validation
-    expect { logic.raise_concerns }.not_to raise_error
-
-    # 2. Processing
-    result = logic.process
-    expect(result).to be_a(Hash)
-
-    # 3. Response formatting
-    response = logic.response_data
-    expect(response).to have_key(:post)
-  end
-end
-```
-
-## Summary
-
-Otto 2 testing emphasizes:
-
-1. **Handler-Level Authentication**: Test via RouteAuthWrapper, not middleware
-2. **Two-Layer Authorization**: Test both route-level and resource-level checks
-3. **Strategy Result Pattern**: Use `env['otto.strategy_result']` for auth state
-4. **Full-Stack Testing**: Use Rack::Test for end-to-end validation
-5. **Security by Default**: Verify IP privacy, security headers, and CSRF protection
-6. **Configuration Freezing**: Test freeze after first request
-7. **Multi-Strategy Auth**: Test OR logic for multiple auth strategies
-8. **Logic Class Lifecycle**: Test raise_concerns, process, and response_data
-9. **Error Handlers**: Test registration and execution of custom error handlers
-10. **Shared Examples**: Create reusable patterns for common scenarios
-
-This guide provides a comprehensive foundation for testing Otto 2 applications with confidence.
+- Authentication responses and route roles:
+  [`spec/otto/security/route_auth_wrapper_spec.rb`](../../spec/otto/security/route_auth_wrapper_spec.rb)
+- Terminal API-key behavior:
+  [`spec/otto/security/authentication/api_key_fail_closed_integration_spec.rb`](../../spec/otto/security/authentication/api_key_fail_closed_integration_spec.rb)
+- Registered lambda routes and response types:
+  [`spec/otto/lambda_routes_integration_spec.rb`](../../spec/otto/lambda_routes_integration_spec.rb)
+- Response selection:
+  [`spec/otto/response_integration_spec.rb`](../../spec/otto/response_integration_spec.rb)
+- Static files after freezing:
+  [`spec/otto/static_file_freezing_spec.rb`](../../spec/otto/static_file_freezing_spec.rb)

--- a/docs/guides/testing-guide.md
+++ b/docs/guides/testing-guide.md
@@ -46,7 +46,12 @@ module OttoAppSpecHelpers
   def rack_env(path = '/', method: 'GET', headers: {}, params: {})
     env = Rack::MockRequest.env_for(path, method: method, params: params)
     headers.each do |name, value|
-      env["HTTP_#{name.upcase.tr('-', '_')}"] = value
+      rack_name = name.upcase.tr('-', '_')
+      # Rack keeps Content-Type and Content-Length unprefixed; everything else
+      # is HTTP_-prefixed. Without this, a JSON request never reaches Otto's
+      # JSON parser.
+      key = %w[CONTENT_TYPE CONTENT_LENGTH].include?(rack_name) ? rack_name : "HTTP_#{rack_name}"
+      env[key] = value
     end
     env
   end


### PR DESCRIPTION
Rewrites the `docs/guides/` set for accuracy and length. The testing guide drops
from 1934 to 386 lines and now leads with request specs through a real `Otto`
instance; `ip_privacy.md` becomes a stub pointing at `privacy.md`, whose contract
tables were corrected (`otto.client_ip` under `:audit` and exempt requests,
`otto.ip_match`, the `**` sentinels).

Also documents two forwarded-authority limits that were previously implicit: the
settings do not validate the ordinary `Host` header, and pinning
`forwarded_priority` does not cover `X-Forwarded-SSL`. Adds an AGENTS.md rule
requiring authoritative sources for project claims, and merges the two competing
revisions of the #259 changelog fragment.

Related to #259