### PR TITLE
Copy static not_found/server_error triples per request; accept callables

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -859,6 +859,7 @@ RSpec/SpecFilePathFormat:
     - 'spec/otto/enhanced_routing_spec.rb'
     - 'spec/otto/error_handler_registration_spec.rb'
     - 'spec/otto/error_handling_spec.rb'
+    - 'spec/otto/fallback_response_isolation_spec.rb'
     - 'spec/otto/file_safety_spec.rb'
     - 'spec/otto/locale_config_spec.rb'
     - 'spec/otto/mcp/rate_limiting_spec.rb'

--- a/changelog.d/20260910_090000_fallback_response_isolation.rst
+++ b/changelog.d/20260910_090000_fallback_response_isolation.rst
@@ -15,8 +15,10 @@ Added
 
 - ``Otto#not_found=`` and ``Otto#server_error=`` accept a callable
   (``call(env)``; ``server_error`` also receives the exception when the
-  callable takes two arguments) that builds a fresh response per request.
-  ``env['otto.error_id']`` carries the logged correlation id. A callable that
-  raises or returns a non-triple is logged and replaced by the built-in
-  secure error response. Both writers reject values that are neither a Rack
-  triple nor callable with ``ArgumentError``. (#272)
+  callable declares a second positional parameter) that builds a fresh
+  response per request. ``env['otto.error_id']`` carries the logged
+  correlation id. A callable that raises or returns a non-triple is logged
+  and replaced by the built-in secure error response. Both writers reject
+  values that are neither a Rack triple (Integer status, Hash-like headers,
+  body responding to ``each`` or ``call``) nor callable with
+  ``ArgumentError``. (#272)

--- a/changelog.d/20260910_090000_fallback_response_isolation.rst
+++ b/changelog.d/20260910_090000_fallback_response_isolation.rst
@@ -1,0 +1,22 @@
+Security
+--------
+
+- ``Otto#not_found=`` and ``Otto#server_error=`` static Rack triples are now
+  copied per request instead of being returned by reference. Cookie
+  middleware (rack-session, Otto's CSRF middleware, anything calling
+  ``Rack::Utils.set_cookie_header!``) writes response headers in place, so a
+  shared triple accumulated every ``Set-Cookie`` committed on earlier 404/500
+  responses and replayed them to later clients. Headers keep their class,
+  Array-valued headers and Array bodies are copied, and a frozen triple yields
+  a writable copy. (#272)
+
+Added
+-----
+
+- ``Otto#not_found=`` and ``Otto#server_error=`` accept a callable
+  (``call(env)``; ``server_error`` also receives the exception when the
+  callable takes two arguments) that builds a fresh response per request.
+  ``env['otto.error_id']`` carries the logged correlation id. A callable that
+  raises or returns a non-triple is logged and replaced by the built-in
+  secure error response. Both writers reject values that are neither a Rack
+  triple nor callable with ``ArgumentError``. (#272)

--- a/docs/guides/configuration_freezing.md
+++ b/docs/guides/configuration_freezing.md
@@ -69,7 +69,10 @@ some state that is not included in `freeze_configuration!`:
 
 - `error_handlers` remains a mutable Hash, although
   `register_error_handler` rejects calls after freezing;
-- the `not_found` and `server_error` fallback response writers remain available;
+- the `not_found` and `server_error` fallback response writers remain
+  available. A configured static triple is never returned by reference:
+  Otto copies it per request, so header writes by cookie middleware do not
+  reach the configured object even though it is not frozen;
 - the inner static-file cache remains mutable by design.
 
 Application code should not mutate those objects directly after boot. Do not

--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -163,6 +163,32 @@ silently weakening the route. Do not use `csrf=exempt` as a general API switch;
 choose an independent request-authentication and replay-protection model for
 webhooks or other non-browser endpoints.
 
+## Fallback 404 and 500 responses
+
+A `GET /404` or `GET /500` route in the routes file handles misses and
+unhandled errors like any other route. Without one, Otto uses `not_found=` and
+`server_error=`, which accept either a Rack triple or a callable:
+
+```ruby
+otto.not_found = [404, { 'content-type' => 'application/json' }, ['{"error":"Not Found"}']]
+
+otto.server_error = lambda do |env, error|
+  [500, { 'content-type' => 'text/plain' }, ["Error #{env['otto.error_id']}"]]
+end
+```
+
+A callable is invoked on every request (`not_found` with `env`, `server_error`
+with `env` and the exception, or `env` alone for a one-argument callable) and
+must return a Rack triple. A static triple is copied per request before it is
+returned, so middleware that writes response headers in place (rack-session,
+Otto's CSRF middleware, anything calling `Rack::Utils.set_cookie_header!`)
+never mutates the configured object or leaks one client's `Set-Cookie` into
+another's response. Do not rely on mutating the configured triple after boot;
+assign a new value or use the callable form instead.
+
+For JSON clients, an unhandled error returns Otto's built-in JSON error body
+regardless of `server_error`; a `/500` route applies to every client.
+
 ## Configuration timing
 
 Construct and configure the Otto instance before the first request:

--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -177,14 +177,18 @@ otto.server_error = lambda do |env, error|
 end
 ```
 
-A callable is invoked on every request (`not_found` with `env`, `server_error`
-with `env` and the exception, or `env` alone for a one-argument callable) and
-must return a Rack triple. A static triple is copied per request before it is
-returned, so middleware that writes response headers in place (rack-session,
-Otto's CSRF middleware, anything calling `Rack::Utils.set_cookie_header!`)
-never mutates the configured object or leaks one client's `Set-Cookie` into
-another's response. Do not rely on mutating the configured triple after boot;
-assign a new value or use the callable form instead.
+A callable is invoked on every request with `env` (`not_found`) or `env` and
+the exception (`server_error`), trimmed to the positional parameters it
+declares, so `->(env) { ... }` and `->(env = nil) { ... }` both work for
+`server_error`. It must return a Rack triple: an Integer status, Hash-like
+headers, and a body that responds to `each` (a bare String is rejected, at
+assignment time for a static triple). A static triple is copied per request
+before it is returned, so middleware that writes response headers in place
+(rack-session, Otto's CSRF middleware, anything calling
+`Rack::Utils.set_cookie_header!`) never mutates the configured object or
+leaks one client's `Set-Cookie` into another's response. Do not rely on
+mutating the configured triple after boot; assign a new value or use the
+callable form instead.
 
 For JSON clients, an unhandled error returns Otto's built-in JSON error body
 regardless of `server_error`; a `/500` route applies to every client.

--- a/lib/otto.rb
+++ b/lib/otto.rb
@@ -80,8 +80,52 @@ class Otto
               :routes_by_definition, :option,
               :static_route, :security_config, :locale_config, :auth_config,
               :route_handler_factory, :mcp_server, :caddy_tls_server, :security, :middleware,
-              :error_handlers, :request_class, :response_class
-  attr_accessor :not_found, :server_error
+              :error_handlers, :request_class, :response_class,
+              :not_found, :server_error
+
+  # Configure the response returned when no route (and no +/404+ route) matches.
+  #
+  # Accepts either a Rack triple +[status, headers, body]+ or anything that
+  # responds to +call(env)+ and returns one. A static triple is never handed
+  # back to the Rack stack by reference: Otto returns a per-request copy whose
+  # headers (and Array-valued header entries, and Array body) are fresh
+  # containers, so cookie middleware such as rack-session or Otto's own CSRF
+  # middleware cannot accumulate +Set-Cookie+ values on the configured object
+  # and replay them to later clients. Prefer the callable form when the
+  # response should vary per request.
+  #
+  # @param response [Array, #call, nil] a Rack triple, a callable, or nil to
+  #   restore the built-in {Otto::Static.not_found} response
+  # @raise [ArgumentError] when +response+ is neither a Rack triple nor callable
+  #
+  # @example Static triple (copied per request)
+  #   otto.not_found = [404, { 'content-type' => 'application/json' }, ['{"error":"Not Found"}']]
+  #
+  # @example Callable, built fresh on every miss
+  #   otto.not_found = ->(env) { [404, { 'content-type' => 'text/plain' }, ["No #{env['PATH_INFO']}"]] }
+  def not_found=(response)
+    @not_found = validate_fallback_response!(:not_found, response)
+  end
+
+  # Configure the response returned for an unhandled error when no +/500+
+  # route is configured and the client does not prefer JSON.
+  #
+  # Accepts either a Rack triple or anything that responds to +call(env)+ or
+  # +call(env, error)+ and returns one; +env['otto.error_id']+ carries the
+  # logged correlation id. As with {#not_found=}, a static triple is copied
+  # per request so header writes by cookie middleware never touch the
+  # configured object. A callable that raises is logged and replaced by the
+  # built-in secure error response.
+  #
+  # @param response [Array, #call, nil] a Rack triple, a callable, or nil to
+  #   restore the built-in secure error response
+  # @raise [ArgumentError] when +response+ is neither a Rack triple nor callable
+  #
+  # @example Callable receiving the error
+  #   otto.server_error = ->(env, error) { [500, { 'content-type' => 'text/plain' }, ['Oops']] }
+  def server_error=(response)
+    @server_error = validate_fallback_response!(:server_error, response)
+  end
 
   def initialize(path = nil, opts = {})
     constructed = false
@@ -300,6 +344,49 @@ class Otto
       end
     end
   end
+
+  # Validate a value assigned to {#not_found=} or {#server_error=}.
+  #
+  # @param name [Symbol] the setting name, for the error message
+  # @param response [Object] the assigned value
+  # @return [Array, #call, nil] the value, when acceptable
+  # @raise [ArgumentError] otherwise
+  def validate_fallback_response!(name, response)
+    return response if response.nil? || response.respond_to?(:call)
+    return response if rack_triple?(response)
+
+    raise ArgumentError,
+      "#{name} must be a Rack triple [status, headers, body] or respond to #call, got #{response.inspect}"
+  end
+
+  def rack_triple?(response)
+    response.is_a?(Array) && response.length == 3 &&
+      response[0].respond_to?(:to_int) &&
+      response[1].respond_to?(:each_pair)
+  end
+
+  # Resolve a configured fallback into a fresh Rack triple for one request.
+  #
+  # A callable is invoked with the remaining arguments; a static triple is
+  # used as-is. Either way the result is copied (see
+  # {Otto::Static.copy_response}) so the Rack stack never receives a
+  # container shared with the configuration or with another request.
+  #
+  # @param name [Symbol] the setting name, for the error message
+  # @param fallback [Array, #call] the configured value
+  # @param * remaining positional arguments are passed to a callable fallback
+  # @return [Array] a new Rack triple
+  # @raise [TypeError] when a callable returns something other than a Rack triple
+  def resolve_fallback_response(name, fallback, *)
+    response = fallback.respond_to?(:call) ? fallback.call(*) : fallback
+    unless rack_triple?(response)
+      raise TypeError,
+        "#{name} callable must return a Rack triple [status, headers, body], got #{response.inspect}"
+    end
+
+    Otto::Static.copy_response(response)
+  end
+  private :validate_fallback_response!, :rack_triple?, :resolve_fallback_response
 
   # Class methods for Otto framework providing singleton access and configuration
   module ClassMethods

--- a/lib/otto.rb
+++ b/lib/otto.rb
@@ -68,6 +68,10 @@ class Otto
 
   LIB_HOME = __dir__ unless defined?(Otto::LIB_HOME)
 
+  # Parameter types (from Proc#parameters / Method#parameters) that consume
+  # one positional argument each. See {#fallback_call_args}.
+  POSITIONAL_PARAMETER_TYPES = %i[req opt].freeze
+
   @debug = case ENV.fetch('OTTO_DEBUG', nil)
            in 'true' | '1' | 'yes' | 'on'
              true
@@ -85,7 +89,8 @@ class Otto
 
   # Configure the response returned when no route (and no +/404+ route) matches.
   #
-  # Accepts either a Rack triple +[status, headers, body]+ or anything that
+  # Accepts either a Rack triple +[status, headers, body]+ (the body must
+  # respond to +each+, or +call+ for a streaming body) or anything that
   # responds to +call(env)+ and returns one. A static triple is never handed
   # back to the Rack stack by reference: Otto returns a per-request copy whose
   # headers (and Array-valued header entries, and Array body) are fresh
@@ -110,8 +115,9 @@ class Otto
   # Configure the response returned for an unhandled error when no +/500+
   # route is configured and the client does not prefer JSON.
   #
-  # Accepts either a Rack triple or anything that responds to +call(env)+ or
-  # +call(env, error)+ and returns one; +env['otto.error_id']+ carries the
+  # Accepts either a Rack triple or anything that responds to +call(env, error)+
+  # and returns one; a callable declaring a single positional parameter (or
+  # none) receives only what it declares. +env['otto.error_id']+ carries the
   # logged correlation id. As with {#not_found=}, a static triple is copied
   # per request so header writes by cookie middleware never touch the
   # configured object. A callable that raises is logged and replaced by the
@@ -359,26 +365,31 @@ class Otto
       "#{name} must be a Rack triple [status, headers, body] or respond to #call, got #{response.inspect}"
   end
 
+  # A Rack triple: an Integer-like status, Hash-like headers, and a body that
+  # responds to +each+ (or +call+, for a streaming body).
   def rack_triple?(response)
-    response.is_a?(Array) && response.length == 3 &&
-      response[0].respond_to?(:to_int) &&
-      response[1].respond_to?(:each_pair)
+    return false unless response.is_a?(Array) && response.length == 3
+
+    status, headers, body = response
+    status.respond_to?(:to_int) && headers.respond_to?(:each_pair) &&
+      (body.respond_to?(:each) || body.respond_to?(:call))
   end
 
   # Resolve a configured fallback into a fresh Rack triple for one request.
   #
-  # A callable is invoked with the remaining arguments; a static triple is
-  # used as-is. Either way the result is copied (see
-  # {Otto::Static.copy_response}) so the Rack stack never receives a
-  # container shared with the configuration or with another request.
+  # A callable is invoked with as many of +args+ as it accepts (see
+  # {#fallback_call_args}); a static triple is used as-is. Either way the
+  # result is copied (see {Otto::Static.copy_response}) so the Rack stack
+  # never receives a container shared with the configuration or with another
+  # request.
   #
   # @param name [Symbol] the setting name, for the error message
   # @param fallback [Array, #call] the configured value
-  # @param * remaining positional arguments are passed to a callable fallback
+  # @param args [Array] positional arguments offered to a callable fallback
   # @return [Array] a new Rack triple
   # @raise [TypeError] when a callable returns something other than a Rack triple
-  def resolve_fallback_response(name, fallback, *)
-    response = fallback.respond_to?(:call) ? fallback.call(*) : fallback
+  def resolve_fallback_response(name, fallback, *args)
+    response = fallback.respond_to?(:call) ? fallback.call(*fallback_call_args(fallback, args)) : fallback
     unless rack_triple?(response)
       raise TypeError,
         "#{name} callable must return a Rack triple [status, headers, body], got #{response.inspect}"
@@ -386,7 +397,23 @@ class Otto
 
     Otto::Static.copy_response(response)
   end
-  private :validate_fallback_response!, :rack_triple?, :resolve_fallback_response
+
+  # Trim +args+ to the positional parameters +callable+ declares, so a lambda
+  # or Method that takes fewer (or optional) parameters is never handed an
+  # argument it would reject. A splat parameter receives everything. Arity
+  # alone cannot express this: +->(env = nil) {}+ has arity -1, the same as
+  # +proc { |*a| }+, yet accepts at most one argument.
+  #
+  # @param callable [#call]
+  # @param args [Array] the arguments on offer, in order
+  # @return [Array] the leading subset of +args+ the callable accepts
+  def fallback_call_args(callable, args)
+    params = callable.respond_to?(:parameters) ? callable.parameters : callable.method(:call).parameters
+    return args if params.any? { |type, _name| type == :rest }
+
+    args.first(params.count { |type, _name| POSITIONAL_PARAMETER_TYPES.include?(type) })
+  end
+  private :validate_fallback_response!, :rack_triple?, :resolve_fallback_response, :fallback_call_args
 
   # Class methods for Otto framework providing singleton access and configuration
   module ClassMethods

--- a/lib/otto/core/error_handler.rb
+++ b/lib/otto/core/error_handler.rb
@@ -71,8 +71,8 @@ class Otto
         # Content negotiation for built-in error response
         return json_error_response(error_id) if wants_json_response?(env)
 
-        # Fallback to built-in error response
-        @server_error || secure_error_response(error_id)
+        # Fallback to the configured server_error response, else the built-in one
+        server_error_response(env, error, error_id)
       end
 
       # Register an error handler for expected business logic errors
@@ -266,6 +266,55 @@ class Otto
 
           [status, headers, [body]]
         end
+      end
+
+      # Build the fallback 500 response for an unhandled error.
+      #
+      # A configured +server_error+ callable is invoked per request with
+      # +env+ (and the original +error+ when its arity allows); +env+ carries
+      # +otto.error_id+ so the response can reference the logged error. A
+      # configured static triple is copied per request (see
+      # {Otto::Static.copy_response}) so header writes by cookie middleware
+      # cannot accumulate on the shared object. A callable that raises is
+      # logged and replaced by the built-in secure response, mirroring how a
+      # failing custom +/500+ route is handled.
+      #
+      # @param env [Hash] Rack environment
+      # @param error [Exception] the unhandled error
+      # @param error_id [String] correlation id already logged for +error+
+      # @return [Array] a fresh Rack triple
+      def server_error_response(env, error, error_id)
+        fallback = @server_error
+        return secure_error_response(error_id) if fallback.nil?
+
+        env['otto.error_id'] = error_id
+        resolve_fallback_response(:server_error, fallback, *server_error_callable_args(fallback, env, error))
+      rescue StandardError => e
+        fallback_error_id = SecureRandom.hex(8)
+        base_context = Otto::LoggingHelpers.request_context(env)
+
+        Otto.structured_log(:error, 'Error in server_error fallback',
+          base_context.merge(
+            error: e.message,
+            error_class: e.class.name,
+            error_id: fallback_error_id,
+            original_error_id: error_id
+          ))
+        Otto::LoggingHelpers.log_backtrace(e,
+          base_context.merge(error_id: fallback_error_id, original_error_id: error_id))
+
+        secure_error_response(error_id)
+      end
+
+      # Arguments for a +server_error+ callable: +(env, error)+, or just
+      # +(env)+ when the callable declares a single parameter (a lambda or
+      # Method with arity 1 would raise on the two-argument form). A static
+      # triple takes no arguments.
+      def server_error_callable_args(fallback, env, error)
+        return [] unless fallback.respond_to?(:call)
+
+        arity = fallback.respond_to?(:arity) ? fallback.arity : fallback.method(:call).arity
+        arity == 1 ? [env] : [env, error]
       end
 
       def secure_error_response(error_id)

--- a/lib/otto/core/error_handler.rb
+++ b/lib/otto/core/error_handler.rb
@@ -271,13 +271,13 @@ class Otto
       # Build the fallback 500 response for an unhandled error.
       #
       # A configured +server_error+ callable is invoked per request with
-      # +env+ (and the original +error+ when its arity allows); +env+ carries
-      # +otto.error_id+ so the response can reference the logged error. A
-      # configured static triple is copied per request (see
-      # {Otto::Static.copy_response}) so header writes by cookie middleware
-      # cannot accumulate on the shared object. A callable that raises is
-      # logged and replaced by the built-in secure response, mirroring how a
-      # failing custom +/500+ route is handled.
+      # +env+ and the original +error+, trimmed to the positional parameters
+      # it declares; +env+ carries +otto.error_id+ so the response can
+      # reference the logged error. A configured static triple is copied per
+      # request (see {Otto::Static.copy_response}) so header writes by cookie
+      # middleware cannot accumulate on the shared object. A callable that
+      # raises is logged and replaced by the built-in secure response,
+      # mirroring how a failing custom +/500+ route is handled.
       #
       # @param env [Hash] Rack environment
       # @param error [Exception] the unhandled error
@@ -288,7 +288,7 @@ class Otto
         return secure_error_response(error_id) if fallback.nil?
 
         env['otto.error_id'] = error_id
-        resolve_fallback_response(:server_error, fallback, *server_error_callable_args(fallback, env, error))
+        resolve_fallback_response(:server_error, fallback, env, error)
       rescue StandardError => e
         fallback_error_id = SecureRandom.hex(8)
         base_context = Otto::LoggingHelpers.request_context(env)
@@ -304,17 +304,6 @@ class Otto
           base_context.merge(error_id: fallback_error_id, original_error_id: error_id))
 
         secure_error_response(error_id)
-      end
-
-      # Arguments for a +server_error+ callable: +(env, error)+, or just
-      # +(env)+ when the callable declares a single parameter (a lambda or
-      # Method with arity 1 would raise on the two-argument form). A static
-      # triple takes no arguments.
-      def server_error_callable_args(fallback, env, error)
-        return [] unless fallback.respond_to?(:call)
-
-        arity = fallback.respond_to?(:arity) ? fallback.arity : fallback.method(:call).arity
-        arity == 1 ? [env] : [env, error]
       end
 
       def secure_error_response(error_id)

--- a/lib/otto/core/router.rb
+++ b/lib/otto/core/router.rb
@@ -287,8 +287,27 @@ class Otto
             Otto::LoggingHelpers.request_context(env).merge(
               fallback_to: 'default_not_found'
             ))
-          @not_found || Otto::Static.not_found
+          not_found_response(env)
         end
+      end
+
+      # Build the response for a request that matched no route and has no
+      # +/404+ route configured.
+      #
+      # A configured +not_found+ callable is invoked with +env+ on every miss.
+      # A configured static triple is copied per request (see
+      # {Otto::Static.copy_response}) so header writes by cookie middleware
+      # cannot accumulate on, or leak between requests through, the shared
+      # object. With nothing configured the built-in {Otto::Static.not_found}
+      # response is used.
+      #
+      # @param env [Hash] Rack environment
+      # @return [Array] a fresh Rack triple
+      def not_found_response(env)
+        fallback = @not_found
+        return Otto::Static.not_found if fallback.nil?
+
+        resolve_fallback_response(:not_found, fallback, env)
       end
 
       def build_route_params(route, values)

--- a/lib/otto/static.rb
+++ b/lib/otto/static.rb
@@ -15,6 +15,44 @@ class Otto
       [404, security_headers.merge({ 'content-type' => 'text/plain' }), ['Not Found']]
     end
 
+    # Return a per-request copy of a Rack triple so callers can never hand a
+    # shared object back to the Rack stack.
+    #
+    # Middleware above Otto (rack-session, Otto's own CSRF middleware, anything
+    # that calls +Rack::Utils.set_cookie_header!+) writes response headers in
+    # place. Returning a configured triple by reference lets those writes
+    # accumulate on the shared object for the life of the process, so every
+    # subsequent 404/500 replays every Set-Cookie any earlier one committed.
+    #
+    # The copy is intentionally shallow-plus-one: the headers container keeps
+    # its class (a +Rack::Headers+ stays case-insensitive), each Array-valued
+    # header (Rack 3's representation of a repeated header) is copied so an
+    # append cannot reach the shared Array, and an Array body is copied so a
+    # middleware appending chunks cannot grow the shared body. A frozen
+    # configured triple yields an unfrozen copy, so cookie middleware works
+    # after configuration freezing as well.
+    #
+    # @param response [Array] a Rack triple +[status, headers, body]+
+    # @return [Array] a new triple that shares no mutable container with +response+
+    def copy_response(response)
+      status, headers, body = response
+      [status, copy_headers(headers), body.is_a?(Array) ? body.dup : body]
+    end
+
+    # Copy a Rack headers container, keeping its class and copying Array values.
+    #
+    # @param headers [Hash, Rack::Headers, nil] the headers to copy
+    # @return [Hash, Rack::Headers] a new container of the same class
+    def copy_headers(headers)
+      return {} if headers.nil?
+
+      copied = headers.dup
+      copied.each_pair do |key, value|
+        copied[key] = value.dup if value.is_a?(Array)
+      end
+      copied
+    end
+
     def security_headers
       {
         'x-frame-options' => 'DENY',

--- a/spec/otto/fallback_response_isolation_spec.rb
+++ b/spec/otto/fallback_response_isolation_spec.rb
@@ -92,6 +92,27 @@ RSpec.describe Otto do
       expect { otto.public_send(:"#{writer}=", ['404', {}, []]) }.to raise_error(ArgumentError)
     end
 
+    it 'rejects a triple whose body is a bare String' do
+      expect { otto.public_send(:"#{writer}=", [404, {}, 'Not Found']) }
+        .to raise_error(ArgumentError, /#{writer} must be a Rack triple/)
+    end
+
+    it 'rejects a triple whose body is nil' do
+      expect { otto.public_send(:"#{writer}=", [404, {}, nil]) }.to raise_error(ArgumentError)
+    end
+
+    it 'accepts a body that responds to #each without being an Array' do
+      body = Class.new { def each = yield('chunk') }.new
+      otto.public_send(:"#{writer}=", [404, {}, body])
+      expect(otto.public_send(reader)[2]).to equal(body)
+    end
+
+    it 'accepts a streaming body that responds to #call' do
+      body = ->(stream) { stream.write('chunk') }
+      otto.public_send(:"#{writer}=", [404, {}, body])
+      expect(otto.public_send(reader)[2]).to equal(body)
+    end
+
     it 'leaves the previous value in place when rejecting' do
       otto.public_send(:"#{writer}=", not_found_triple)
       expect { otto.public_send(:"#{writer}=", 42) }.to raise_error(ArgumentError)
@@ -305,6 +326,36 @@ RSpec.describe Otto do
       expect(response[0]).to eq(500)
       expect(described_class.logger).to have_received(:error).with(/not_found callable must return a Rack triple/)
     end
+
+    it 'turns a callable returning a triple with a String body into a 500' do
+      otto.not_found = ->(_env) { [404, {}, 'Not Found'] }
+
+      expect(miss(otto)[0]).to eq(500)
+      expect(described_class.logger).to have_received(:error).with(/not_found callable must return a Rack triple/)
+    end
+
+    it 'passes env to a lambda whose only parameter is optional' do
+      otto.not_found = ->(env = nil) { [404, {}, [env['PATH_INFO']]] }
+
+      expect(miss(otto, '/opt')[2]).to eq(['/opt'])
+    end
+
+    it 'passes nothing to a lambda that declares no parameters' do
+      otto.not_found = -> { [404, {}, ['bare']] }
+
+      expect(miss(otto)[2]).to eq(['bare'])
+    end
+
+    it 'passes only env to a lambda that declares more parameters than are available' do
+      received = :unset
+      otto.not_found = lambda do |env, extra = :default|
+        received = extra
+        [404, {}, [env['PATH_INFO']]]
+      end
+
+      expect(miss(otto, '/two')[2]).to eq(['/two'])
+      expect(received).to eq(:default)
+    end
   end
 
   describe 'not_found precedence' do
@@ -438,6 +489,43 @@ RSpec.describe Otto do
         expect(boom(otto)[2].join).to match(/\A[a-f0-9]{16}\z/)
       end
 
+      it 'receives only env when its single parameter is optional' do
+        otto.server_error = ->(env = nil) { [500, {}, [env['otto.error_id']]] }
+
+        expect(boom(otto)[2].join).to match(/\A[a-f0-9]{16}\z/)
+        expect(described_class.logger).not_to have_received(:error).with(/Error in server_error fallback/)
+      end
+
+      it 'receives env and the error when the error parameter is optional' do
+        otto.server_error = ->(_env, error = nil) { [500, {}, [error.message]] }
+
+        expect(boom(otto)[2]).to eq(['kaboom'])
+      end
+
+      it 'receives nothing when it declares no parameters' do
+        otto.server_error = -> { [500, {}, ['bare']] }
+
+        expect(boom(otto)[2]).to eq(['bare'])
+      end
+
+      it 'accepts an object whose #call takes env and an optional error' do
+        handler = Class.new do
+          def call(env, error = nil) = [500, {}, ["#{error.class} #{env['otto.error_id']}"]]
+        end.new
+        otto.server_error = handler
+
+        expect(boom(otto)[2].join).to match(/\ARuntimeError [a-f0-9]{16}\z/)
+      end
+
+      it 'accepts a Method object with a required and a splat parameter' do
+        handler = Class.new do
+          def call(env, *rest) = [500, {}, [env['PATH_INFO'], rest.length.to_s]]
+        end.new
+        otto.server_error = handler.method(:call)
+
+        expect(boom(otto)[2]).to eq(['/boom', '1'])
+      end
+
       it 'accepts an object whose #call takes env and error' do
         handler = Class.new do
           def call(_env, error) = [503, { 'content-type' => 'text/plain' }, [error.message]]
@@ -491,6 +579,16 @@ RSpec.describe Otto do
 
         response = boom(otto)
         expect(response[0]).to eq(500)
+        expect(response[2].join).to match(/An error occurred|Server error/)
+        expect(described_class.logger).to have_received(:error).with(/server_error callable must return a Rack triple/)
+      end
+
+      it 'falls back to the built-in secure response when it returns a triple with a String body' do
+        otto.server_error = ->(_env, _error) { [500, {}, 'broken'] }
+
+        response = boom(otto)
+        expect(response[0]).to eq(500)
+        expect(response[2]).not_to eq('broken')
         expect(response[2].join).to match(/An error occurred|Server error/)
         expect(described_class.logger).to have_received(:error).with(/server_error callable must return a Rack triple/)
       end

--- a/spec/otto/fallback_response_isolation_spec.rb
+++ b/spec/otto/fallback_response_isolation_spec.rb
@@ -1,0 +1,508 @@
+# spec/otto/fallback_response_isolation_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rack/response'
+require 'rack/headers'
+
+# Fallback response isolation (#272): a static not_found / server_error triple
+# must never be handed back to the Rack stack by reference, and both
+# writers accept a per-request callable.
+RSpec.describe Otto do
+  # Commits a cookie the way rack-session's commit_session does: wrap the
+  # returned headers in Rack::Response::Raw and call #set_cookie, which
+  # appends via Rack::Utils.set_cookie_header! when a value already exists.
+  let(:cookie_committer) do
+    Class.new do
+      def initialize(app, name: 'sid')
+        @app  = app
+        @name = name
+      end
+
+      def call(env)
+        status, headers, body = @app.call(env)
+        Rack::Response::Raw.new(status, headers).set_cookie(@name, value: env.fetch('test.cookie', 'v'))
+        [status, headers, body]
+      end
+    end
+  end
+
+  let(:static_headers) { { 'content-type' => 'application/json' } }
+  let(:not_found_triple) { [404, static_headers, ['{"error":"Not Found"}']] }
+  let(:server_error_triple) { [500, static_headers, ['{"error":"Internal Server Error"}']] }
+
+  let(:otto) { create_minimal_otto }
+
+  def miss(app, path = '/nope', cookie: nil)
+    env = mock_rack_env(path: path)
+    env['test.cookie'] = cookie if cookie
+    app.call(env)
+  end
+
+  def cookies_in(response)
+    Array(response[1]['set-cookie'])
+  end
+
+  before do
+    allow(described_class.logger).to receive(:info)
+    allow(described_class.logger).to receive(:warn)
+    allow(described_class.logger).to receive(:error)
+    allow(described_class.logger).to receive(:debug)
+  end
+
+  shared_examples 'a fallback response writer' do |writer|
+    let(:reader) { writer }
+
+    it 'accepts a Rack triple' do
+      otto.public_send(:"#{writer}=", not_found_triple)
+      expect(otto.public_send(reader)).to equal(not_found_triple)
+    end
+
+    it 'accepts a proc, a lambda, a Method and any object responding to #call' do
+      handler = Class.new { def call(_env) = [404, {}, []] }.new
+      [proc { |_env| not_found_triple }, ->(_env) { not_found_triple }, handler, handler.method(:call)].each do |callable|
+        otto.public_send(:"#{writer}=", callable)
+        expect(otto.public_send(reader)).to equal(callable)
+      end
+    end
+
+    it 'accepts nil to restore the built-in response' do
+      otto.public_send(:"#{writer}=", not_found_triple)
+      otto.public_send(:"#{writer}=", nil)
+      expect(otto.public_send(reader)).to be_nil
+    end
+
+    it 'rejects a String' do
+      expect { otto.public_send(:"#{writer}=", 'Not Found') }
+        .to raise_error(ArgumentError, /#{writer} must be a Rack triple/)
+    end
+
+    it 'rejects an Array that is not a triple' do
+      expect { otto.public_send(:"#{writer}=", [404, {}]) }.to raise_error(ArgumentError)
+      expect { otto.public_send(:"#{writer}=", [404, {}, [], :extra]) }.to raise_error(ArgumentError)
+    end
+
+    it 'rejects a triple whose headers are not a Hash-like' do
+      expect { otto.public_send(:"#{writer}=", [404, 'content-type: text/plain', []]) }
+        .to raise_error(ArgumentError)
+    end
+
+    it 'rejects a triple whose status is not an Integer' do
+      expect { otto.public_send(:"#{writer}=", ['404', {}, []]) }.to raise_error(ArgumentError)
+    end
+
+    it 'leaves the previous value in place when rejecting' do
+      otto.public_send(:"#{writer}=", not_found_triple)
+      expect { otto.public_send(:"#{writer}=", 42) }.to raise_error(ArgumentError)
+      expect(otto.public_send(reader)).to equal(not_found_triple)
+    end
+  end
+
+  describe '#not_found=' do
+    it_behaves_like 'a fallback response writer', :not_found
+  end
+
+  describe '#server_error=' do
+    it_behaves_like 'a fallback response writer', :server_error
+  end
+
+  describe 'Otto::Static.copy_response' do
+    it 'returns a new triple sharing no mutable container with the original' do
+      original = [404, { 'x-list' => %w[a b], 'x-one' => '1' }, ['body']]
+      copy = Otto::Static.copy_response(original)
+
+      expect(copy).to eq(original)
+      expect(copy).not_to equal(original)
+      expect(copy[1]).not_to equal(original[1])
+      expect(copy[1]['x-list']).not_to equal(original[1]['x-list'])
+      expect(copy[2]).not_to equal(original[2])
+    end
+
+    it 'keeps the headers class so Rack::Headers stays case-insensitive' do
+      headers = Rack::Headers.new
+      headers['Content-Type'] = 'text/plain'
+      copy = Otto::Static.copy_response([404, headers, []])
+
+      expect(copy[1]).to be_a(Rack::Headers)
+      expect(copy[1]['CONTENT-TYPE']).to eq('text/plain')
+    end
+
+    it 'returns writable containers for a frozen triple' do
+      frozen = [404, { 'x-list' => %w[a].freeze }.freeze, ['body'].freeze].freeze
+      copy = Otto::Static.copy_response(frozen)
+
+      expect(copy[1]).not_to be_frozen
+      expect(copy[1]['x-list']).not_to be_frozen
+      expect(copy[2]).not_to be_frozen
+      expect { copy[1]['set-cookie'] = 'sid=1' }.not_to raise_error
+    end
+
+    it 'leaves a non-Array body untouched' do
+      body = Object.new
+      expect(Otto::Static.copy_response([200, {}, body])[2]).to equal(body)
+    end
+
+    it 'substitutes an empty Hash for nil headers' do
+      expect(Otto::Static.copy_response([204, nil, []])[1]).to eq({})
+    end
+  end
+
+  describe 'static not_found triple' do
+    before { otto.not_found = not_found_triple }
+
+    it 'returns an equal but distinct triple on every miss' do
+      first  = miss(otto)
+      second = miss(otto)
+
+      expect(first).to eq(not_found_triple)
+      expect(first).not_to equal(not_found_triple)
+      expect(first[1]).not_to equal(static_headers)
+      expect(first[1]).not_to equal(second[1])
+      expect(first[2]).not_to equal(not_found_triple[2])
+    end
+
+    it 'does not expose the configured headers to in-place writes' do
+      miss(otto)[1]['set-cookie'] = 'sid=leaked'
+      expect(static_headers).not_to have_key('set-cookie')
+    end
+
+    it 'copies Array-valued headers so an append cannot reach the shared Array' do
+      otto.not_found = [404, { 'set-cookie' => ['a=1'] }, []]
+      miss(otto)[1]['set-cookie'] << 'b=2'
+
+      expect(otto.not_found[1]['set-cookie']).to eq(['a=1'])
+      expect(miss(otto)[1]['set-cookie']).to eq(['a=1'])
+    end
+
+    it 'preserves a Rack::Headers container' do
+      headers = Rack::Headers.new
+      headers['Content-Type'] = 'text/html'
+      otto.not_found = [404, headers, ['<h1>Nope</h1>']]
+
+      response = miss(otto)
+      expect(response[1]).to be_a(Rack::Headers)
+      expect(response[1]['content-type']).to eq('text/html')
+      expect(response[1]).not_to equal(headers)
+    end
+
+    it 'still serves a frozen triple once cookie middleware writes headers' do
+      otto.not_found = [404, { 'content-type' => 'text/plain' }.freeze, ['gone'].freeze].freeze
+      app = cookie_committer.new(otto)
+
+      expect(cookies_in(miss(app))).to eq(['sid=v'])
+    end
+
+    context 'when cookie middleware is mounted above Otto' do
+      let(:app) { cookie_committer.new(otto) }
+
+      it 'returns exactly one Set-Cookie per miss and never replays an earlier one' do
+        first  = miss(app, cookie: 'first-session')
+        second = miss(app, cookie: 'second-session')
+
+        expect(cookies_in(first)).to eq(['sid=first-session'])
+        expect(cookies_in(second)).to eq(['sid=second-session'])
+        expect(second[1].to_s).not_to include('first-session')
+      end
+
+      it 'leaves the configured triple untouched afterwards' do
+        3.times { |i| miss(app, cookie: "s#{i}") }
+
+        expect(static_headers).to eq('content-type' => 'application/json')
+        expect(otto.not_found).to eq([404, { 'content-type' => 'application/json' }, ['{"error":"Not Found"}']])
+      end
+
+      it 'isolates concurrent misses from each other' do
+        responses = Array.new(16) do |i|
+          Thread.new { miss(app, cookie: "t#{i}") } # rubocop:disable ThreadSafety/NewThread
+        end.map(&:value)
+
+        responses.each_with_index do |response, i|
+          expect(cookies_in(response)).to eq(["sid=t#{i}"])
+        end
+        expect(static_headers).not_to have_key('set-cookie')
+      end
+    end
+
+    context "when the cookie is committed by Otto's own middleware stack" do
+      before { otto.use(cookie_committer, name: 'inner') }
+
+      it 'returns exactly one Set-Cookie per miss' do
+        first  = miss(otto, cookie: 'one')
+        second = miss(otto, cookie: 'two')
+
+        expect(cookies_in(first)).to eq(['inner=one'])
+        expect(cookies_in(second)).to eq(['inner=two'])
+        expect(static_headers).not_to have_key('set-cookie')
+      end
+    end
+
+    context "when Otto's CSRF middleware sets the session cookie" do
+      let(:otto) { create_secure_otto(csrf_protection: true, request_validation: false) }
+      let(:html_headers) { { 'content-type' => 'text/html' } }
+
+      before { otto.not_found = [404, html_headers, ['<html><head></head><body>Nope</body></html>']] }
+
+      it 'sets a single session cookie per miss and leaves the configured triple clean' do
+        first  = miss(otto)
+        second = miss(otto)
+
+        expect(cookies_in(first).length).to eq(1)
+        expect(cookies_in(second).length).to eq(1)
+        expect(cookies_in(first).first).to start_with('_otto_session=')
+        expect(cookies_in(second).first).not_to eq(cookies_in(first).first)
+        expect(html_headers).not_to have_key('set-cookie')
+        expect(otto.not_found[2]).to eq(['<html><head></head><body>Nope</body></html>'])
+      end
+    end
+  end
+
+  describe 'not_found callable' do
+    it 'is invoked with the Rack env on every miss' do
+      seen = []
+      otto.not_found = lambda do |env|
+        seen << env['PATH_INFO']
+        [404, { 'content-type' => 'text/plain' }, ["No #{env['PATH_INFO']}"]]
+      end
+
+      expect(miss(otto, '/a')[2]).to eq(['No /a'])
+      expect(miss(otto, '/b')[2]).to eq(['No /b'])
+      expect(seen).to eq(['/a', '/b'])
+    end
+
+    it 'accepts an object responding to #call' do
+      handler = Class.new do
+        def call(env) = [404, { 'x-path' => env['PATH_INFO'] }, []]
+      end.new
+      otto.not_found = handler
+
+      expect(miss(otto, '/obj')[1]['x-path']).to eq('/obj')
+    end
+
+    it 'copies a triple the callable returns, so a memoized triple is still isolated' do
+      shared = [404, { 'content-type' => 'text/plain' }, ['memo']]
+      otto.not_found = ->(_env) { shared }
+      app = cookie_committer.new(otto)
+
+      expect(cookies_in(miss(app, cookie: 'a'))).to eq(['sid=a'])
+      expect(cookies_in(miss(app, cookie: 'b'))).to eq(['sid=b'])
+      expect(shared[1]).not_to have_key('set-cookie')
+    end
+
+    it 'turns a raising callable into a 500 through the error handler' do
+      otto.not_found = ->(_env) { raise 'boom' }
+
+      response = miss(otto)
+      expect(response[0]).to eq(500)
+      expect(response[2].join).to match(/error/i)
+      expect(described_class.logger).to have_received(:error).with(/Unhandled error in request.*boom/)
+    end
+
+    it 'turns a callable returning a non-triple into a 500' do
+      otto.not_found = ->(_env) { 'Not Found' }
+
+      response = miss(otto)
+      expect(response[0]).to eq(500)
+      expect(described_class.logger).to have_received(:error).with(/not_found callable must return a Rack triple/)
+    end
+  end
+
+  describe 'not_found precedence' do
+    it 'uses the built-in response, fresh per call, when nothing is configured' do
+      first  = miss(otto)
+      second = miss(otto)
+
+      expect(first[0]).to eq(404)
+      expect(first[2]).to eq(['Not Found'])
+      expect(first[1]).not_to equal(second[1])
+    end
+
+    it 'restores the built-in response after assigning nil' do
+      otto.not_found = not_found_triple
+      otto.not_found = nil
+
+      expect(miss(otto)[2]).to eq(['Not Found'])
+    end
+
+    it 'prefers a GET /404 route over the configured fallback' do
+      stub_const('FallbackTestApp', Class.new do
+        def self.missing(_req, res)
+          res.write('routed 404')
+        end
+      end)
+      otto = create_minimal_otto(['GET /404 FallbackTestApp.missing'])
+      calls = 0
+      otto.not_found = lambda do |_env|
+        calls += 1
+        not_found_triple
+      end
+
+      expect(miss(otto)[2].join).to eq('routed 404')
+      expect(calls).to eq(0)
+    end
+
+    it 'is not consulted for a matched route' do
+      stub_const('FallbackTestApp', Class.new do
+        def self.index(_req, res)
+          res.write('hit')
+        end
+      end)
+      otto = create_minimal_otto(['GET /hit FallbackTestApp.index'])
+      otto.not_found = ->(_env) { raise 'should not be called' }
+
+      expect(miss(otto, '/hit')[2].join).to eq('hit')
+    end
+  end
+
+  describe 'server_error' do
+    let(:otto) do
+      stub_const('FallbackTestApp', Class.new do
+        def self.boom(_req, _res)
+          raise 'kaboom'
+        end
+      end)
+      create_minimal_otto(['GET /boom FallbackTestApp.boom'])
+    end
+
+    def boom(app, cookie: nil, accept: nil)
+      env = mock_rack_env(path: '/boom')
+      env['test.cookie'] = cookie if cookie
+      env['HTTP_ACCEPT'] = accept if accept
+      app.call(env)
+    end
+
+    context 'with a static triple' do
+      before { otto.server_error = server_error_triple }
+
+      it 'returns an equal but distinct triple on every error' do
+        first  = boom(otto)
+        second = boom(otto)
+
+        expect(first).to eq(server_error_triple)
+        expect(first).not_to equal(server_error_triple)
+        expect(first[1]).not_to equal(static_headers)
+        expect(first[1]).not_to equal(second[1])
+      end
+
+      it 'returns exactly one Set-Cookie per error through cookie middleware' do
+        app = cookie_committer.new(otto)
+
+        expect(cookies_in(boom(app, cookie: 'one'))).to eq(['sid=one'])
+        expect(cookies_in(boom(app, cookie: 'two'))).to eq(['sid=two'])
+        expect(static_headers).not_to have_key('set-cookie')
+      end
+
+      it 'still returns the built-in JSON error body to JSON clients' do
+        response = boom(otto, accept: 'application/json')
+
+        expect(response[0]).to eq(500)
+        expect(response[1]['content-type']).to eq('application/json')
+        expect(response[2].join).to include('Internal Server Error')
+        expect(response[2]).not_to eq(server_error_triple[2])
+      end
+
+      it 'yields to a GET /500 route' do
+        stub_const('FallbackTestApp', Class.new do
+          def self.boom(_req, _res)
+            raise 'kaboom'
+          end
+
+          def self.error_page(req, res)
+            res.write("custom #{req.env['otto.error_id']}")
+          end
+        end)
+        otto = create_minimal_otto(['GET /boom FallbackTestApp.boom', 'GET /500 FallbackTestApp.error_page'])
+        otto.server_error = server_error_triple
+
+        expect(boom(otto)[2].join).to match(/\Acustom [a-f0-9]{16}\z/)
+      end
+    end
+
+    context 'with a callable' do
+      it 'receives env and the error when it takes two arguments' do
+        received = nil
+        otto.server_error = lambda do |env, error|
+          received = [env['PATH_INFO'], error]
+          [500, { 'content-type' => 'text/plain' }, ["failed #{env['otto.error_id']}"]]
+        end
+
+        response = boom(otto)
+        expect(received[0]).to eq('/boom')
+        expect(received[1]).to be_a(RuntimeError).and have_attributes(message: 'kaboom')
+        expect(response[2].join).to match(/\Afailed [a-f0-9]{16}\z/)
+      end
+
+      it 'receives only env when it takes one argument' do
+        otto.server_error = ->(env) { [500, {}, [env['otto.error_id']]] }
+
+        expect(boom(otto)[2].join).to match(/\A[a-f0-9]{16}\z/)
+      end
+
+      it 'accepts an object whose #call takes env and error' do
+        handler = Class.new do
+          def call(_env, error) = [503, { 'content-type' => 'text/plain' }, [error.message]]
+        end.new
+        otto.server_error = handler
+
+        response = boom(otto)
+        expect(response[0]).to eq(503)
+        expect(response[2]).to eq(['kaboom'])
+      end
+
+      it 'accepts a proc with optional arguments' do
+        otto.server_error = proc { |*args| [500, {}, [args.length.to_s]] }
+
+        expect(boom(otto)[2]).to eq(['2'])
+      end
+
+      it 'is invoked fresh on every error' do
+        calls = 0
+        otto.server_error = lambda do |_env, _error|
+          calls += 1
+          [500, {}, [calls.to_s]]
+        end
+
+        expect(boom(otto)[2]).to eq(['1'])
+        expect(boom(otto)[2]).to eq(['2'])
+      end
+
+      it 'copies the triple it returns' do
+        shared = [500, {}, ['memo']]
+        otto.server_error = ->(_env, _error) { shared }
+        app = cookie_committer.new(otto)
+
+        expect(cookies_in(boom(app, cookie: 'a'))).to eq(['sid=a'])
+        expect(cookies_in(boom(app, cookie: 'b'))).to eq(['sid=b'])
+        expect(shared[1]).to eq({})
+      end
+
+      it 'falls back to the built-in secure response and logs when it raises' do
+        otto.server_error = ->(_env, _error) { raise 'handler broke' }
+
+        response = boom(otto)
+        expect(response[0]).to eq(500)
+        expect(response[1]['content-type']).to eq('text/plain')
+        expect(response[2].join).to match(/An error occurred|Server error/)
+        expect(described_class.logger).to have_received(:error).with(/Error in server_error fallback.*handler broke/)
+      end
+
+      it 'falls back to the built-in secure response when it returns a non-triple' do
+        otto.server_error = ->(_env, _error) {}
+
+        response = boom(otto)
+        expect(response[0]).to eq(500)
+        expect(response[2].join).to match(/An error occurred|Server error/)
+        expect(described_class.logger).to have_received(:error).with(/server_error callable must return a Rack triple/)
+      end
+    end
+
+    it 'uses the built-in secure response, fresh per call, when nothing is configured' do
+      first  = boom(otto)
+      second = boom(otto)
+
+      expect(first[0]).to eq(500)
+      expect(first[2].join).to match(/An error occurred|Server error/)
+      expect(first[1]).not_to equal(second[1])
+    end
+  end
+end


### PR DESCRIPTION
Closes #272

## Problem

A static Rack triple assigned to `Otto#not_found=` or `Otto#server_error=` was returned to the Rack stack by reference on every miss or unhandled error. Cookie middleware (rack-session, Otto's own CSRF middleware, anything calling `Rack::Utils.set_cookie_header!`) writes response headers in place, so the shared headers hash accumulated every `Set-Cookie` committed on earlier 404/500 responses and replayed them to later clients, including session ids.

## Changes

**Copy on return.** Both sites now go through a new `Otto::Static.copy_response`, which returns a fresh triple per request: the headers container keeps its class (a `Rack::Headers` stays case-insensitive), Array-valued headers and Array bodies are copied, and a frozen triple yields a writable copy. Otto's built-in fallbacks were already fresh per call and are unchanged.

**Callable form.** `not_found=` accepts anything responding to `call(env)`; `server_error=` accepts `call(env, error)`, with `env['otto.error_id']` set to the logged correlation id. The offered arguments are trimmed to the positional parameters the callable declares (from `#parameters`, not `#arity`), so `->(env)`, `->(env = nil)`, `->(env, error = nil)` and a splat all work. The result of a callable is validated and copied too. A `server_error` callable that raises or returns a non-triple is logged and replaced by the built-in secure response, mirroring the existing `/500` route behavior; a `not_found` callable that does so flows into the normal error handler as a 500. The `examples/` apps already assign lambdas of exactly these shapes, and previously got a `Proc` back as a Rack response.

**Validation.** Both writers reject values that are neither a Rack triple nor callable with `ArgumentError`, leaving the previous value in place. A triple must have an Integer-like status, Hash-like headers, and a body responding to `each` (or `call`, for a streaming body), so `[404, {}, 'Not Found']` is rejected at assignment rather than failing later in the Rack stack. `nil` restores the built-in response.

Existing precedence is preserved: a `GET /404` or `GET /500` route wins over the configured value, and JSON clients still get the built-in JSON error body on unhandled errors regardless of `server_error`.

## Tests

`spec/otto/fallback_response_isolation_spec.rb` adds 71 examples. Against the unfixed library, 40 of the original 53 fail. Coverage includes:

- Two consecutive misses (and two consecutive unhandled errors) through a middleware that commits a cookie exactly the way rack-session does (`Rack::Response::Raw#set_cookie`) each return exactly one `Set-Cookie`, the second never carries the first's value, and the configured triple's headers are unchanged afterwards. Also exercised through `otto.use`, through the real CSRF middleware, and across 16 concurrent threads.
- Copy semantics: distinct containers per request, Array-valued header isolation, `Rack::Headers` class preserved, frozen triple yields writable copies, non-Array body left alone.
- Callables: per-request invocation, `env` access, required, optional, absent and splat parameters, plain objects and Method objects, a memoized triple returned by a callable is still isolated, raising and non-triple returns (including a String-bodied triple).
- Negative: writer rejects strings, wrong-length arrays, non-hash headers, non-integer status, String and nil bodies; `/404` route and matched routes never invoke `not_found`; `/500` route and JSON negotiation take precedence over `server_error`; built-in defaults still fresh per call when nothing is configured.

Full suite: 2867 examples, 0 failures. Rubocop clean on touched files (the new spec is added to the existing `RSpec/SpecFilePathFormat` exclude list in `.rubocop_todo.yml`, matching every other spec in `spec/otto/`).

## Docs

- YARD on both writers.
- New "Fallback 404 and 500 responses" section in `docs/guides/routing.md`.
- Clarified the `not_found` / `server_error` line in `docs/guides/configuration_freezing.md`.
- Changelog fragment under Security and Added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMXbcVR8BjZHp9aaVpGAyn