### PR TITLE
[#267] Add explicit static-file registration via Otto#mount_static

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,24 @@ Helper modules should avoid overriding these methods inherited from Rack::Reques
 
 No runtime validation is performed for performance reasons. Overriding these methods will cause undefined behavior.
 
+## Static File Registration
+
+Files under the `public:` directory are served without registration. Use
+`mount_static` to bind a URL prefix to a directory outside it, or to verify a
+required asset directory at boot:
+
+```ruby
+otto = Otto.new('routes.txt', public: 'public')
+otto.mount_static('/assets', root: 'build/assets')
+```
+
+- Roots are canonicalized at registration; a missing or unsafe root raises `ArgumentError`
+- Precedence is fixed: literal routes, then mounts (longest prefix first), then `public:`, then dynamic routes
+- Must be registered before first request (before configuration freezing)
+- `add_static_path` was removed in v2.10.0 and has no shim
+
+See `docs/guides/routing.md` for the full contract.
+
 ## Authentication Architecture
 
 Authentication is handled by `RouteAuthWrapper` at the handler level, NOT by middleware.

--- a/changelog.d/20260910_090000_claude_267_static_mounts.rst
+++ b/changelog.d/20260910_090000_claude_267_static_mounts.rst
@@ -1,0 +1,22 @@
+Added
+-----
+
+- ``Otto#mount_static(prefix, root:)`` registers an explicit static mount that
+  serves the files under one directory at a URL prefix. Roots are canonicalized
+  and validated when registered, so a missing, unreadable, non-directory, or
+  unresolvable root fails at boot; each mount serves only files inside its own
+  root and never exposes the root's parent or siblings. Mounts are immutable
+  after configuration freezing and are read without locks at dispatch.
+  Precedence is fixed: literal routes, then mounts (longest prefix first), then
+  the ``public:`` directory, then dynamic routes. Applications that do not call
+  ``mount_static`` are unaffected. See the static files section of
+  ``docs/guides/routing.md``. (#267)
+
+Documentation
+-------------
+
+- Documented static-file dispatch precedence, the containment policy shared by
+  the ``public:`` directory and explicit mounts, and migration guidance for
+  callers of the removed ``add_static_path``. Corrected the configuration
+  freezing guide, which still described the ``routes_static`` cache removed in
+  v2.10.0. (#267)

--- a/docs/guides/configuration_freezing.md
+++ b/docs/guides/configuration_freezing.md
@@ -51,15 +51,17 @@ otto.add_auth_strategy('other', MyApp::OtherStrategy.new)
 - the middleware stack;
 - authentication configuration and instance options;
 - dynamic and literal route tables;
-- route definitions and reverse-route indexes.
+- route definitions and reverse-route indexes;
+- the explicit static mount table (`mount_static`).
 
 Hashes and arrays inside those structures are recursively frozen. Configuration
 objects that implement `deep_freeze!` can prepare memoized values before they
 are frozen.
 
-The static-file route structure is an intentional exception. Its outer hash is
-frozen, but the `routes_static[:GET]` `Concurrent::Map` remains writable because
-Otto caches newly discovered static paths during requests.
+Static-file dispatch keeps no mutable routing state. Files under the implicit
+`public:` directory are resolved on each request against the current canonical
+root, and explicit mounts are an immutable snapshot from the moment they are
+registered; `mount_static` raises `FrozenError` after the freeze boundary.
 
 ## Scope and current limitations
 
@@ -70,7 +72,8 @@ some state that is not included in `freeze_configuration!`:
 - `error_handlers` remains a mutable Hash, although
   `register_error_handler` rejects calls after freezing;
 - the `not_found` and `server_error` fallback response writers remain available;
-- the inner static-file cache remains mutable by design.
+- the `Rack::Files` instance for the implicit `public:` directory is rebuilt
+  when that directory is repointed between requests.
 
 Application code should not mutate those objects directly after boot. Do not
 state or depend on a guarantee that every object reachable from an Otto instance
@@ -85,6 +88,9 @@ These supported mutation paths reject changes after the freeze boundary:
 otto.security_config.disable_csrf_protection!
 otto.add_trusted_proxy('192.0.2.10')
 otto.add_rate_limit_rule('uploads', limit: 5, period: 60)
+
+# Static mounts
+otto.mount_static('/assets', root: 'public/assets')
 
 # Middleware and authentication
 otto.use MyApp::OtherMiddleware
@@ -144,3 +150,5 @@ first requests therefore do not run the freeze operation concurrently.
   freezing behavior.
 - [Configuration-freezing specs](../../spec/otto/configuration_freezing_spec.rb).
 - [Static-file freezing specs](../../spec/otto/static_file_freezing_spec.rb).
+- [Static mount specs](../../spec/otto/core/static_mounts_spec.rb) — registration
+  after the freeze boundary and serving from a frozen mount table.

--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -163,6 +163,88 @@ silently weakening the route. Do not use `csrf=exempt` as a general API switch;
 choose an independent request-authentication and replay-protection model for
 webhooks or other non-browser endpoints.
 
+## Static files
+
+Otto serves static files in two ways. Both apply the same safety policy: the
+requested path is joined to a canonical root, resolved with `File.realpath`
+(which follows every `..`, `.`, and symlink component), and served only when
+the result is still inside that root and is a regular, readable file owned by
+the process user or group. Anything else, including a symlink that points
+outside the root, is treated as not found.
+
+### Implicit public directory
+
+Passing `public:` serves every file under that directory at its relative path.
+Nothing needs registering; a file added after boot is served on the next
+request, and a symlinked public directory that is repointed by a deploy is
+re-resolved on every request.
+
+```ruby
+otto = Otto.new('routes', public: File.expand_path('public', __dir__))
+# public/css/site.css is served at GET /css/site.css
+```
+
+### Explicit static mounts
+
+`mount_static` binds one URL prefix to one directory. Use it when the files do
+not live under a single public directory, when a URL prefix should map to a
+different directory name, or when a required asset directory must be verified
+at boot.
+
+```ruby
+otto = Otto.new('routes')
+otto.mount_static('/assets', root: 'public/assets')
+otto.mount_static('/vendor', root: File.join(Gem.loaded_specs['some-ui-kit'].full_gem_path, 'dist'))
+otto.mount_static('/', root: 'public/root-files') # favicon.ico, robots.txt
+```
+
+- The prefix must start with `/`. A trailing slash is ignored, and `/`
+  mounts the root at the top level. Empty, `.`, and `..` segments are
+  rejected.
+- The root is expanded and canonicalized once, at registration. A root that
+  is missing, unreadable, not a directory, not owned by the process user or
+  group, or a symlink that cannot be resolved raises `ArgumentError`, so a
+  misconfigured application does not boot. Because the root is fixed at
+  registration, a deploy that repoints a symlinked root takes effect at the
+  next restart.
+- A mount authorizes only files inside its own root. It never exposes the
+  root's parent or siblings, and it does not widen the implicit public
+  directory. Registering the same prefix twice on one instance raises
+  `ArgumentError`; different Otto instances are fully independent.
+- Requests are matched on the decoded, trailing-slash-stripped path, the same
+  normalization every other dispatch stage uses. Only `GET` is served, the
+  prefix itself is not (mounts serve files, not directory listings), and a
+  request for a file the root does not contain falls through to the next
+  dispatch stage.
+- `mount_static` must be called before the first request. After configuration
+  freezing it raises `FrozenError`, and `otto.static_mounts` is a frozen,
+  read-only table.
+
+### Dispatch precedence
+
+Precedence is fixed and does not depend on request history:
+
+1. literal routes, such as `GET /assets/app.css Assets#show`;
+2. explicit static mounts, consulted longest prefix first; when the longest
+   matching mount does not contain the file, shorter matching mounts are tried
+   in turn;
+3. the implicit `public:` directory;
+4. dynamic routes, such as `GET /assets/:name Assets#show`.
+
+So a literal route at a mounted path always wins, a mounted file always beats
+a file at the same URL in the public directory, and a dynamic route only sees
+requests that no static source could serve.
+
+### Migrating from `add_static_path`
+
+`add_static_path` was removed in v2.10.0. It only populated a request-time
+cache; it never registered or restricted anything. Callers that used it to
+"register" files under the public directory can delete the call, because the
+public directory is served without registration. Callers that used it to reach
+files outside the public directory should replace it with `mount_static` and
+an explicit root. There is no compatibility shim: calling the removed method
+raises `NoMethodError` at boot.
+
 ## Configuration timing
 
 Construct and configure the Otto instance before the first request:

--- a/lib/otto.rb
+++ b/lib/otto.rb
@@ -55,6 +55,7 @@ require_relative 'otto/logging_helpers'
 class Otto
   include Otto::Core::Router
   include Otto::Core::FileSafety
+  include Otto::Core::StaticMounts
   include Otto::Core::Configuration
   include Otto::Core::ErrorHandler
   include Otto::Core::UriGenerator
@@ -188,6 +189,10 @@ class Otto
     # so reverse lookups (Otto#uri) consult this index instead of the
     # single-route @route_definitions entry (issue #190).
     @routes_by_definition = {}
+    # Explicit static mounts (Core::StaticMounts#mount_static). Always a
+    # frozen snapshot, replaced wholesale on registration; dispatch reads it
+    # without locking.
+    @static_mounts     = [].freeze
     @security_config   = Otto::Security::Config.new
     @middleware        = Otto::Core::MiddlewareStack.new
     # Initialize @auth_config first so it can be shared with the configurator

--- a/lib/otto/core.rb
+++ b/lib/otto/core.rb
@@ -4,6 +4,7 @@
 
 require_relative 'core/router'
 require_relative 'core/file_safety'
+require_relative 'core/static_mounts'
 require_relative 'core/configuration'
 require_relative 'core/error_handler'
 require_relative 'core/uri_generator'

--- a/lib/otto/core/configuration.rb
+++ b/lib/otto/core/configuration.rb
@@ -308,11 +308,14 @@ class Otto
         deep_freeze_value(@routes_literal) if @routes_literal
         deep_freeze_value(@route_definitions) if @route_definitions
         deep_freeze_value(@routes_by_definition) if @routes_by_definition
+        # Explicit static mounts are already immutable snapshots; freezing the
+        # array here records that fact and makes any in-place mutation raise.
+        deep_freeze_value(@static_mounts) if @static_mounts
 
         @configuration_frozen = true
 
         duration = Otto::Utils.now_in_μs - start_time
-        frozen_objects = %w[security_config locale_config middleware auth_config option routes]
+        frozen_objects = %w[security_config locale_config middleware auth_config option routes static_mounts]
         Otto.structured_log(:info, 'Freezing completed',
           {
                   duration: duration,

--- a/lib/otto/core/file_safety.rb
+++ b/lib/otto/core/file_safety.rb
@@ -36,16 +36,32 @@ class Otto
       # callers never have to re-run realpath (one resolution per request).
       StaticFile = Struct.new(:root, :path, :relative)
 
-      # Resolve a request path to a canonical, contained, servable file.
+      # Resolve a request path to a canonical, contained, servable file under
+      # the implicit +public:+ directory.
       #
       # @param path [String, nil] request-relative path (may start with '/')
       # @return [StaticFile, nil] the validated file, or nil when unsafe
       def resolve_static_file(path)
         return nil if option[:public].nil? || option[:public].empty?
-        return nil if path.nil? || path.empty?
 
-        public_dir = canonical_public_dir
-        return nil if public_dir.nil?
+        resolve_file_under(canonical_public_dir, path)
+      end
+
+      # Resolve +path+ against an already-canonical +root+ and return it only
+      # when it is a contained, readable, owned regular file.
+      #
+      # Shared by the implicit public directory and explicit static mounts
+      # (Otto::Core::StaticMounts) so both apply one containment policy.
+      # +root+ must be a File.realpath result: containment compares canonical
+      # strings on a separator boundary, so a non-canonical root would never
+      # match the canonicalized candidate.
+      #
+      # @param root [String, nil] canonical directory
+      # @param path [String, nil] root-relative path (may start with '/')
+      # @return [StaticFile, nil] the validated file, or nil when unsafe
+      def resolve_file_under(root, path)
+        return nil if root.nil? || root.empty?
+        return nil if path.nil? || path.empty?
 
         # A NUL byte in a request path is never legitimate; it is a truncation
         # attack on downstream C string handling. Reject it rather than
@@ -57,18 +73,18 @@ class Otto
 
         # Join, then canonicalize: realpath resolves '..', '.' AND every
         # symlink component, so the containment check below cannot be fooled
-        # by a link that points outside the public directory.
-        candidate = File.join(public_dir, clean_path)
+        # by a link that points outside the root.
+        candidate = File.join(root, clean_path)
         real_path = safe_realpath(candidate)
         return nil if real_path.nil?
 
-        return nil unless contained?(real_path, public_dir)
+        return nil unless contained?(real_path, root)
 
         # Second gate: it must be a readable regular file we (or our group) own.
         return nil unless File.file?(real_path) && File.readable?(real_path)
         return nil unless File.owned?(real_path) || File.grpowned?(real_path)
 
-        StaticFile.new(public_dir, real_path, real_path.delete_prefix(public_dir + File::SEPARATOR))
+        StaticFile.new(root, real_path, real_path.delete_prefix(root + File::SEPARATOR))
       end
 
       def safe_file?(path)

--- a/lib/otto/core/router.rb
+++ b/lib/otto/core/router.rb
@@ -142,9 +142,12 @@ class Otto
 
         static_candidate = !static_route.nil? && http_verb == :GET
 
-        # Dispatch precedence is fixed: literal routes, then static files, then
-        # dynamic routes. Static-file requests always pass through containment
-        # validation before they are served (issues #257 and #260).
+        # Dispatch precedence is fixed: literal routes, then explicit static
+        # mounts (longest prefix first), then the implicit public directory,
+        # then dynamic routes. Every static-file request passes through
+        # containment validation before it is served (issues #257, #260 and
+        # #267). A mount or the public directory claims files, not paths: when
+        # the file is absent the request falls through to the next stage.
         if literal_routes.has_key?(path_info_clean)
           route = literal_routes[path_info_clean]
           Otto.structured_log(:debug, 'Route matched',
@@ -158,6 +161,13 @@ class Otto
             @route_matched_callbacks.each { |cb| cb.call(env, route.route_definition) }
           end
           route.call(env)
+        elsif http_verb == :GET && (mounted = resolve_mounted_file(dispatch_path))
+          mount, static_file = mounted
+          Otto.structured_log(:debug, 'Route matched',
+            Otto::LoggingHelpers.request_context(env).merge(
+              type: 'static_mount', prefix: mount.display_prefix
+            ))
+          serve_static_file(env, static_file, mount.files)
         elsif static_candidate && (static_file = resolve_static_file(dispatch_path))
           Otto.structured_log(:debug, 'Route matched',
             Otto::LoggingHelpers.request_context(env).merge(type: 'static'))
@@ -201,12 +211,16 @@ class Otto
       # Rack::Files could still redirect the open. Closing that requires an
       # O_NOFOLLOW-per-component or fd-based serve, i.e. replacing
       # Rack::Files. Accepted for now; see issue #257.
-      def serve_static_file(env, static_file)
+      #
+      # +files+ is the Rack::Files instance rooted at +static_file.root+: a
+      # mount's own frozen instance, or (by default) the public-directory one
+      # that #static_route_for keeps in step with the current root.
+      def serve_static_file(env, static_file, files = static_route_for(static_file.root))
         static_env = env.dup
         # Rack::Files unescapes PATH_INFO, so escape the canonical path to
         # survive the round trip (escape_path preserves '/').
         static_env['PATH_INFO'] = "/#{Rack::Utils.escape_path(static_file.relative)}"
-        static_route_for(static_file.root).call(static_env)
+        files.call(static_env)
       end
 
       # Rack::Files rooted at the root +static_file+ was validated against.

--- a/lib/otto/core/static_mounts.rb
+++ b/lib/otto/core/static_mounts.rb
@@ -1,0 +1,172 @@
+# lib/otto/core/static_mounts.rb
+#
+# frozen_string_literal: true
+
+require 'rack/files'
+
+class Otto
+  module Core
+    # Explicit static-file registration (issue #267).
+    #
+    # A static mount binds a URL prefix to one directory on disk:
+    #
+    #   otto.mount_static('/assets', root: 'public/assets')
+    #
+    # Requests for GET /assets/<rest> are then resolved against
+    # public/assets/<rest> using the same containment policy as the implicit
+    # +public:+ directory (Otto::Core::FileSafety): the candidate is
+    # canonicalized with File.realpath and must land inside the mount's
+    # canonical root, be a regular readable file, and be owned by the process
+    # user or group. A mount never authorizes anything outside its own root,
+    # so several mounts can point into unrelated directories without exposing
+    # their parents or siblings.
+    #
+    # Registration is a boot-time operation. The root is canonicalized once,
+    # when the mount is registered, and every failure mode (missing,
+    # unreadable, not a directory, escaping symlink, malformed prefix,
+    # duplicate prefix) raises ArgumentError immediately so a misconfigured
+    # application does not start. Mounts participate in configuration
+    # freezing: mount_static raises FrozenError after freeze_configuration!,
+    # and the mount table is an immutable, sorted snapshot that dispatch reads
+    # without any per-request mutation.
+    #
+    # Dispatch precedence is fixed: literal routes, then static mounts (longest
+    # prefix first), then the implicit +public:+ directory, then dynamic
+    # routes. A mount claims files, not the prefix: when no mount root
+    # contains the requested file the request falls through to the next
+    # stage exactly as an unregistered path would. See Otto::Core::Router.
+    module StaticMounts
+      # One registered mount. +prefix+ is the normalized URL prefix ('' for a
+      # root mount), +root+ the canonical directory, +files+ the Rack::Files
+      # instance rooted there. Instances are frozen at construction.
+      StaticMount = Struct.new(:prefix, :root, :files) do
+        # Request-relative path under this mount, or nil when +path+ is not
+        # beneath the prefix. The prefix itself (the directory) never matches:
+        # a mount serves files, not directory listings.
+        #
+        # @param path [String] normalized dispatch path (leading '/')
+        # @return [String, nil]
+        def relative_path_for(path)
+          if prefix.empty?
+            path
+          elsif path.start_with?("#{prefix}/")
+            path[(prefix.length + 1)..]
+          end
+        end
+
+        # Prefix as an operator would write it ('/' for a root mount).
+        def display_prefix
+          prefix.empty? ? '/' : prefix
+        end
+      end
+
+      # Registered mounts, longest prefix first. Frozen snapshot; a new array
+      # replaces it on every registration so readers never observe a partial
+      # update.
+      #
+      # @return [Array<StaticMount>]
+      def static_mounts
+        @static_mounts
+      end
+
+      # Serve the files under +root+ at URLs beneath +prefix+.
+      #
+      # @param prefix [String] URL prefix starting with '/'. A trailing slash
+      #   is ignored; '/' mounts the root at the top level.
+      # @param root [String] directory path; relative paths resolve against
+      #   the process working directory and are canonicalized immediately.
+      # @return [StaticMount] the registered mount
+      # @raise [ArgumentError] on a malformed prefix, a duplicate prefix, or a
+      #   root that is missing, unreadable, not a directory, not owned by the
+      #   process user or group, or that cannot be canonicalized.
+      # @raise [FrozenError] after configuration freezing
+      def mount_static(prefix, root:)
+        ensure_not_frozen!
+
+        clean_prefix = normalize_mount_prefix(prefix)
+        if @static_mounts.any? { |mount| mount.prefix == clean_prefix }
+          raise ArgumentError,
+                "Static mount prefix #{display_mount_prefix(clean_prefix).inspect} is already registered"
+        end
+
+        canonical_root = canonicalize_mount_root(clean_prefix, root)
+        mount = StaticMount.new(clean_prefix, canonical_root, Rack::Files.new(canonical_root).freeze).freeze
+
+        # Longest prefix first so an overlay ('/assets/vendor') is consulted
+        # before the mount that contains it ('/assets'). Ties cannot happen:
+        # prefixes are unique. Rebuild rather than mutate so in-flight readers
+        # keep their snapshot.
+        @static_mounts = (@static_mounts + [mount]).sort_by { |m| -m.prefix.length }.freeze
+
+        Otto.structured_log(:debug, 'Static mount registered',
+          { prefix: mount.display_prefix, root: mount.root })
+        mount
+      end
+
+      private
+
+      # Resolve +path+ through the registered mounts, longest prefix first.
+      # Read-only: safe to call from concurrent request threads.
+      #
+      # @param path [String] normalized dispatch path (leading '/')
+      # @return [Array(StaticMount, Otto::Core::FileSafety::StaticFile), nil]
+      def resolve_mounted_file(path)
+        @static_mounts.each do |mount|
+          relative = mount.relative_path_for(path)
+          next if relative.nil?
+
+          static_file = resolve_file_under(mount.root, relative)
+          return [mount, static_file] if static_file
+        end
+        nil
+      end
+
+      # Validate and normalize a mount prefix. Returns '' for the root mount
+      # and a leading-slash, no-trailing-slash prefix otherwise, matching the
+      # normalized request path the router compares against.
+      def normalize_mount_prefix(prefix)
+        raise ArgumentError, "Static mount prefix must be a String, got #{prefix.class}" unless prefix.is_a?(String)
+        raise ArgumentError, "Static mount prefix #{prefix.inspect} contains a NUL byte" if prefix.include?("\0")
+        raise ArgumentError, "Static mount prefix #{prefix.inspect} must start with '/'" unless prefix.start_with?('/')
+
+        clean = prefix.sub(%r{/+\z}, '')
+        return '' if clean.empty?
+
+        segments = clean.split('/', -1).drop(1)
+        if segments.any? { |segment| segment.empty? || segment == '.' || segment == '..' }
+          raise ArgumentError,
+                "Static mount prefix #{prefix.inspect} must not contain empty, '.', or '..' segments"
+        end
+
+        clean.freeze
+      end
+
+      # Canonicalize a mount root under Otto's static-file safety policy and
+      # fail loudly on anything that could not be served safely.
+      def canonicalize_mount_root(prefix, root)
+        label = "Static mount #{display_mount_prefix(prefix).inspect}"
+        raise ArgumentError, "#{label} root must be a String, got #{root.class}" unless root.is_a?(String)
+        raise ArgumentError, "#{label} root must not be empty" if root.strip.empty?
+        raise ArgumentError, "#{label} root #{root.inspect} contains a NUL byte" if root.include?("\0")
+
+        real = safe_realpath(File.expand_path(root))
+        if real.nil?
+          raise ArgumentError,
+                "#{label} root #{root.inspect} cannot be resolved " \
+                '(missing, unreadable component, or symlink loop)'
+        end
+        raise ArgumentError, "#{label} root #{root.inspect} is not a directory" unless File.directory?(real)
+        raise ArgumentError, "#{label} root #{root.inspect} is not readable" unless File.readable?(real)
+
+        owned = File.owned?(real) || File.grpowned?(real)
+        raise ArgumentError, "#{label} root #{root.inspect} is not owned by the process user or group" unless owned
+
+        real.freeze
+      end
+
+      def display_mount_prefix(prefix)
+        prefix.empty? ? '/' : prefix
+      end
+    end
+  end
+end

--- a/spec/otto/core/static_mounts_spec.rb
+++ b/spec/otto/core/static_mounts_spec.rb
@@ -1,0 +1,442 @@
+# spec/otto/core/static_mounts_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Explicit static-file registration (issue #267): Otto#mount_static binds a
+# URL prefix to one canonical directory, validated at registration and served
+# under the same containment policy as the implicit public directory.
+RSpec.describe Otto::Core::StaticMounts do
+  let(:base) { Dir.mktmpdir('otto_static_mounts') }
+  let(:assets_dir) { File.join(base, 'assets') }
+  let(:vendor_dir) { File.join(base, 'vendor') }
+  let(:public_dir) { File.join(base, 'public') }
+
+  before do
+    FileUtils.mkdir_p(File.join(assets_dir, 'js'))
+    FileUtils.mkdir_p(vendor_dir)
+    FileUtils.mkdir_p(File.join(public_dir, 'assets'))
+    File.write(File.join(assets_dir, 'app.css'), 'assets app.css')
+    File.write(File.join(assets_dir, 'js', 'app.js'), 'assets app.js')
+    File.write(File.join(vendor_dir, 'lib.js'), 'vendor lib.js')
+    File.write(File.join(public_dir, 'index.html'), 'public index')
+    File.write(File.join(public_dir, 'assets', 'app.css'), 'public app.css')
+    # A file beside the mount roots that no registration authorizes.
+    File.write(File.join(base, 'secret.txt'), 'secret')
+  end
+
+  after do
+    FileUtils.rm_rf(base)
+  end
+
+  def get(app, path, method: 'GET')
+    status, headers, body = app.call(Rack::MockRequest.env_for(path, method: method))
+    [status, headers, body.to_enum(:each).to_a.join]
+  end
+
+  describe '#mount_static' do
+    it 'serves files under the prefix from the mount root' do
+      app = Otto.new
+      app.mount_static('/assets', root: assets_dir)
+
+      expect(get(app, '/assets/app.css')).to include(200, 'assets app.css')
+      expect(get(app, '/assets/js/app.js')).to include(200, 'assets app.js')
+    end
+
+    it 'maps the prefix onto the root rather than exposing the root at its own path' do
+      app = Otto.new
+      app.mount_static('/static', root: assets_dir)
+
+      expect(get(app, '/static/app.css').first).to eq(200)
+      expect(get(app, '/assets/app.css').first).to eq(404)
+      expect(get(app, '/app.css').first).to eq(404)
+    end
+
+    it 'mounts a root directory at the top level with "/"' do
+      app = Otto.new
+      app.mount_static('/', root: assets_dir)
+
+      expect(get(app, '/app.css')).to include(200, 'assets app.css')
+      expect(get(app, '/js/app.js')).to include(200, 'assets app.js')
+    end
+
+    it 'ignores a trailing slash on the prefix' do
+      app = Otto.new
+      app.mount_static('/assets/', root: assets_dir)
+
+      expect(app.static_mounts.map(&:prefix)).to eq(['/assets'])
+      expect(get(app, '/assets/app.css').first).to eq(200)
+    end
+
+    it 'canonicalizes the root at registration' do
+      link = File.join(base, 'assets-link')
+      File.symlink(assets_dir, link)
+      app = Otto.new
+      mount = app.mount_static('/assets', root: link)
+
+      expect(mount.root).to eq(File.realpath(assets_dir))
+      expect(get(app, '/assets/app.css').first).to eq(200)
+    end
+
+    it 'normalizes dot segments in the root at registration' do
+      app = Otto.new
+      app.mount_static('/assets', root: File.join(assets_dir, 'js', '..', '.'))
+
+      expect(app.static_mounts.first.root).to eq(File.realpath(assets_dir))
+    end
+
+    it 'returns the registered mount and exposes a frozen, longest-prefix-first table' do
+      app = Otto.new
+      app.mount_static('/assets', root: assets_dir)
+      mount = app.mount_static('/assets/vendor', root: vendor_dir)
+
+      expect(mount).to be_frozen
+      expect(app.static_mounts).to be_frozen
+      expect(app.static_mounts.map(&:prefix)).to eq(['/assets/vendor', '/assets'])
+    end
+
+    it 'sets a content type for served files' do
+      app = Otto.new
+      app.mount_static('/assets', root: assets_dir)
+
+      _status, headers, _body = get(app, '/assets/js/app.js')
+      expect(headers['content-type']).to eq('text/javascript')
+    end
+  end
+
+  describe 'file resolution' do
+    let(:app) do
+      Otto.new.tap { |otto| otto.mount_static('/assets', root: assets_dir) }
+    end
+
+    it 'does not serve the prefix itself' do
+      expect(get(app, '/assets').first).to eq(404)
+      expect(get(app, '/assets/').first).to eq(404)
+    end
+
+    it 'does not serve directories under the prefix' do
+      expect(get(app, '/assets/js').first).to eq(404)
+    end
+
+    it 'does not match a longer path segment that merely starts with the prefix' do
+      FileUtils.mkdir_p(File.join(base, 'assets2'))
+      File.write(File.join(base, 'assets2', 'x.txt'), 'x')
+
+      expect(get(app, '/assets2/x.txt').first).to eq(404)
+    end
+
+    it 'serves only GET requests' do
+      expect(get(app, '/assets/app.css', method: 'POST').first).to eq(404)
+      expect(get(app, '/assets/app.css', method: 'PUT').first).to eq(404)
+    end
+
+    it 'falls through when the file is missing' do
+      expect(get(app, '/assets/missing.css')).to include(404)
+    end
+  end
+
+  describe 'containment' do
+    let(:app) do
+      Otto.new.tap { |otto| otto.mount_static('/assets', root: assets_dir) }
+    end
+
+    it 'rejects path traversal out of the mount root' do
+      expect(get(app, '/assets/../secret.txt').first).to eq(404)
+      expect(get(app, '/assets/js/../../secret.txt').first).to eq(404)
+      expect(get(app, '/assets/%2e%2e/secret.txt').first).to eq(404)
+      expect(get(app, '/assets/js/%2e%2e/%2e%2e/secret.txt').first).to eq(404)
+    end
+
+    it 'rejects a NUL byte in the request path' do
+      expect(get(app, '/assets/app.css%00').first).to eq(404)
+    end
+
+    it 'rejects a symlink that escapes the mount root' do
+      File.symlink(File.join(base, 'secret.txt'), File.join(assets_dir, 'leak.txt'))
+      File.symlink(vendor_dir, File.join(assets_dir, 'leakdir'))
+
+      expect(get(app, '/assets/leak.txt').first).to eq(404)
+      expect(get(app, '/assets/leakdir/lib.js').first).to eq(404)
+    end
+
+    it 'serves a symlink whose target stays inside the mount root' do
+      File.symlink(File.join(assets_dir, 'app.css'), File.join(assets_dir, 'alias.css'))
+
+      expect(get(app, '/assets/alias.css')).to include(200, 'assets app.css')
+    end
+
+    it 'never authorizes files beside the mount root' do
+      # The parent of the mount root contains secret.txt and vendor/; neither
+      # is reachable through the registration.
+      expect(get(app, '/secret.txt').first).to eq(404)
+      expect(get(app, '/vendor/lib.js').first).to eq(404)
+      expect(get(app, '/assets/secret.txt').first).to eq(404)
+    end
+
+    it 'does not widen the implicit public directory' do
+      app_with_public = Otto.new(nil, { public: public_dir })
+      app_with_public.mount_static('/vendor', root: vendor_dir)
+
+      expect(get(app_with_public, '/vendor/lib.js').first).to eq(200)
+      expect(get(app_with_public, '/index.html').first).to eq(200)
+      # vendor/ is a sibling of public/, not inside it.
+      expect(get(app_with_public, '/lib.js').first).to eq(404)
+      expect(get(app_with_public, '/../vendor/lib.js').first).to eq(404)
+    end
+
+    it 'serves the canonical file, not the request path' do
+      # The mount's Rack::Files is frozen, so observe the validated file that
+      # the router hands to the serving step instead of stubbing the server.
+      File.symlink(File.join(assets_dir, 'app.css'), File.join(assets_dir, 'alias.css'))
+      allow(app).to receive(:serve_static_file).and_call_original
+
+      get(app, '/assets/alias.css')
+
+      expect(app).to have_received(:serve_static_file).with(
+        anything,
+        having_attributes(root: File.realpath(assets_dir), relative: 'app.css'),
+        app.static_mounts.first.files
+      )
+    end
+  end
+
+  describe 'precedence' do
+    it 'lets a literal route win over a mounted file at the same path' do
+      routes = create_test_routes_file('mount_literal.txt', ['GET /assets/app.css TestApp.index'])
+      app = Otto.new(routes)
+      app.mount_static('/assets', root: assets_dir)
+
+      expect(get(app, '/assets/app.css')).to include(200, 'Hello World')
+      expect(get(app, '/assets/js/app.js')).to include(200, 'assets app.js')
+    end
+
+    it 'lets a mounted file win over the implicit public directory' do
+      app = Otto.new(nil, { public: public_dir })
+      app.mount_static('/assets', root: assets_dir)
+
+      expect(get(app, '/assets/app.css')).to include(200, 'assets app.css')
+      expect(get(app, '/index.html')).to include(200, 'public index')
+    end
+
+    it 'falls back to the public directory when no mount contains the file' do
+      File.write(File.join(public_dir, 'assets', 'only-public.css'), 'only public')
+      app = Otto.new(nil, { public: public_dir })
+      app.mount_static('/assets', root: assets_dir)
+
+      expect(get(app, '/assets/only-public.css')).to include(200, 'only public')
+    end
+
+    it 'lets a mounted file win over a dynamic route' do
+      routes = create_test_routes_file('mount_dynamic.txt', ['GET /assets/:id TestApp.show'])
+      app = Otto.new(routes)
+      app.mount_static('/assets', root: assets_dir)
+
+      expect(get(app, '/assets/app.css')).to include(200, 'assets app.css')
+      expect(get(app, '/assets/missing.css')).to include(200, 'Showing missing.css')
+    end
+
+    it 'consults mounts longest prefix first and falls through to shorter ones' do
+      FileUtils.mkdir_p(File.join(assets_dir, 'vendor'))
+      File.write(File.join(assets_dir, 'vendor', 'shared.js'), 'from assets')
+      File.write(File.join(vendor_dir, 'shared.js'), 'from vendor')
+      app = Otto.new
+      app.mount_static('/assets', root: assets_dir)
+      app.mount_static('/assets/vendor', root: vendor_dir)
+
+      expect(get(app, '/assets/vendor/shared.js')).to include(200, 'from vendor')
+      expect(get(app, '/assets/vendor/lib.js')).to include(200, 'vendor lib.js')
+      # Registration order does not affect the outcome.
+      reversed = Otto.new
+      reversed.mount_static('/assets/vendor', root: vendor_dir)
+      reversed.mount_static('/assets', root: assets_dir)
+      expect(get(reversed, '/assets/vendor/shared.js')).to include(200, 'from vendor')
+    end
+
+    it 'is independent of request history' do
+      routes = create_test_routes_file('mount_history.txt', ['GET /assets/app.css TestApp.index'])
+      app = Otto.new(routes)
+      app.mount_static('/assets', root: assets_dir)
+
+      first = get(app, '/assets/app.css')
+      get(app, '/assets/js/app.js')
+      second = get(app, '/assets/app.css')
+
+      expect(first.last).to eq('Hello World')
+      expect(second.last).to eq('Hello World')
+    end
+  end
+
+  describe 'registration failures' do
+    let(:app) { Otto.new }
+
+    it 'rejects a missing root' do
+      expect { app.mount_static('/assets', root: File.join(base, 'nope')) }
+        .to raise_error(ArgumentError, /root .*nope.* cannot be resolved/)
+    end
+
+    it 'rejects a root that is a file' do
+      expect { app.mount_static('/assets', root: File.join(base, 'secret.txt')) }
+        .to raise_error(ArgumentError, /is not a directory/)
+    end
+
+    it 'rejects a root whose symlink dangles' do
+      File.symlink(File.join(base, 'gone'), File.join(base, 'dangling'))
+
+      expect { app.mount_static('/assets', root: File.join(base, 'dangling')) }
+        .to raise_error(ArgumentError, /cannot be resolved/)
+    end
+
+    it 'rejects a root that is not a String' do
+      expect { app.mount_static('/assets', root: nil) }
+        .to raise_error(ArgumentError, /root must be a String/)
+      expect { app.mount_static('/assets', root: '') }
+        .to raise_error(ArgumentError, /root must not be empty/)
+    end
+
+    it 'rejects a root containing a NUL byte' do
+      expect { app.mount_static('/assets', root: "#{assets_dir}\0") }
+        .to raise_error(ArgumentError, /NUL byte/)
+    end
+
+    it 'requires the root keyword' do
+      expect { app.mount_static('/assets') }.to raise_error(ArgumentError)
+    end
+
+    it 'rejects a prefix that does not start with a slash' do
+      expect { app.mount_static('assets', root: assets_dir) }
+        .to raise_error(ArgumentError, %r{must start with '/})
+      expect { app.mount_static('', root: assets_dir) }
+        .to raise_error(ArgumentError, %r{must start with '/})
+    end
+
+    it 'rejects a prefix that is not a String' do
+      expect { app.mount_static(:assets, root: assets_dir) }
+        .to raise_error(ArgumentError, /prefix must be a String/)
+    end
+
+    it 'rejects a prefix with empty, dot, or dot-dot segments' do
+      ['/a//b', '/a/./b', '/a/../b', '/..', '/.'].each do |prefix|
+        expect { app.mount_static(prefix, root: assets_dir) }
+          .to raise_error(ArgumentError, /empty, '\.', or '\.\.' segments/), prefix
+      end
+    end
+
+    it 'rejects a prefix containing a NUL byte' do
+      expect { app.mount_static("/assets\0", root: assets_dir) }
+        .to raise_error(ArgumentError, /NUL byte/)
+    end
+
+    it 'rejects a duplicate prefix, including one that only differs by a trailing slash' do
+      app.mount_static('/assets', root: assets_dir)
+
+      expect { app.mount_static('/assets', root: vendor_dir) }
+        .to raise_error(ArgumentError, /already registered/)
+      expect { app.mount_static('/assets/', root: vendor_dir) }
+        .to raise_error(ArgumentError, /already registered/)
+      expect(app.static_mounts.size).to eq(1)
+    end
+
+    it 'leaves the mount table untouched when a registration fails' do
+      app.mount_static('/assets', root: assets_dir)
+      before = app.static_mounts
+
+      expect { app.mount_static('/vendor', root: File.join(base, 'nope')) }.to raise_error(ArgumentError)
+      expect(app.static_mounts).to equal(before)
+    end
+  end
+
+  describe 'configuration freezing' do
+    it 'rejects registration after the configuration is frozen' do
+      app = Otto.new
+      app.mount_static('/assets', root: assets_dir)
+      app.freeze_configuration!
+
+      expect { app.mount_static('/vendor', root: vendor_dir) }
+        .to raise_error(FrozenError, /Cannot modify frozen configuration/)
+      expect(app.static_mounts.map(&:prefix)).to eq(['/assets'])
+    end
+
+    it 'keeps serving mounted files after freezing' do
+      app = Otto.new
+      app.mount_static('/assets', root: assets_dir)
+      app.freeze_configuration!
+
+      expect(app.static_mounts).to be_frozen
+      expect(get(app, '/assets/app.css')).to include(200, 'assets app.css')
+    end
+
+    it 'serves concurrent requests across mounts after freezing' do
+      count = 40
+      count.times do |i|
+        File.write(File.join(assets_dir, "a#{i}.txt"), "assets #{i}")
+        File.write(File.join(vendor_dir, "v#{i}.txt"), "vendor #{i}")
+      end
+      app = Otto.new(nil, { public: public_dir })
+      app.mount_static('/assets', root: assets_dir)
+      app.mount_static('/assets/vendor', root: vendor_dir)
+      app.freeze_configuration!
+
+      errors = Queue.new
+      threads = Array.new(count) do |i|
+        Thread.new do # rubocop:disable ThreadSafety/NewThread
+          expected = {
+            "/assets/a#{i}.txt" => "assets #{i}",
+            "/assets/vendor/v#{i}.txt" => "vendor #{i}",
+            '/index.html' => 'public index',
+          }
+          expected.each do |path, content|
+            status, _headers, body = get(app, path)
+            errors << "#{path}: #{status} #{body}" unless status == 200 && body == content
+          end
+          status, = get(app, '/assets/../secret.txt')
+          errors << "traversal served with #{status}" unless status == 404
+        rescue StandardError => e
+          errors << "#{e.class}: #{e.message}"
+        end
+      end
+      threads.each(&:join)
+
+      expect(errors.size).to eq(0), -> { Array.new(errors.size) { errors.pop }.join("\n") }
+    end
+  end
+
+  describe 'instance isolation' do
+    it 'keeps mounts private to the instance that registered them' do
+      with_mount = Otto.new
+      without_mount = Otto.new
+      with_mount.mount_static('/assets', root: assets_dir)
+
+      expect(get(with_mount, '/assets/app.css').first).to eq(200)
+      expect(get(without_mount, '/assets/app.css').first).to eq(404)
+      expect(without_mount.static_mounts).to be_empty
+    end
+
+    it 'lets two instances mount the same prefix on different roots' do
+      first = Otto.new
+      second = Otto.new
+      first.mount_static('/files', root: assets_dir)
+      second.mount_static('/files', root: vendor_dir)
+
+      expect(get(first, '/files/app.css').first).to eq(200)
+      expect(get(first, '/files/lib.js').first).to eq(404)
+      expect(get(second, '/files/lib.js').first).to eq(200)
+      expect(get(second, '/files/app.css').first).to eq(404)
+    end
+  end
+
+  describe 'implicit public directory without mounts' do
+    it 'is unchanged when nothing is registered' do
+      app = Otto.new(nil, { public: public_dir })
+
+      expect(app.static_mounts).to eq([])
+      expect(get(app, '/index.html')).to include(200, 'public index')
+      expect(get(app, '/assets/app.css')).to include(200, 'public app.css')
+      expect(get(app, '/../secret.txt').first).to eq(404)
+    end
+
+    it 'no longer responds to the removed add_static_path' do
+      expect(Otto.new).not_to respond_to(:add_static_path)
+    end
+  end
+end

--- a/spec/otto/core/static_mounts_spec.rb
+++ b/spec/otto/core/static_mounts_spec.rb
@@ -101,7 +101,9 @@ RSpec.describe Otto::Core::StaticMounts do
       app.mount_static('/assets', root: assets_dir)
 
       _status, headers, _body = get(app, '/assets/js/app.js')
-      expect(headers['content-type']).to eq('text/javascript')
+      # Rack::Mime has reported .js as both application/javascript and
+      # text/javascript across releases; either is a JavaScript type.
+      expect(headers['content-type']).to match(%r{\A(text|application)/javascript})
     end
   end
 
@@ -133,6 +135,18 @@ RSpec.describe Otto::Core::StaticMounts do
 
     it 'falls through when the file is missing' do
       expect(get(app, '/assets/missing.css')).to include(404)
+    end
+
+    it 'treats a leading slash on the relative path as root-relative' do
+      # Dispatch always hands resolve_file_under a leading-slash path. Ruby's
+      # File.join keeps every component (unlike Python's os.path.join), so the
+      # root is never discarded; pin that so the join is not "fixed" later.
+      mount = app.static_mounts.first
+      resolved = app.resolve_file_under(mount.root, '/js/app.js')
+
+      expect(resolved).to have_attributes(root: mount.root, relative: 'js/app.js')
+      expect(app.resolve_file_under(mount.root, '//js/app.js')).to have_attributes(relative: 'js/app.js')
+      expect(app.resolve_file_under(mount.root, '/../secret.txt')).to be_nil
     end
   end
 


### PR DESCRIPTION
Closes #267. Follow-up to #260 (PR #268), which removed `add_static_path` because it only populated a request-time cache.

## API

One method, one form:

```ruby
otto = Otto.new('routes', public: 'public')
otto.mount_static('/assets', root: 'build/assets')
otto.mount_static('/vendor', root: File.join(gem_path, 'dist'))
otto.mount_static('/', root: 'public/root-files')   # favicon.ico, robots.txt
```

The issue floated both `mount_static` and `allow_static_file` and asked for the smallest interface backed by concrete use cases. A prefix-to-directory mount covers all four listed use cases; the single-file allowlist case is a root mount of a directory that holds only those files. A file-shaped root would have meant a second matching rule keyed on filesystem state at registration, so it is left out.

## Behavior

- **Registration validates and canonicalizes.** The root is expanded and resolved with `File.realpath` once, at registration. Missing, unreadable, non-directory, unowned, dangling or looping roots, malformed prefixes (no leading `/`, empty/`.`/`..` segments, NUL), and duplicate prefixes raise `ArgumentError`, so a bad configuration fails at boot. A failed registration leaves the mount table untouched.
- **One containment gate.** `FileSafety#resolve_static_file` is split into `resolve_file_under(root, path)` so the implicit `public:` directory and explicit mounts share the #257 policy: realpath, separator-boundary containment, regular readable file, owned by user or group. A mount authorizes only files inside its own root and never widens the public directory or exposes the root's parent or siblings.
- **Fixed precedence.** Literal routes, then mounts (longest prefix first, falling through to shorter matching mounts), then the `public:` directory, then dynamic routes. A mount claims files, not the prefix: a missing file falls through exactly like an unregistered path. Only `GET` is served, matching the existing public-directory rule.
- **Immutable after freezing.** The mount table is a frozen Array snapshot replaced wholesale on each registration and deep-frozen in `freeze_configuration!`; `mount_static` raises `FrozenError` afterwards. Each mount holds its own frozen `Rack::Files`, so dispatch reads with no locks and no mutable caches. Instances are isolated.
- **Public directory unchanged.** Applications that never call `mount_static` take the same path as before; the existing static specs pass unchanged.

## `add_static_path`

No deprecation shim. The method was removed in the released 2.10.0 and the changelog already says so; re-adding a name whose only job is to raise would resurrect it. Callers get `NoMethodError` at boot, and the routing guide carries the migration guidance: drop the call if the files live under `public:`, or replace it with `mount_static` and an explicit root.

One design trade-off worth a look: a mount root is fixed at registration, whereas the public directory is re-resolved per request and follows a deploy symlink flip. Mounts therefore take a repointed root at the next restart. That is what makes the table immutable, and it is documented, but it is a difference between the two mechanisms.

## Docs

- `docs/guides/routing.md`: new "Static files" section covering both mechanisms, the safety policy, dispatch precedence, and migration from `add_static_path`.
- `docs/guides/configuration_freezing.md`: still described the `routes_static` cache removed in 2.10.0; corrected, and the mount table added to the frozen list.
- `AGENTS.md`: registration note alongside the other boot-time registration APIs.
- `changelog.d/20260910_090000_claude_267_static_mounts.rst`.

## Tests

`spec/otto/core/static_mounts_spec.rb` (45 examples): prefix mapping, root mounts, canonicalization, traversal and symlink containment, sibling non-exposure, precedence against literal/public/dynamic routes and between mounts, every registration failure, freezing, concurrent requests across mounts after freeze, instance isolation, and unchanged public-directory behavior.

Full suite: 2841 examples, 0 failures. Rubocop clean on every touched file; the three remaining offenses in the repo are pre-existing `Style/DirectiveScope` hits in two CSP specs this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017b7Ry4L5pKhpwzP4efXPDC

---
_Generated by [Claude Code](https://claude.ai/code/session_017b7Ry4L5pKhpwzP4efXPDC)_